### PR TITLE
[WIP] Add support for DaemonSets as pod controllers

### DIFF
--- a/cmd/fluxsvc/kubeservice
+++ b/cmd/fluxsvc/kubeservice
@@ -59,8 +59,8 @@ def service_for_file(path):
     obj = yaml.load(stream)
 
   kind = obj["kind"]
-  if kind not in {"ReplicationController", "Deployment"}:
-    raise Kubeimage("Not a ReplicationController or Deployment")
+  if kind not in {"ReplicationController", "Deployment", "DaemonSet"}:
+    raise Kubeimage("Not a ReplicationController, Deployment or DaemonSet")
 
   namespace = safe_lookup(obj, ["metadata", "namespace"], default="default")
   labels = safe_lookup(obj, ["spec", "template", "metadata", "labels"])

--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -23,13 +23,17 @@ func (c podController) newRegrade(newDefinition *apiObject) (*regrade, error) {
 	}
 
 	var result regrade
-	if c.Deployment != nil {
+	switch {
+	case c.Deployment != nil:
 		result.exec = deploymentExec(c.Deployment, newDefinition)
 		result.summary = "Applying deployment"
-	} else if c.ReplicationController != nil {
+	case c.ReplicationController != nil:
 		result.exec = rollingUpgradeExec(c.ReplicationController, newDefinition)
 		result.summary = "Rolling upgrade"
-	} else {
+	case c.DaemonSet != nil:
+		result.exec = daemonsetExec(c.DaemonSet, newDefinition)
+		result.summary = "Applying DaemonSet"
+	default:
 		return nil, platform.ErrNoMatching
 	}
 	return &result, nil
@@ -118,5 +122,16 @@ func deploymentExec(def *apiext.Deployment, newDef *apiObject) regradeExecFunc {
 			err = cmd.Run()
 		}
 		return err
+	}
+}
+
+func daemonsetExec(def *apiext.DaemonSet, newDef *apiObject) regradeExecFunc {
+	return func(c *Cluster, logger log.Logger) error {
+		return c.doReleaseCommand(
+			logger,
+			newDef,
+			"apply",
+			"-f", "-", // take definition from stdin
+		)
 	}
 }


### PR DESCRIPTION
NB: this itself is not sufficient, because DaemonSets do not have support for rollout as deployments do. We may be able to fake it by deleting the pods in question and letting them be created; otherwise, we'll have to wait until there's a rollout thingy.

Most relevant seeming issue in k8s: https://github.com/kubernetes/kubernetes/issues/22543