### PR TITLE
Test RPC mechanism

### DIFF
--- a/platform/mock.go
+++ b/platform/mock.go
@@ -1,0 +1,45 @@
+package platform
+
+import (
+	"github.com/weaveworks/flux"
+)
+
+type MockPlatform struct {
+	AllServicesArgTest func(string, flux.ServiceIDSet) error
+	AllServicesAnswer  []Service
+	AllServicesError   error
+
+	SomeServicesArgTest func([]flux.ServiceID) error
+	SomeServicesAnswer  []Service
+	SomeServicesError   error
+
+	RegradeArgTest func([]RegradeSpec) error
+	RegradeError   error
+}
+
+func (p *MockPlatform) AllServices(ns string, ss flux.ServiceIDSet) ([]Service, error) {
+	if p.AllServicesArgTest != nil {
+		if err := p.AllServicesArgTest(ns, ss); err != nil {
+			return nil, err
+		}
+	}
+	return p.AllServicesAnswer, p.AllServicesError
+}
+
+func (p *MockPlatform) SomeServices(ss []flux.ServiceID) ([]Service, error) {
+	if p.SomeServicesArgTest != nil {
+		if err := p.SomeServicesArgTest(ss); err != nil {
+			return nil, err
+		}
+	}
+	return p.SomeServicesAnswer, p.SomeServicesError
+}
+
+func (p *MockPlatform) Regrade(ss []RegradeSpec) error {
+	if p.RegradeArgTest != nil {
+		if err := p.RegradeArgTest(ss); err != nil {
+			return err
+		}
+	}
+	return p.RegradeError
+}

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -1,0 +1,37 @@
+package platform
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/weaveworks/flux"
+)
+
+func TestPlatformMock(t *testing.T) {
+	var p Platform = &MockPlatform{
+		AllServicesAnswer: []Service{Service{}},
+		SomeServicesArgTest: func([]flux.ServiceID) error {
+			return errors.New("arg fail")
+		},
+		RegradeError: errors.New("fail"),
+	}
+
+	// Just token tests so we're attempting _something_ here
+	ss, err := p.AllServices("", flux.ServiceIDSet{})
+	if err != nil {
+		t.Error(err)
+	}
+	if len(ss) != 1 {
+		t.Errorf("expected answer given in mock, but got %+v", ss)
+	}
+
+	ss, err = p.SomeServices([]flux.ServiceID{})
+	if err == nil {
+		t.Error("expected error from args test, got nil")
+	}
+
+	err = p.Regrade([]RegradeSpec{})
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/platform/rpc/rpc_test.go
+++ b/platform/rpc/rpc_test.go
@@ -27,6 +27,13 @@ func TestRPC(t *testing.T) {
 	services := flux.ServiceIDSet{}
 	services.Add([]flux.ServiceID{serviceID})
 
+	regrades := []platform.RegradeSpec{
+		platform.RegradeSpec{
+			ServiceID:     serviceID,
+			NewDefinition: []byte("imagine a definition here"),
+		},
+	}
+
 	mock := &platform.MockPlatform{
 		AllServicesArgTest: func(ns string, ss flux.ServiceIDSet) error {
 			if !(ns == namespace &&
@@ -35,7 +42,31 @@ func TestRPC(t *testing.T) {
 			}
 			return nil
 		},
-		AllServicesAnswer: []platform.Service{platform.Service{}, platform.Service{}},
+		AllServicesAnswer: []platform.Service{
+			platform.Service{
+				ID:       flux.ServiceID("foobar/hello"),
+				IP:       "10.32.1.45",
+				Metadata: map[string]string{},
+				Status:   "ok",
+				Containers: platform.ContainersOrExcuse{
+					Containers: []platform.Container{
+						platform.Container{
+							Name:  "frobnicator",
+							Image: "quay.io/example.com/frob:v0.4.5",
+						},
+					},
+				},
+			},
+			platform.Service{},
+		},
+
+		RegradeArgTest: func(specs []platform.RegradeSpec) error {
+			if !reflect.DeepEqual(regrades, specs) {
+				return fmt.Errorf("did not get expected args, got %+v", specs)
+			}
+			return nil
+		},
+		RegradeError: nil,
 	}
 
 	clientConn, serverConn := pipes()
@@ -57,5 +88,19 @@ func TestRPC(t *testing.T) {
 	}
 	if !reflect.DeepEqual(ss, mock.AllServicesAnswer) {
 		t.Error(fmt.Errorf("expected %d result(s), got %+v", len(mock.AllServicesAnswer), ss))
+	}
+
+	err = client.Regrade(regrades)
+	if err != nil {
+		t.Error(err)
+	}
+
+	regradeErrors := platform.RegradeError{
+		serviceID: fmt.Errorf("it just failed"),
+	}
+	mock.RegradeError = regradeErrors
+	err = client.Regrade(regrades)
+	if !reflect.DeepEqual(err, regradeErrors) {
+		t.Errorf("expected RegradeError, got %#v", err)
 	}
 }

--- a/platform/rpc/rpc_test.go
+++ b/platform/rpc/rpc_test.go
@@ -1,0 +1,61 @@
+package rpc
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/platform"
+)
+
+func pipes() (io.ReadWriteCloser, io.ReadWriteCloser) {
+	type end struct {
+		io.Reader
+		io.WriteCloser
+	}
+
+	serverReader, clientWriter := io.Pipe()
+	clientReader, serverWriter := io.Pipe()
+	return end{clientReader, clientWriter}, end{serverReader, serverWriter}
+}
+
+func TestRPC(t *testing.T) {
+	namespace := "space-of-names"
+	serviceID := flux.ServiceID(namespace + "/service")
+	services := flux.ServiceIDSet{}
+	services.Add([]flux.ServiceID{serviceID})
+
+	mock := &platform.MockPlatform{
+		AllServicesArgTest: func(ns string, ss flux.ServiceIDSet) error {
+			if !(ns == namespace &&
+				ss.Contains(serviceID)) {
+				return fmt.Errorf("did not get expected args, got %q, %+v", ns, ss)
+			}
+			return nil
+		},
+		AllServicesAnswer: []platform.Service{platform.Service{}, platform.Service{}},
+	}
+
+	clientConn, serverConn := pipes()
+
+	server, err := NewServer(mock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go server.ServeConn(serverConn)
+
+	client := NewClient(clientConn)
+	if err := client.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := client.AllServices(namespace, services)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(ss, mock.AllServicesAnswer) {
+		t.Error(fmt.Errorf("expected %d result(s), got %+v", len(mock.AllServicesAnswer), ss))
+	}
+}

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -59,17 +59,18 @@ func (p *RPCServer) SomeServices(ids []flux.ServiceID, resp *[]platform.Service)
 	return err
 }
 
-func (p *RPCServer) Regrade(spec []platform.RegradeSpec, regradeError *RegradeResult) error {
+func (p *RPCServer) Regrade(spec []platform.RegradeSpec, regradeResult *RegradeResult) error {
 	result := RegradeResult{}
 	err := p.p.Regrade(spec)
 	if err != nil {
-		switch err := err.(type) {
+		switch regradeErr := err.(type) {
 		case platform.RegradeError:
-			for s, e := range err {
+			for s, e := range regradeErr {
 				result[s] = e.Error()
 			}
+			err = nil
 		}
 	}
-	*regradeError = result
+	*regradeResult = result
 	return err
 }


### PR DESCRIPTION
Adds some tests of the mechanism between RPCClient and RPCServer, by setting up pipe-connections between a client and a server.

A mock implementation of the platform is included, so answers, errors, and expected args can be supplied as a fixture.

Also fixes a bug uncovered by the tests: detecting (and reconstituting) a RegradeError was broken, because the server passed the error back as the return value as well as putting a value in the out-arg.