### PR TITLE
Don't drop websocket on application error

### DIFF
--- a/platform/platform.go
+++ b/platform/platform.go
@@ -25,6 +25,16 @@ type Platform interface {
 	Ping() error
 }
 
+// Wrap errors in this to indicate that the platform should be
+// considered dead, and disconnected.
+type FatalError struct {
+	Err error
+}
+
+func (err FatalError) Error() string {
+	return err.Err.Error()
+}
+
 // For getting a connection to a platform; this can happen in
 // different ways, e.g., by having direct access to Kubernetes in
 // standalone mode, or by going via a message bus.

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -101,7 +101,7 @@ func (p *removeablePlatform) closeWithError(err error) {
 
 func (p *removeablePlatform) AllServices(maybeNamespace string, ignored flux.ServiceIDSet) (s []Service, err error) {
 	defer func() {
-		if err != nil {
+		if _, ok := err.(FatalError); ok {
 			p.closeWithError(err)
 		}
 	}()
@@ -110,7 +110,7 @@ func (p *removeablePlatform) AllServices(maybeNamespace string, ignored flux.Ser
 
 func (p *removeablePlatform) SomeServices(ids []flux.ServiceID) (s []Service, err error) {
 	defer func() {
-		if err != nil {
+		if _, ok := err.(FatalError); ok {
 			p.closeWithError(err)
 		}
 	}()
@@ -119,7 +119,7 @@ func (p *removeablePlatform) SomeServices(ids []flux.ServiceID) (s []Service, er
 
 func (p *removeablePlatform) Regrade(spec []RegradeSpec) (err error) {
 	defer func() {
-		if err != nil {
+		if _, ok := err.(FatalError); ok {
 			p.closeWithError(err)
 		}
 	}()
@@ -128,7 +128,7 @@ func (p *removeablePlatform) Regrade(spec []RegradeSpec) (err error) {
 
 func (p *removeablePlatform) Ping() (err error) {
 	defer func() {
-		if err != nil {
+		if _, ok := err.(FatalError); ok {
 			p.closeWithError(err)
 		}
 	}()

--- a/platform/standalone_test.go
+++ b/platform/standalone_test.go
@@ -22,7 +22,7 @@ func TestStandaloneMessageBus(t *testing.T) {
 
 	// subscribing another connection kicks the first one off
 	p2 := &MockPlatform{PingError: errors.New("ping failed")}
-	done2 := make(chan error)
+	done2 := make(chan error, 2)
 	bus.Subscribe(instID, p2, done2)
 
 	select {
@@ -36,10 +36,34 @@ func TestStandaloneMessageBus(t *testing.T) {
 	if err == nil {
 		t.Error("expected error from pinging mock platform, but got nil")
 	}
+
+	done2 <- nil
+	err = <-done2
+	if err != nil {
+		t.Error("did not expect subscription error after application-level error")
+	}
+
+	// Now test that a FatalError does shut the subscription down
+	p3 := &MockPlatform{PingError: FatalError{errors.New("ping failed")}}
+	done3 := make(chan error)
+	bus.Subscribe(instID, p3, done3)
+
 	select {
 	case <-done2:
 		break
 	case <-time.After(1 * time.Second):
-		t.Error("expected error from connection connection on error, got none")
+		t.Error("expected connection to be kicked when subsequent connection arrived, but it wasn't")
+	}
+
+	err = bus.Ping(instID)
+	if err == nil {
+		t.Error("expected error from pinging mock platform, but got nil")
+	}
+
+	select {
+	case <-done3:
+		break
+	case <-time.After(1 * time.Second):
+		t.Error("expected error from connection on error, got none")
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -339,7 +339,7 @@ func applyConfigUpdates(updates flux.UnsafeInstanceConfig) instance.UpdateFunc {
 func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.Platform) (err error) {
 	defer func() {
 		if err != nil {
-			s.logger.Log("method", "Daemon", "err", err)
+			s.logger.Log("method", "RegisterDaemon", "err", err)
 		}
 	}()
 	// Register the daemon with our message bus, waiting for it to be


### PR DESCRIPTION
At present, any error returned by a daemon will cause the connection
to be dropped: the error is fed back to the subscribe method, which
closes its completion channel, and the HTTP handler exits, closing the
connection.

Most of these errors will be *application* level errors, e.g,. "such
and such a service does not exist", rather than transport level
errors. So it's reasonable to keep the connection open in these cases.

Happily, the RPC mechanism transmits application errors as strings,
and reconstitutes them by simply casting them to `rpc.ServerError`, so
we can detect them. Everything else becomes a `FatalError`, which will
close down the connection as before.
