### PR TITLE
Detect when the client v service API is mismatched

### DIFF
--- a/cmd/fluxctl/main.go
+++ b/cmd/fluxctl/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"io"
 	"os"
 	"strings"
 
@@ -9,8 +10,10 @@ import (
 	transport "github.com/weaveworks/flux/http"
 )
 
-func main() {
+func run(args []string, stderr io.Writer) int {
 	rootCmd := newRoot().Command()
+	rootCmd.SetArgs(args)
+	rootCmd.SetOutput(stderr)
 	if cmd, err := rootCmd.ExecuteC(); err != nil {
 		err = errors.Cause(err)
 		switch err := err.(type) {
@@ -32,6 +35,11 @@ func main() {
 			cmd.Println("Error: ", err.Error())
 			cmd.Printf("Run '%v --help' for usage.\n", cmd.CommandPath())
 		}
-		os.Exit(1)
+		return 1
 	}
+	return 0
+}
+
+func main() {
+	os.Exit(run(os.Args, os.Stderr))
 }

--- a/cmd/fluxctl/main.go
+++ b/cmd/fluxctl/main.go
@@ -1,14 +1,36 @@
 package main
 
-import "os"
+import (
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	transport "github.com/weaveworks/flux/http"
+)
 
 func main() {
 	rootCmd := newRoot().Command()
 	if cmd, err := rootCmd.ExecuteC(); err != nil {
-		switch err.(type) {
+		err = errors.Cause(err)
+		switch err := err.(type) {
 		case usageError:
 			cmd.Println("")
 			cmd.Println(cmd.UsageString())
+		case *transport.APIError:
+			switch {
+			case err.IsMissing():
+				cmd.Println(strings.Join([]string{
+					"Error: Service API endpoint not found. This usually means that there is a mismatch between the client and the service. Please visit",
+					"    https://github.com/weaveworks/flux/releases",
+					"to download a new release of the client."}, "\n"))
+			default:
+				cmd.Println("Problem communicating with the service: ", err.Error())
+				cmd.Printf("Run '%v --help' for usage.\n", cmd.CommandPath())
+			}
+		default:
+			cmd.Println("Error: ", err.Error())
+			cmd.Printf("Run '%v --help' for usage.\n", cmd.CommandPath())
 		}
 		os.Exit(1)
 	}

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -56,6 +56,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		Use:               "fluxctl",
 		Long:              rootLongHelp,
 		SilenceUsage:      true,
+		SilenceErrors:     true,
 		PersistentPreRunE: opts.PersistentPreRunE,
 	}
 	cmd.PersistentFlags().StringVarP(&opts.URL, "url", "u", "https://cloud.weave.works/api/flux",

--- a/cmd/fluxctl/version_test.go
+++ b/cmd/fluxctl/version_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// Test that given a server that responds with 404 for a particular
+// route, we get a version warning.
+func TestUnknownVersion(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	telltale := "endpoint not found"
+	errout := &bytes.Buffer{}
+	res := run([]string{"--url", server.URL, "list-services"}, errout)
+	if res == 0 {
+		t.Errorf("Expected non-zero return from main, got %d", res)
+	}
+	if !strings.Contains(errout.String(), telltale) {
+		t.Fatalf("Expected %q in output to stderr, but it was not seen in %q", telltale, errout.String())
+	}
+}


### PR DESCRIPTION
Getting a 404 result from the client usually means that there's a
mismatch between the client and the service. This commit makes that
situation detectable by returning a particular type for transport
errors (as opposed to application errors), and treating 404 as a
special case in the client.