### PR TITLE
Quell traces from kubeservice, and correctly interpret its output

### DIFF
--- a/platform/kubernetes/files_for.go
+++ b/platform/kubernetes/files_for.go
@@ -53,9 +53,11 @@ func FilesFor(path, namespace, service string) (filenames []string, err error) {
 		if err := cmd.Run(); err != nil {
 			continue
 		}
-		out := strings.TrimSpace(stdout.String())
-		if out == tgt { // kubeservice output is "namespace/service", same as ServiceID
-			winners = append(winners, file)
+		for _, out := range strings.Split(strings.TrimSpace(stdout.String()), "\n") {
+			if out == tgt { // kubeservice output is "namespace/service", same as ServiceID
+				winners = append(winners, file)
+				break
+			}
 		}
 	}
 

--- a/platform/kubernetes/files_for.go
+++ b/platform/kubernetes/files_for.go
@@ -46,21 +46,14 @@ func FilesFor(path, namespace, service string) (filenames []string, err error) {
 	tgt := fmt.Sprintf("%s/%s", namespace, service)
 	var winners []string
 	for _, file := range candidates {
-		var stdout, stderr bytes.Buffer
+		var stdout bytes.Buffer
 		cmd := exec.Command(bin, "./"+filepath.Base(file)) // due to bug (?) in kubeservice
 		cmd.Dir = filepath.Dir(file)
 		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		fmt.Fprintf(os.Stderr, "Args: %v\n", cmd.Args)
-		fmt.Fprintf(os.Stderr, "Dir: %s\n", cmd.Dir)
 		if err := cmd.Run(); err != nil {
-			fmt.Fprintf(os.Stderr, stdout.String()+"\n")
-			fmt.Fprintf(os.Stderr, stderr.String()+"\n")
-			fmt.Fprintf(os.Stderr, "kubeservice FAILED: %v\n", err)
 			continue
 		}
 		out := strings.TrimSpace(stdout.String())
-		fmt.Fprintf(os.Stderr, "kubeservice SUCCESS: %s -> %s\n", file, out)
 		if out == tgt { // kubeservice output is "namespace/service", same as ServiceID
 			winners = append(winners, file)
 		}


### PR DESCRIPTION
Fixed #301. Fixes #254.
See commits.