### PR TITLE
Use NATS as a message bus

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -26,13 +26,16 @@ dependencies:
     - "~/flux/vendor/gopkg.in"
     - "~/flux/vendor/golang.org"
     - "~/download"
-  override: 
+  override:
     - go get github.com/Masterminds/glide
     - go get github.com/FiloSottile/gvt
+    - go get github.com/nats-io/gnatsd
     - gvt restore
 
 test:
   override:
+    - gnatsd:
+        background: true
     - go build -v $(glide novendor)
     - go test -v -race $(glide novendor)
   post:

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -165,9 +165,11 @@ func main() {
 				logger.Log("component", "message bus", "err", err)
 				os.Exit(1)
 			}
+			logger.Log("component", "message bus", "type", "NATS")
 			messageBus = bus
 		} else {
 			messageBus = platform.NewStandaloneMessageBus()
+			logger.Log("component", "message bus", "type", "standalone")
 		}
 	}
 

--- a/deploy/nats.yaml
+++ b/deploy/nats.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nats
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: nats
+    spec:
+      containers:
+      - name: nats
+        image: library/nats:0.9.4
+        imagePullPolicy: IfNotPresent
+        args:
+        - nats
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nats
+spec:
+  ports:
+    - port: 4222
+  selector:
+    name: nats

--- a/guid/guid.go
+++ b/guid/guid.go
@@ -1,0 +1,17 @@
+package guid
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func New() string {
+	b := make([]byte, 16)
+	rand.Read(b)
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:])
+}

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -3,16 +3,11 @@ package jobs
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
-	"math/rand"
 	"time"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/guid"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 const (
 	// DefaultQueue is the queue to use if none is set.
@@ -67,13 +62,7 @@ type JobPopper interface {
 type JobID string
 
 func NewJobID() JobID {
-	b := make([]byte, 16)
-	rand.Read(b)
-	return JobID(fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:]))
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
+	return JobID(guid.New())
 }
 
 // Job describes a worker job

--- a/platform/metrics.go
+++ b/platform/metrics.go
@@ -96,3 +96,23 @@ func (i *instrumentedPlatform) Ping() (err error) {
 	}(time.Now())
 	return i.p.Ping()
 }
+
+// BusMetrics has metrics for messages buses.
+type BusMetrics struct {
+	KickCount metrics.Counter
+}
+
+func NewBusMetrics() BusMetrics {
+	return BusMetrics{
+		KickCount: prometheus.NewCounterFrom(stdprometheus.CounterOpts{
+			Namespace: "flux",
+			Subsystem: "bus",
+			Name:      "kick_total",
+			Help:      "Count of bus subscriptions kicked off by a newer subscription.",
+		}, []string{"instanceID"}),
+	}
+}
+
+func (m BusMetrics) IncrKicks(inst flux.InstanceID) {
+	m.KickCount.With("instanceID", string(inst)).Add(1)
+}

