### PR TITLE
Fair Scheduling

### DIFF
--- a/http/transport.go
+++ b/http/transport.go
@@ -249,7 +249,7 @@ func handlePostRelease(s api.FluxService) http.Handler {
 
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		if err := json.NewEncoder(w).Encode(postReleaseResponse{
-			Status:    "Submitted.",
+			Status:    "Queued.",
 			ReleaseID: id,
 		}); err != nil {
 			w.WriteHeader(http.StatusInternalServerError)

--- a/jobs/db_store.go
+++ b/jobs/db_store.go
@@ -166,8 +166,8 @@ func (s *DatabaseStore) PutJob(inst flux.InstanceID, job Job) (JobID, error) {
 		if job.Key != "" {
 			var count int
 			err = s.conn.QueryRow(`
-				SELECT count(*) FROM jobs WHERE key = $1 AND finished_at IS NULL
-			`, job.Key).Scan(&count)
+				SELECT count(1) FROM jobs WHERE instance_id = $1 AND key = $2 AND finished_at IS NULL
+			`, string(inst), job.Key).Scan(&count)
 			if err != nil {
 				return errors.Wrap(err, "looking for existing job")
 			}

--- a/jobs/db_store.go
+++ b/jobs/db_store.go
@@ -405,8 +405,10 @@ func (s *DatabaseStore) GC() error {
 
 		if _, err := s.conn.Exec(`
 			DELETE FROM jobs
-						WHERE finished_at IS NOT NULL
-							AND submitted_at < $1
+						WHERE (finished_at IS NOT NULL AND submitted_at < $1)
+						   OR (claimed_at IS NOT NULL
+							 AND claimed_at < $1
+							 AND (heartbeat_at IS NULL OR heartbeat_at < $1))
 		`, now.Add(-s.oldest)); err != nil {
 			return errors.Wrap(err, "deleting old jobs")
 		}

--- a/jobs/db_store.go
+++ b/jobs/db_store.go
@@ -107,7 +107,7 @@ func (s *DatabaseStore) GetJob(inst flux.InstanceID, id JobID) (Job, error) {
 func (s *DatabaseStore) PutJobIgnoringDuplicates(inst flux.InstanceID, job Job) (JobID, error) {
 	var (
 		jobID       = NewJobID()
-		status      = "Submitted job."
+		status      = "Queued."
 		paramsBytes []byte
 		err         error
 	)

--- a/jobs/db_store_test.go
+++ b/jobs/db_store_test.go
@@ -416,7 +416,7 @@ func TestDatabaseStoreFairScheduling(t *testing.T) {
 	// - It should be instance1's next job
 	job2, err := db.NextJob(nil)
 	bailIfErr(t, err)
-	// - It should be the highest priority
+	// - It should be the next job for instance1
 	if job2.ID != job2ID {
 		t.Errorf("Got an unexpected job id")
 	}


### PR DESCRIPTION
Fixes #298 

Only run one job at a time per instance.

Caveat is that if there is a crash which leaves a job claimed, but not finished, no more jobs will happen. We should probably timeout/expire old jobs based on heartbeat! Maybe that plays into recoverable jobs? or we could just GC old jobs which were claimed but not heartbeated in a long time. @squaremo, I added a commit of GCing old jobs, wdyt?