### PR TITLE
Version release binaries

### DIFF
--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -66,6 +66,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 	svcopts := newService(opts)
 
 	cmd.AddCommand(
+		newVersionCommand(),
 		newServiceShow(svcopts).Command(),
 		newServiceList(svcopts).Command(),
 		newServiceRelease(svcopts).Command(),

--- a/cmd/fluxctl/version_cmd.go
+++ b/cmd/fluxctl/version_cmd.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var version string
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Output the version of fluxctl",
+		RunE: func(_ *cobra.Command, args []string) error {
+			if version == "" {
+				version = "unversioned"
+			}
+			fmt.Println(version)
+			return nil
+		},
+	}
+}


### PR DESCRIPTION
Add the command `fluxctl version`, and give the release binaries a version based on the state of the git repo (as for image tags).

The purpose is to be able to identify the binary used by a user, e.g., in bug reports.