--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -1,0 +1,197 @@
+package nats
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/nats-io/nats"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/platform"
+	"github.com/weaveworks/flux/platform/rpc"
+)
+
+const (
+	timeout      = 5 * time.Second
+	presenceTick = 10 * time.Millisecond
+)
+
+type NATS struct {
+	url  string
+	conn *nats.EncodedConn
+}
+
+var _ platform.MessageBus = &NATS{}
+
+func NewMessageBus(url string) (*NATS, error) {
+	conn, err := nats.Connect(url)
+	if err != nil {
+		return nil, err
+	}
+	encConn, err := nats.NewEncodedConn(conn, nats.JSON_ENCODER)
+	if err != nil {
+		return nil, err
+	}
+	return &NATS{
+		url:  url,
+		conn: encConn,
+	}, nil
+}
+
+// Wait up to `timeout` for a particular instance to connect. Mostly
+// useful for synchronising during testing.
+func (n *NATS) AwaitPresence(instID flux.InstanceID, timeout time.Duration) error {
+	timer := time.After(timeout)
+	attempts := time.NewTicker(presenceTick)
+	defer attempts.Stop()
+
+	var pres Presence
+	for {
+		select {
+		case <-attempts.C:
+			if err := n.conn.Request(string(instID)+".Platform.Presence", Presence{}, &pres, presenceTick); err == nil {
+				return nil
+			}
+		case <-timer:
+			return errors.New("timeout")
+		}
+	}
+}
+
+type requester struct {
+	conn    *nats.EncodedConn
+	subject string
+}
+
+type Presence struct{}
+
+type AllServicesResponse struct {
+	Services []platform.Service
+	Error    string
+}
+
+type SomeServicesResponse struct {
+	Services []platform.Service
+	Error    string
+}
+
+type RegradeResponse struct {
+	Result rpc.RegradeResult
+	Error  string
+}
+
+func maybeError(msg string) error {
+	if msg != "" {
+		return errors.New(msg)
+	}
+	return nil
+}
+
+func maybeString(err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	return ""
+}
+
+func (r *requester) AllServices(ns string, ig flux.ServiceIDSet) ([]platform.Service, error) {
+	var response AllServicesResponse
+	if err := r.conn.Request(r.subject+".Platform.AllServices", rpc.AllServicesRequest{ns, ig}, &response, timeout); err != nil {
+		return nil, err
+	}
+	return response.Services, maybeError(response.Error)
+}
+
+func (r *requester) SomeServices(incl []flux.ServiceID) ([]platform.Service, error) {
+	var response SomeServicesResponse
+	if err := r.conn.Request(r.subject+".Platform.SomeServices", incl, &response, timeout); err != nil {
+		return nil, err
+	}
+	return response.Services, maybeError(response.Error)
+}
+
+func (r *requester) Regrade(specs []platform.RegradeSpec) error {
+	var response RegradeResponse
+	if err := r.conn.Request(r.subject+".Platform.Regrade", specs, &response, timeout); err != nil {
+		return err
+	}
+	if len(response.Result) > 0 {
+		errs := platform.RegradeError{}
+		for s, e := range response.Result {
+			errs[s] = errors.New(e)
+		}
+		return errs
+	}
+	return maybeError(response.Error)
+}
+
+// Connect returns a platform.Platform implementation that can be used
+// to talk to a particular instance.
+func (n *NATS) Connect(instID flux.InstanceID) (platform.Platform, error) {
+	return &requester{
+		conn:    n.conn,
+		subject: string(instID),
+	}, nil
+}
+
+// Subscribe registers a remote platform.Platform implementation as
+// representing a particular instance ID, blocking indefinitely.
+func (n *NATS) Subscribe(instID flux.InstanceID, remote platform.Platform) error {
+	type req struct {
+		reply   string
+		request interface{}
+	}
+	requests := make(chan req)
+	errc := make(chan error)
+
+	n.conn.Subscribe(string(instID)+".Platform.Presence", func(_, reply string, presReq *Presence) {
+		requests <- req{reply, presReq}
+	})
+	n.conn.Subscribe(string(instID)+".Platform.AllServices", func(subj, reply string, asReq *rpc.AllServicesRequest) {
+		requests <- req{reply, asReq}
+	})
+	n.conn.Subscribe(string(instID)+".Platform.SomeServices", func(subj, reply string, ssReq *[]flux.ServiceID) {
+		requests <- req{reply, ssReq}
+	})
+	n.conn.Subscribe(string(instID)+".Platform.Regrade", func(subj, reply string, rgdReq *[]platform.RegradeSpec) {
+		requests <- req{reply, rgdReq}
+	})
+
+	for {
+		select {
+		case r := <-requests:
+			switch request := r.request.(type) {
+			case *Presence:
+				n.conn.Publish(r.reply, Presence{})
+			case *rpc.AllServicesRequest:
+				ss, err := remote.AllServices(request.MaybeNamespace, request.Ignored)
+				n.conn.Publish(r.reply, AllServicesResponse{ss, maybeString(err)})
+			case *[]flux.ServiceID:
+				ss, err := remote.SomeServices(*request)
+				n.conn.Publish(r.reply, SomeServicesResponse{ss, maybeString(err)})
+			case *[]platform.RegradeSpec:
+				resp := RegradeResponse{}
+				err := remote.Regrade(*request)
+				switch err := err.(type) {
+				case platform.RegradeError:
+					result := rpc.RegradeResult{}
+					for s, e := range err {
+						result[s] = e.Error()
+					}
+					resp.Result = result
+				default:
+					resp.Error = maybeString(err)
+				}
+				n.conn.Publish(r.reply, resp)
+			default:
+				errc <- errors.New(fmt.Sprintf("Unknown request value %+v", r.request))
+			}
+		case err := <-errc:
+			errc <- err
+			close(errc)
+			break
+		}
+	}
+	return <-errc
+}

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -83,9 +83,13 @@ func TestNATS(t *testing.T) {
 		t.Fatal("expected error but didn't get one")
 	}
 
