### PR TITLE
README: remove user stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,12 @@
 # Flux
 
-Work with your code, from laptop to prod.
-
-## User stories
-
-I want to update a specific image in a specific service, and deploy it.
-
-```
-fluxctl release --service=S --update-image=I
-```
-
-I want to deploy specific service/image pairs from some other source of truth, e.g. a dev environment to a prod environment.
-
-```
-# Some script wrapping this command:
-fluxctl release --service=S --update-image=I
-```
-
-I want to deploy the latest images for a given service.
-
-```
-fluxctl release --service=S --update-all-images
-```
-
-I want to release a specific image to all services that are using that image, except some services that I have manually excluded somehow.
-
-```
-fluxctl release --all --update-image=I
-```
-
-I want to deploy the latest images for all services on the platform, except some services that I have manually excluded somehow.
-
-```
-fluxctl release --all --update-all-images
-```
-
-I want to deploy a service with no change of image, just taking the latest resource definition file.
-This may be known as a config change deployment.
-
-```
-fluxctl release --service=S
-```
-
-I want to automatically deploy the latest images for a set of opt-in services.
-
-```
-fluxctl automate --service=S
-```
-
-I want to show all recognized services and their status.
-
-```
-fluxctl list-services
-```
-
-I want to find out what images are available for a service.
-
-```
-fluxctl list-images --service=S
-```
-
-I want to inspect the history of actions taken with Flux, both per-service and overall.
-
-```
-fluxctl history [--service=S]
-```
+Flux is a tool for deploying container images to Kubernetes clusters.
 
 ## Installing
 
-For the minute you will have to build or use the container images
-`weaveworks/flux{d,svc}`. The directory [`deploy/`](https://github.com/weaveworks/flux/tree/master/deploy) has example Kubernetes configuration and instructions for using it.
+For the minute you will have to build or use the container images `weaveworks/flux{d,svc}`.
+The directory [`deploy/`](https://github.com/weaveworks/flux/tree/master/deploy)
+ has example Kubernetes configuration and instructions for using it.
 
 ## Developing
 


### PR DESCRIPTION
The user stories were written and recorded in the README to guide
development early on. They don't belong here any more.