### PR TITLE
Platform presence

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,7 +20,8 @@ type ClientService interface {
 }
 
 type DaemonService interface {
-	RegisterDaemon(flux.InstanceID, platform.Platform) error
+	RegisterDaemon(flux.InstanceID, platform.RemotePlatform) error
+	IsDaemonConnected(flux.InstanceID) error
 }
 
 type FluxService interface {

--- a/api/api.go
+++ b/api/api.go
@@ -20,7 +20,7 @@ type ClientService interface {
 }
 
 type DaemonService interface {
-	RegisterDaemon(flux.InstanceID, platform.RemotePlatform) error
+	RegisterDaemon(flux.InstanceID, platform.Platform) error
 	IsDaemonConnected(flux.InstanceID) error
 }
 

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -383,6 +383,11 @@ func definitionObj(bytes []byte) (*apiObject, error) {
 	return &obj, yaml.Unmarshal(bytes, &obj)
 }
 
+func (c *Cluster) Ping() error {
+	_, err := c.client.ServerVersion()
+	return err
+}
+
 // --- end platform API
 
 type statusMap struct {

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -15,6 +15,8 @@ type MockPlatform struct {
 
 	RegradeArgTest func([]RegradeSpec) error
 	RegradeError   error
+
+	PingError error
 }
 
 func (p *MockPlatform) AllServices(ns string, ss flux.ServiceIDSet) ([]Service, error) {
@@ -42,4 +44,8 @@ func (p *MockPlatform) Regrade(ss []RegradeSpec) error {
 		}
 	}
 	return p.RegradeError
+}
+
+func (p *MockPlatform) Ping() error {
+	return p.PingError
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -24,17 +24,32 @@ type Platform interface {
 	Regrade([]RegradeSpec) error
 }
 
+type RemotePlatform interface {
+	Platform
+	Ping() error
+}
+
 // For getting a connection to a platform; this can happen in
 // different ways, e.g., by having direct access to Kubernetes in
 // standalone mode, or by going via a message bus.
 type Connecter interface {
+	// Connect returns a platform for the instance specified. An error
+	// is returned only if there is a problem (possibly transient)
+	// with the underlying mechanism (i.e., not if the platform is
+	// simply not known to be connected at this time).
 	Connect(inst flux.InstanceID) (Platform, error)
 }
 
 // MessageBus handles routing messages to/from the matching platform.
 type MessageBus interface {
 	Connecter
-	Subscribe(inst flux.InstanceID, p Platform) error
+	// Subscribe registers a platform as the daemon for the instance
+	// specified.
+	Subscribe(inst flux.InstanceID, p RemotePlatform) error
+	// Ping returns nil if the daemon for the instance given is known
+	// to be connected, or ErrPlatformNotAvailable otherwise. NB this
+	// differs from the semantics of `Connecter.Connect`.
+	Ping(inst flux.InstanceID) error
 }
 
 // Service describes a platform service, generally a floating IP with one or

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -45,7 +45,7 @@ type MessageBus interface {
 	Connecter
 	// Subscribe registers a platform as the daemon for the instance
 	// specified.
-	Subscribe(inst flux.InstanceID, p RemotePlatform) error
+	Subscribe(inst flux.InstanceID, p RemotePlatform, done chan<- error)
 	// Ping returns nil if the daemon for the instance given is known
 	// to be connected, or ErrPlatformNotAvailable otherwise. NB this
 	// differs from the semantics of `Connecter.Connect`.

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -22,10 +22,6 @@ type Platform interface {
 	AllServices(maybeNamespace string, ignored flux.ServiceIDSet) ([]Service, error)
 	SomeServices([]flux.ServiceID) ([]Service, error)
 	Regrade([]RegradeSpec) error
-}
-
-type RemotePlatform interface {
-	Platform
 	Ping() error
 }
 
@@ -45,7 +41,7 @@ type MessageBus interface {
 	Connecter
 	// Subscribe registers a platform as the daemon for the instance
 	// specified.
-	Subscribe(inst flux.InstanceID, p RemotePlatform, done chan<- error)
+	Subscribe(inst flux.InstanceID, p Platform, done chan<- error)
 	// Ping returns nil if the daemon for the instance given is known
 	// to be connected, or ErrPlatformNotAvailable otherwise. NB this
 	// differs from the semantics of `Connecter.Connect`.

--- a/platform/rpc/client.go
+++ b/platform/rpc/client.go
@@ -21,12 +21,6 @@ func NewClient(conn io.ReadWriteCloser) *RPCClient {
 	return &RPCClient{jsonrpc.NewClient(conn)}
 }
 
-// Ping, is used to check if the remote platform is available. Might go away,
-// and just rely on an error from the other methods.
-func (p *RPCClient) Ping() error {
-	return p.client.Call("RPCServer.Ping", struct{}{}, nil)
-}
-
 // AllServicesRequest is the request datastructure for AllServices
 type AllServicesRequest struct {
 	MaybeNamespace string
@@ -61,6 +55,11 @@ func (p *RPCClient) Regrade(spec []platform.RegradeSpec) error {
 		return errs
 	}
 	return nil
+}
+
+// Ping is used to check if the remote platform is available.
+func (p *RPCClient) Ping() error {
+	return p.client.Call("RPCServer.Ping", struct{}{}, nil)
 }
 
 // Close closes the connection to the remote platform, it does *not* cause the

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -38,7 +38,7 @@ type RPCServer struct {
 }
 
 func (p *RPCServer) Ping(_ struct{}, _ *struct{}) error {
-	return nil
+	return p.p.Ping()
 }
 
 func (p *RPCServer) AllServices(req AllServicesRequest, resp *[]platform.Service) error {

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -37,7 +37,7 @@ func (s *StandaloneMessageBus) Connect(inst flux.InstanceID) (Platform, error) {
 // requests can be routed to it. Once the connection is closed --
 // trying to use it is the only way to tell if it's closed -- the
 // error representing the cause will be sent to the channel supplied.
-func (s *StandaloneMessageBus) Subscribe(inst flux.InstanceID, p RemotePlatform, complete chan<- error) {
+func (s *StandaloneMessageBus) Subscribe(inst flux.InstanceID, p Platform, complete chan<- error) {
 	s.Lock()
 	// We're replacing another client
 	if existing, ok := s.connected[inst]; ok {
@@ -70,7 +70,7 @@ func (s *StandaloneMessageBus) Subscribe(inst flux.InstanceID, p RemotePlatform,
 // ErrPlatformNotAvailable if not.
 func (s *StandaloneMessageBus) Ping(inst flux.InstanceID) error {
 	var (
-		p  RemotePlatform
+		p  Platform
 		ok bool
 	)
 	s.RLock()
@@ -84,7 +84,7 @@ func (s *StandaloneMessageBus) Ping(inst flux.InstanceID) error {
 }
 
 type removeablePlatform struct {
-	remote RemotePlatform
+	remote Platform
 	done   chan error
 	sync.Mutex
 }
@@ -146,5 +146,9 @@ func (p disconnectedPlatform) SomeServices([]flux.ServiceID) ([]Service, error) 
 }
 
 func (p disconnectedPlatform) Regrade([]RegradeSpec) error {
+	return ErrPlatformNotAvailable
+}
+
+func (p disconnectedPlatform) Ping() error {
 	return ErrPlatformNotAvailable
 }

--- a/platform/standalone_test.go
+++ b/platform/standalone_test.go
@@ -8,19 +8,10 @@ import (
 	"github.com/weaveworks/flux"
 )
 
-type mockRemotePlatform struct {
-	*MockPlatform
-	pingError error
-}
-
-func (p *mockRemotePlatform) Ping() error {
-	return p.pingError
-}
-
 func TestStandaloneMessageBus(t *testing.T) {
 	instID := flux.InstanceID("instance")
 	bus := NewStandaloneMessageBus()
-	p := &mockRemotePlatform{}
+	p := &MockPlatform{}
 
 	done := make(chan error)
 	bus.Subscribe(instID, p, done)
@@ -30,7 +21,7 @@ func TestStandaloneMessageBus(t *testing.T) {
 	}
 
 	// subscribing another connection kicks the first one off
-	p2 := &mockRemotePlatform{pingError: errors.New("ping failed")}
+	p2 := &MockPlatform{PingError: errors.New("ping failed")}
 	done2 := make(chan error)
 	bus.Subscribe(instID, p2, done2)
 

--- a/platform/standalone_test.go
+++ b/platform/standalone_test.go
@@ -1,0 +1,54 @@
+package platform
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/weaveworks/flux"
+)
+
+type mockRemotePlatform struct {
+	*MockPlatform
+	pingError error
+}
+
+func (p *mockRemotePlatform) Ping() error {
+	return p.pingError
+}
+
+func TestStandaloneMessageBus(t *testing.T) {
+	instID := flux.InstanceID("instance")
+	bus := NewStandaloneMessageBus()
+	p := &mockRemotePlatform{}
+
+	done := make(chan error)
+	bus.Subscribe(instID, p, done)
+
+	if err := bus.Ping(instID); err != nil {
+		t.Fatal(err)
+	}
+
+	// subscribing another connection kicks the first one off
+	p2 := &mockRemotePlatform{pingError: errors.New("ping failed")}
+	done2 := make(chan error)
+	bus.Subscribe(instID, p2, done2)
+
+	select {
+	case <-done:
+		break
+	case <-time.After(1 * time.Second):
+		t.Error("expected connection to be kicked when subsequent connection arrived, but it wasn't")
+	}
+
+	err := bus.Ping(instID)
+	if err == nil {
+		t.Error("expected error from pinging mock platform, but got nil")
+	}
+	select {
+	case <-done2:
+		break
+	case <-time.After(1 * time.Second):
+		t.Error("expected error from connection connection on error, got none")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -346,7 +346,11 @@ func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.Remote
 	// closed. NB we cannot in general expect there to be a
 	// configuration record for this instance; it may be connecting
 	// before there is configuration supplied.
-	return s.messageBus.Subscribe(instID, &loggingPlatform{platform, log.NewContext(s.logger).With("instanceID", instID)})
+	done := make(chan error)
+	s.messageBus.Subscribe(instID, &loggingPlatform{platform, log.NewContext(s.logger).With("instanceID", instID)}, done)
+	err = <-done
+	close(done)
+	return err
 }
 
 func (s *Server) IsDaemonConnected(instID flux.InstanceID) error {

--- a/server/server.go
+++ b/server/server.go
@@ -336,7 +336,7 @@ func applyConfigUpdates(updates flux.UnsafeInstanceConfig) instance.UpdateFunc {
 // go, aside from just trying to connection. Therefore, the server
 // will get an error when we try to use the client. We rely on that to
 // break us out of this method.
-func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.RemotePlatform) (err error) {
+func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.Platform) (err error) {
 	defer func() {
 		if err != nil {
 			s.logger.Log("method", "Daemon", "err", err)
@@ -358,7 +358,7 @@ func (s *Server) IsDaemonConnected(instID flux.InstanceID) error {
 }
 
 type loggingPlatform struct {
-	platform platform.RemotePlatform
+	platform platform.Platform
 	logger   log.Logger
 }
 


### PR DESCRIPTION
This adds a method `IsDaemonConnected` to the `DaemonAPI` interface, for checking whether a particular daemon is known to be connected, and exposes it in the HTTP transport.

It's not in the ClientAPI interface because I don't expect it to be called from the command-line client (although that's somewhat arbitrary at this point, anyway it can be moved later).

`IsDaemonConnected` asks the message bus, which checks for the presence of a platform subscribed as the instance given. "Presence" means that we can ping it via an RPC call -- necessitating a type representing a platform that can be pinged, `RemotePlatform`.

Why ping? In some ways, just answering "yes" if there's a connection registered would be neater and faster. However, we don't in general know if connections are live, since they may not shut down cleanly -- and we only find that out after attempting to write to (and read from) the socket. A secondary benefit of using a ping is that it demonstrates that the process on the other side is still minimally
active.

(It also fixes a bug in which the test for cleaning up a connection compared two interface pointers that would never be equal.)

To make testing easier, I've changed the signature of Subscribe so that it accepts a channel on which to synchronise, and returns immediately instead of blocking. This involves a goroutine to
clean up after, and forward any error.