-	close(errc)
-	if err := <-errc; err != nil {
-		t.Fatal(err)
+	select {
+	case <-errc:
+		if err == nil {
+			t.Fatal("expected error return from subscription but didn't get one")
+		}
+	default:
+		t.Fatal("expected error return from subscription but didn't get one")
 	}
 }
 

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -1,0 +1,110 @@
+package nats
+
+import (
+	"errors"
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/platform"
+)
+
+var testNATS = flag.String("nats-url", "", "NATS connection URL; use NATS' default if empty")
+
+func TestNATS(t *testing.T) {
+	flag.Parse()
+	if *testNATS == "" {
+		*testNATS = nats.DefaultURL
+	}
+
+	bus, err := NewMessageBus(*testNATS)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	errc := make(chan error)
+	subscribe := func(inst flux.InstanceID, plat platform.Platform) {
+		go func() {
+			errc <- bus.Subscribe(inst, plat)
+		}()
+		if err := bus.AwaitPresence(inst, 5*time.Second); err != nil {
+			t.Fatal("Timed out waiting for instance to subscribe")
+		}
+	}
+
+	instA := flux.InstanceID("steamy-windows-89")
+	mockA := mockPlatform{
+		allServicesResult: []platform.Service{platform.Service{}},
+		regradeError:      platform.RegradeError{flux.ServiceID("foo/bar"): errors.New("foo barred")},
+	}
+	subscribe(instA, mockA)
+
+	plat, err := bus.Connect(instA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ss, err := plat.AllServices("", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mockA.allServicesResult) != len(ss) {
+		t.Fatalf("Expected %d result, got %d", len(mockA.allServicesResult), len(ss))
+	}
+
+	err = plat.Regrade([]platform.RegradeSpec{})
+	if _, ok := err.(platform.RegradeError); !ok {
+		t.Fatalf("expected RegradeError, got %+v", err)
+	}
+
+	mockB := mockPlatform{
+		allServicesError:   errors.New("just didn't feel like it"),
+		someServicesResult: []platform.Service{platform.Service{}, platform.Service{}},
+	}
+	instB := flux.InstanceID("smokey-water-72")
+	subscribe(instB, mockB)
+	platB, err := bus.Connect(instB)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err = platB.SomeServices([]flux.ServiceID{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mockB.someServicesResult) != len(ss) {
+		t.Fatalf("Expected %d result, got %d", len(mockB.someServicesResult), len(ss))
+	}
+
+	ss, err = platB.AllServices("", nil)
+	if err == nil {
+		t.Fatal("expected error but didn't get one")
+	}
+
+	close(errc)
+	if err := <-errc; err != nil {
+		t.Fatal(err)
+	}
+}
+
+type mockPlatform struct {
+	allServicesResult  []platform.Service
+	allServicesError   error
+	someServicesResult []platform.Service
+	someServicesError  error
+	regradeError       error
+}
+
+func (p mockPlatform) AllServices(string, flux.ServiceIDSet) ([]platform.Service, error) {
+	return p.allServicesResult, p.allServicesError
+}
+
+func (p mockPlatform) SomeServices([]flux.ServiceID) ([]platform.Service, error) {
+	return p.someServicesResult, p.someServicesError
+}
+
+func (p mockPlatform) Regrade([]platform.RegradeSpec) error {
+	return p.regradeError
+}

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -2,6 +2,7 @@ package nats
 
 import (
 	"errors"
+
 	"flag"
 	"testing"
 	"time"
@@ -14,7 +15,7 @@ import (
 
 var testNATS = flag.String("nats-url", "", "NATS connection URL; use NATS' default if empty")
 
-func TestNATS(t *testing.T) {
+func setup(t *testing.T) *NATS {
 	flag.Parse()
 	if *testNATS == "" {
 		*testNATS = nats.DefaultURL
@@ -24,21 +25,59 @@ func TestNATS(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	return bus
+}
+
+func subscribe(t *testing.T, bus *NATS, errc chan error, inst flux.InstanceID, plat platform.Platform) {
+	bus.Subscribe(inst, plat, errc)
+	if err := bus.AwaitPresence(inst, 5*time.Second); err != nil {
+		t.Fatal("Timed out waiting for instance to subscribe")
+	}
+}
+
+func TestPing(t *testing.T) {
+	bus := setup(t)
 
 	errc := make(chan error)
-	subscribe := func(inst flux.InstanceID, plat platform.Platform) {
-		bus.Subscribe(inst, plat, errc)
-		if err := bus.AwaitPresence(inst, 5*time.Second); err != nil {
-			t.Fatal("Timed out waiting for instance to subscribe")
-		}
+	instID := flux.InstanceID("wirey-bird-68")
+	platA := &platform.MockPlatform{}
+	subscribe(t, bus, errc, instID, platA)
+
+	// AwaitPresence uses Ping, so we have to install our error after
+	// subscribe succeeds.
+	platA.PingError = errors.New("ping problem")
+	if err := platA.Ping(); err == nil {
+		t.Fatalf("expected error from directly calling ping, got nil")
 	}
+
+	err := bus.Ping(instID)
+	if err == nil {
+		t.Errorf("expected error from ping, got nil")
+	} else if err.Error() != "ping problem" {
+		t.Errorf("got the wrong error: %s", err.Error())
+	}
+
+	select {
+	case err := <-errc:
+		if err == nil {
+			t.Fatal("expected error return from subscription but didn't get one")
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("expected error return from subscription but didn't get one")
+	}
+}
+
+func TestMethods(t *testing.T) {
+	bus := setup(t)
+
+	errc := make(chan error)
 
 	instA := flux.InstanceID("steamy-windows-89")
 	mockA := &platform.MockPlatform{
 		AllServicesAnswer: []platform.Service{platform.Service{}},
 		RegradeError:      platform.RegradeError{flux.ServiceID("foo/bar"): errors.New("foo barred")},
 	}
-	subscribe(instA, mockA)
+	subscribe(t, bus, errc, instA, mockA)
 
 	plat, err := bus.Connect(instA)
 	if err != nil {
@@ -62,7 +101,7 @@ func TestNATS(t *testing.T) {
 		SomeServicesAnswer: []platform.Service{platform.Service{}, platform.Service{}},
 	}
 	instB := flux.InstanceID("smokey-water-72")
-	subscribe(instB, mockB)
+	subscribe(t, bus, errc, instB, mockB)
 	platB, err := bus.Connect(instB)
 	if err != nil {
 		t.Fatal(err)
@@ -82,7 +121,7 @@ func TestNATS(t *testing.T) {
 	}
 
 	select {
-	case <-errc:
+	case err := <-errc:
 		if err == nil {
 			t.Fatal("expected error return from subscription but didn't get one")
 		}

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -15,13 +15,15 @@ import (
 
 var testNATS = flag.String("nats-url", "", "NATS connection URL; use NATS' default if empty")
 
+var metrics = platform.NewBusMetrics()
+
 func setup(t *testing.T) *NATS {
 	flag.Parse()
 	if *testNATS == "" {
 		*testNATS = nats.DefaultURL
 	}
 
-	bus, err := NewMessageBus(*testNATS)
+	bus, err := NewMessageBus(*testNATS, metrics)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/platform/rpc/nats/doc.go
+++ b/platform/rpc/nats/doc.go
@@ -1,0 +1,18 @@
+package nats
+
+/* A `MessageBus` implementation that uses NATS (https://nats.io/).
+
+The responsibility of the MessageBus is to:
+
+ 1. Connect to the platform for an instance (hand out Platform
+ implementations given an instance ID); and,
+ 2. Register a remote platform against an instance ID.
+
+In NATS terms, this means:
+
+ 1. Supplying a platform implementation that will send requests to
+ NATS, addressed to the instance, and relay the responses back; and,
+ 2. Listening for platform requests for an instance, relay them to the
+ remote platform, and relay the responses back to NATS
+
+*/

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -10,11 +10,13 @@ import (
 type StandaloneMessageBus struct {
 	connected map[flux.InstanceID]*removeablePlatform
 	sync.RWMutex
+	metrics BusMetrics
 }
 
-func NewStandaloneMessageBus() *StandaloneMessageBus {
+func NewStandaloneMessageBus(metrics BusMetrics) *StandaloneMessageBus {
 	return &StandaloneMessageBus{
 		connected: map[flux.InstanceID]*removeablePlatform{},
+		metrics:   metrics,
 	}
 }
 
@@ -42,6 +44,7 @@ func (s *StandaloneMessageBus) Subscribe(inst flux.InstanceID, p Platform, compl
 	// We're replacing another client
 	if existing, ok := s.connected[inst]; ok {
 		delete(s.connected, inst)
+		s.metrics.IncrKicks(inst)
 		existing.closeWithError(errors.New("duplicate connection; replacing with newer"))
 	}
 

--- a/platform/standalone_test.go
+++ b/platform/standalone_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestStandaloneMessageBus(t *testing.T) {
 	instID := flux.InstanceID("instance")
-	bus := NewStandaloneMessageBus()
+	bus := NewStandaloneMessageBus(NewBusMetrics())
 	p := &MockPlatform{}
 
 	done := make(chan error)

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -499,6 +499,94 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/nats-io/gnatsd/auth",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "auth",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/conf",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "conf",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/server",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "/server",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/test",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "test",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/util",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "util",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/vendor/github.com/nats-io/nuid",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "vendor/github.com/nats-io/nuid",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/vendor/golang.org/x/crypto/bcrypt",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "vendor/golang.org/x/crypto/bcrypt",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/gnatsd/vendor/golang.org/x/crypto/blowfish",
+			"repository": "https://github.com/nats-io/gnatsd",
+			"vcs": "git",
+			"revision": "8ffdb6b7f6c6eb73e0253cdd9f53eeb959c6d861",
+			"branch": "master",
+			"path": "vendor/golang.org/x/crypto/blowfish",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/nats",
+			"repository": "https://github.com/nats-io/nats",
+			"vcs": "git",
+			"revision": "61923ed1eaf8398000991fbbee2ef11ab5a5be0d",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/nats-io/nuid",
+			"repository": "https://github.com/nats-io/nuid",
+			"vcs": "git",
+			"revision": "289cccf02c178dc782430d534e3c1f5b72af807f",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/petar/GoLLRB/llrb",
 			"repository": "https://github.com/petar/GoLLRB",
 			"vcs": "git",


### PR DESCRIPTION
In short: this provides an implementation of `MessageBus` which sends requests over NATS.

What's the point? If we are serving daemon connections from more than one pod (i.e., if we scale the fluxsvc deployment to > 1) then the pod that answers a client request may be different to the pod that is serving the daemon's connection. Using a message bus (i.e., NATS) connects them up.

It may be possible to make the `net/rpc` abstractions work with NATS (though I didn't find a library for it). However, we have a requirement which is difficult to reconcile with `net/rpc`: each request must be addressed and routed to a specific daemon. For that reason I implemented a simple scheme using NATS operations (Subscribe, Request) directly.