### PR TITLE
Regrade -> Release

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -124,15 +124,15 @@ func (h *Instance) ExactImages(images []flux.ImageID) (ImageMap, error) {
 	return m, nil
 }
 
-func (h *Instance) PlatformRelease(specs []platform.ReleaseSpec) (err error) {
+func (h *Instance) PlatformApply(defs []platform.ServiceDefinition) (err error) {
 	defer func(begin time.Time) {
 		h.duration.With(
-			"method", "PlatformRelease",
+			"method", "PlatformApply",
 			"success", fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return h.platform.Release(specs)
+	return h.platform.Apply(defs)
 }
 
 func (h *Instance) GetConfig() (Config, error) {

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -124,15 +124,15 @@ func (h *Instance) ExactImages(images []flux.ImageID) (ImageMap, error) {
 	return m, nil
 }
 
-func (h *Instance) PlatformRegrade(specs []platform.RegradeSpec) (err error) {
+func (h *Instance) PlatformRelease(specs []platform.ReleaseSpec) (err error) {
 	defer func(begin time.Time) {
 		h.duration.With(
-			"method", "PlatformRegrade",
+			"method", "PlatformRelease",
 			"success", fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
-	return h.platform.Regrade(specs)
+	return h.platform.Release(specs)
 }
 
 func (h *Instance) GetConfig() (Config, error) {

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -57,7 +57,7 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 			http.DefaultClient,
 			c.Settings.Slack.HookURL,
 			c.Settings.Slack.Username,
-			`Release`, // only catch the final message
+			`(done|failed)$`, // only catch the final message
 		))
 	}
 

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -57,7 +57,7 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 			http.DefaultClient,
 			c.Settings.Slack.HookURL,
 			c.Settings.Slack.Username,
-			`Regrade`, // only catch the final message
+			`Release`, // only catch the final message
 		))
 	}
 

--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -16,13 +16,13 @@ import (
 	"github.com/weaveworks/flux/platform"
 )
 
-func (c podController) newRegrade(newDefinition *apiObject) (*regrade, error) {
+func (c podController) newRelease(newDefinition *apiObject) (*release, error) {
 	k := c.kind()
 	if newDefinition.Kind != k {
 		return nil, fmt.Errorf(`Expected new definition of kind %q, to match old definition; got %q`, k, newDefinition.Kind)
 	}
 
-	var result regrade
+	var result release
 	if c.Deployment != nil {
 		result.exec = deploymentExec(c.Deployment, newDefinition)
 		result.summary = "Applying deployment"
@@ -86,7 +86,7 @@ func (c *Cluster) doReleaseCommand(logger log.Logger, newDefinition *apiObject, 
 	return err
 }
 
-func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) regradeExecFunc {
+func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) releaseExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
 		return c.doReleaseCommand(
 			logger,
@@ -99,7 +99,7 @@ func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) regra
 	}
 }
 
-func deploymentExec(def *apiext.Deployment, newDef *apiObject) regradeExecFunc {
+func deploymentExec(def *apiext.Deployment, newDef *apiObject) releaseExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
 		err := c.doReleaseCommand(
 			logger,

--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -16,13 +16,13 @@ import (
 	"github.com/weaveworks/flux/platform"
 )
 
-func (c podController) newRelease(newDefinition *apiObject) (*release, error) {
+func (c podController) newApply(newDefinition *apiObject) (*apply, error) {
 	k := c.kind()
 	if newDefinition.Kind != k {
 		return nil, fmt.Errorf(`Expected new definition of kind %q, to match old definition; got %q`, k, newDefinition.Kind)
 	}
 
-	var result release
+	var result apply
 	if c.Deployment != nil {
 		result.exec = deploymentExec(c.Deployment, newDefinition)
 		result.summary = "Applying deployment"
@@ -68,7 +68,7 @@ func (c *Cluster) kubectlCommand(args ...string) *exec.Cmd {
 	return cmd
 }
 
-func (c *Cluster) doReleaseCommand(logger log.Logger, newDefinition *apiObject, args ...string) error {
+func (c *Cluster) doApplyCommand(logger log.Logger, newDefinition *apiObject, args ...string) error {
 	cmd := c.kubectlCommand(args...)
 	cmd.Stdin = bytes.NewReader(newDefinition.bytes)
 	stderr := &bytes.Buffer{}
@@ -86,9 +86,9 @@ func (c *Cluster) doReleaseCommand(logger log.Logger, newDefinition *apiObject, 
 	return err
 }
 
-func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) releaseExecFunc {
+func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) applyExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
-		return c.doReleaseCommand(
+		return c.doApplyCommand(
 			logger,
 			newDef,
 			"rolling-update",
@@ -99,9 +99,9 @@ func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) relea
 	}
 }
 
-func deploymentExec(def *apiext.Deployment, newDef *apiObject) releaseExecFunc {
+func deploymentExec(def *apiext.Deployment, newDef *apiObject) applyExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
-		err := c.doReleaseCommand(
+		err := c.doApplyCommand(
 			logger,
 			newDef,
 			"apply",

--- a/platform/metrics.go
+++ b/platform/metrics.go
@@ -61,14 +61,14 @@ func (i *instrumentedPlatform) SomeServices(ids []flux.ServiceID) (svcs []Servic
 	return i.p.SomeServices(ids)
 }
 
-func (i *instrumentedPlatform) Release(spec []ReleaseSpec) (err error) {
+func (i *instrumentedPlatform) Apply(defs []ServiceDefinition) (err error) {
 	defer func(begin time.Time) {
 		i.m.RequestDuration.With(
 			LabelMethod, "Release",
 			LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.Release(spec)
+	return i.p.Apply(defs)
 }
 
 func (i *instrumentedPlatform) Ping() (err error) {

--- a/platform/metrics.go
+++ b/platform/metrics.go
@@ -61,14 +61,14 @@ func (i *instrumentedPlatform) SomeServices(ids []flux.ServiceID) (svcs []Servic
 	return i.p.SomeServices(ids)
 }
 
-func (i *instrumentedPlatform) Regrade(spec []RegradeSpec) (err error) {
+func (i *instrumentedPlatform) Release(spec []ReleaseSpec) (err error) {
 	defer func(begin time.Time) {
 		i.m.RequestDuration.With(
-			LabelMethod, "Regrade",
+			LabelMethod, "Release",
 			LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.Regrade(spec)
+	return i.p.Release(spec)
 }
 
 func (i *instrumentedPlatform) Ping() (err error) {

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -13,8 +13,8 @@ type MockPlatform struct {
 	SomeServicesAnswer  []Service
 	SomeServicesError   error
 
-	ReleaseArgTest func([]ReleaseSpec) error
-	ReleaseError   error
+	ApplyArgTest func([]ServiceDefinition) error
+	ApplyError   error
 
 	PingError error
 }
@@ -37,13 +37,13 @@ func (p *MockPlatform) SomeServices(ss []flux.ServiceID) ([]Service, error) {
 	return p.SomeServicesAnswer, p.SomeServicesError
 }
 
-func (p *MockPlatform) Release(ss []ReleaseSpec) error {
-	if p.ReleaseArgTest != nil {
-		if err := p.ReleaseArgTest(ss); err != nil {
+func (p *MockPlatform) Apply(defs []ServiceDefinition) error {
+	if p.ApplyArgTest != nil {
+		if err := p.ApplyArgTest(defs); err != nil {
 			return err
 		}
 	}
-	return p.ReleaseError
+	return p.ApplyError
 }
 
 func (p *MockPlatform) Ping() error {

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -13,8 +13,8 @@ type MockPlatform struct {
 	SomeServicesAnswer  []Service
 	SomeServicesError   error
 
-	RegradeArgTest func([]RegradeSpec) error
-	RegradeError   error
+	ReleaseArgTest func([]ReleaseSpec) error
+	ReleaseError   error
 
 	PingError error
 }
@@ -37,13 +37,13 @@ func (p *MockPlatform) SomeServices(ss []flux.ServiceID) ([]Service, error) {
 	return p.SomeServicesAnswer, p.SomeServicesError
 }
 
-func (p *MockPlatform) Regrade(ss []RegradeSpec) error {
-	if p.RegradeArgTest != nil {
-		if err := p.RegradeArgTest(ss); err != nil {
+func (p *MockPlatform) Release(ss []ReleaseSpec) error {
+	if p.ReleaseArgTest != nil {
+		if err := p.ReleaseArgTest(ss); err != nil {
 			return err
 		}
 	}
-	return p.RegradeError
+	return p.ReleaseError
 }
 
 func (p *MockPlatform) Ping() error {

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -21,7 +21,7 @@ var (
 type Platform interface {
 	AllServices(maybeNamespace string, ignored flux.ServiceIDSet) ([]Service, error)
 	SomeServices([]flux.ServiceID) ([]Service, error)
-	Release([]ReleaseSpec) error
+	Apply([]ServiceDefinition) error
 	Ping() error
 }
 
@@ -112,15 +112,15 @@ var (
 	ErrNoMatchingImages     = errors.New("no matching images")
 )
 
-// ReleaseSpec is provided to platform.Release method/s.
-type ReleaseSpec struct {
+// ServiceDefinition is provided to platform.Apply method/s.
+type ServiceDefinition struct {
 	ServiceID     flux.ServiceID
 	NewDefinition []byte // of the pod controller e.g. deployment
 }
 
-type ReleaseError map[flux.ServiceID]error
+type ApplyError map[flux.ServiceID]error
 
-func (e ReleaseError) Error() string {
+func (e ApplyError) Error() string {
 	var errs []string
 	for id, err := range e {
 		errs = append(errs, fmt.Sprintf("%s: %v", id, err))

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -21,7 +21,7 @@ var (
 type Platform interface {
 	AllServices(maybeNamespace string, ignored flux.ServiceIDSet) ([]Service, error)
 	SomeServices([]flux.ServiceID) ([]Service, error)
-	Regrade([]RegradeSpec) error
+	Release([]ReleaseSpec) error
 	Ping() error
 }
 
@@ -112,15 +112,15 @@ var (
 	ErrNoMatchingImages     = errors.New("no matching images")
 )
 
-// RegradeSpec is provided to platform.Regrade method/s.
-type RegradeSpec struct {
+// ReleaseSpec is provided to platform.Release method/s.
+type ReleaseSpec struct {
 	ServiceID     flux.ServiceID
 	NewDefinition []byte // of the pod controller e.g. deployment
 }
 
-type RegradeError map[flux.ServiceID]error
+type ReleaseError map[flux.ServiceID]error
 
-func (e RegradeError) Error() string {
+func (e ReleaseError) Error() string {
 	var errs []string
 	for id, err := range e {
 		errs = append(errs, fmt.Sprintf("%s: %v", id, err))

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -13,7 +13,7 @@ func TestPlatformMock(t *testing.T) {
 		SomeServicesArgTest: func([]flux.ServiceID) error {
 			return errors.New("arg fail")
 		},
-		RegradeError: errors.New("fail"),
+		ReleaseError: errors.New("fail"),
 	}
 
 	// Just token tests so we're attempting _something_ here
@@ -30,7 +30,7 @@ func TestPlatformMock(t *testing.T) {
 		t.Error("expected error from args test, got nil")
 	}
 
-	err = p.Regrade([]RegradeSpec{})
+	err = p.Release([]ReleaseSpec{})
 	if err == nil {
 		t.Error("expected error, got nil")
 	}

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -13,7 +13,7 @@ func TestPlatformMock(t *testing.T) {
 		SomeServicesArgTest: func([]flux.ServiceID) error {
 			return errors.New("arg fail")
 		},
-		ReleaseError: errors.New("fail"),
+		ApplyError: errors.New("fail"),
 	}
 
 	// Just token tests so we're attempting _something_ here
@@ -30,7 +30,7 @@ func TestPlatformMock(t *testing.T) {
 		t.Error("expected error from args test, got nil")
 	}
 
-	err = p.Release([]ReleaseSpec{})
+	err = p.Apply([]ServiceDefinition{})
 	if err == nil {
 		t.Error("expected error, got nil")
 	}

--- a/platform/rpc/client.go
+++ b/platform/rpc/client.go
@@ -47,18 +47,20 @@ func (p *RPCClient) SomeServices(ids []flux.ServiceID) ([]platform.Service, erro
 	return s, err
 }
 
-// Release tells the remote platform to apply some release specs.
-func (p *RPCClient) Release(spec []platform.ReleaseSpec) error {
-	var releaseErrors ReleaseResult
-	if err := p.client.Call("RPCServer.Regrade", spec, &releaseErrors); err != nil {
+// Apply tells the remote platform to apply some new service definitions.
+func (p *RPCClient) Apply(defs []platform.ServiceDefinition) error {
+	var applyErrors ApplyResult
+	// TODO: This is still calling "Regrade" for backwards compatibility with old
+	// fluxds. Change this to "Apply" when we do a major version release.
+	if err := p.client.Call("RPCServer.Regrade", defs, &applyErrors); err != nil {
 		if _, ok := err.(rpc.ServerError); !ok && err != nil {
 			err = platform.FatalError{err}
 		}
 		return err
 	}
-	if len(releaseErrors) > 0 {
-		errs := platform.ReleaseError{}
-		for s, e := range releaseErrors {
+	if len(applyErrors) > 0 {
+		errs := platform.ApplyError{}
+		for s, e := range applyErrors {
 			errs[s] = errors.New(e)
 		}
 		return errs

--- a/platform/rpc/client.go
+++ b/platform/rpc/client.go
@@ -47,18 +47,18 @@ func (p *RPCClient) SomeServices(ids []flux.ServiceID) ([]platform.Service, erro
 	return s, err
 }
 
-// Regrade tells the remote platform to apply some regrade specs.
-func (p *RPCClient) Regrade(spec []platform.RegradeSpec) error {
-	var regradeErrors RegradeResult
-	if err := p.client.Call("RPCServer.Regrade", spec, &regradeErrors); err != nil {
+// Release tells the remote platform to apply some release specs.
+func (p *RPCClient) Release(spec []platform.ReleaseSpec) error {
+	var releaseErrors ReleaseResult
+	if err := p.client.Call("RPCServer.Release", spec, &releaseErrors); err != nil {
 		if _, ok := err.(rpc.ServerError); !ok && err != nil {
 			err = platform.FatalError{err}
 		}
 		return err
 	}
-	if len(regradeErrors) > 0 {
-		errs := platform.RegradeError{}
-		for s, e := range regradeErrors {
+	if len(releaseErrors) > 0 {
+		errs := platform.ReleaseError{}
+		for s, e := range releaseErrors {
 			errs[s] = errors.New(e)
 		}
 		return errs

--- a/platform/rpc/client.go
+++ b/platform/rpc/client.go
@@ -50,7 +50,7 @@ func (p *RPCClient) SomeServices(ids []flux.ServiceID) ([]platform.Service, erro
 // Release tells the remote platform to apply some release specs.
 func (p *RPCClient) Release(spec []platform.ReleaseSpec) error {
 	var releaseErrors ReleaseResult
-	if err := p.client.Call("RPCServer.Release", spec, &releaseErrors); err != nil {
+	if err := p.client.Call("RPCServer.Regrade", spec, &releaseErrors); err != nil {
 		if _, ok := err.(rpc.ServerError); !ok && err != nil {
 			err = platform.FatalError{err}
 		}

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -77,7 +77,7 @@ func TestMethods(t *testing.T) {
 	instA := flux.InstanceID("steamy-windows-89")
 	mockA := &platform.MockPlatform{
 		AllServicesAnswer: []platform.Service{platform.Service{}},
-		RegradeError:      platform.RegradeError{flux.ServiceID("foo/bar"): errors.New("foo barred")},
+		ApplyError:        platform.ApplyError{flux.ServiceID("foo/bar"): errors.New("foo barred")},
 	}
 	subscribe(t, bus, errc, instA, mockA)
 
@@ -93,9 +93,9 @@ func TestMethods(t *testing.T) {
 		t.Fatalf("Expected %d result, got %d", len(mockA.AllServicesAnswer), len(ss))
 	}
 
-	err = plat.Regrade([]platform.RegradeSpec{})
-	if _, ok := err.(platform.RegradeError); !ok {
-		t.Fatalf("expected RegradeError, got %+v", err)
+	err = plat.Apply([]platform.ServiceDefinition{})
+	if _, ok := err.(platform.ApplyError); !ok {
+		t.Fatalf("expected ApplyError, got %+v", err)
 	}
 
 	mockB := &platform.MockPlatform{

--- a/platform/rpc/rpc_test.go
+++ b/platform/rpc/rpc_test.go
@@ -29,8 +29,8 @@ func TestRPC(t *testing.T) {
 	services := flux.ServiceIDSet{}
 	services.Add(serviceList)
 
-	regrades := []platform.RegradeSpec{
-		platform.RegradeSpec{
+	releases := []platform.ReleaseSpec{
+		platform.ReleaseSpec{
 			ServiceID:     serviceID,
 			NewDefinition: []byte("imagine a definition here"),
 		},
@@ -72,13 +72,13 @@ func TestRPC(t *testing.T) {
 		},
 		SomeServicesAnswer: serviceAnswer,
 
-		RegradeArgTest: func(specs []platform.RegradeSpec) error {
-			if !reflect.DeepEqual(regrades, specs) {
+		ReleaseArgTest: func(specs []platform.ReleaseSpec) error {
+			if !reflect.DeepEqual(releases, specs) {
 				return fmt.Errorf("did not get expected args, got %+v", specs)
 			}
 			return nil
 		},
-		RegradeError: nil,
+		ReleaseError: nil,
 	}
 
 	clientConn, serverConn := pipes()
@@ -120,18 +120,18 @@ func TestRPC(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 
-	err = client.Regrade(regrades)
+	err = client.Release(releases)
 	if err != nil {
 		t.Error(err)
 	}
 
-	regradeErrors := platform.RegradeError{
+	releaseErrors := platform.ReleaseError{
 		serviceID: fmt.Errorf("it just failed"),
 	}
-	mock.RegradeError = regradeErrors
-	err = client.Regrade(regrades)
-	if !reflect.DeepEqual(err, regradeErrors) {
-		t.Errorf("expected RegradeError, got %#v", err)
+	mock.ReleaseError = releaseErrors
+	err = client.Release(releases)
+	if !reflect.DeepEqual(err, releaseErrors) {
+		t.Errorf("expected ReleaseError, got %#v", err)
 	}
 }
 

--- a/platform/rpc/rpc_test.go
+++ b/platform/rpc/rpc_test.go
@@ -29,8 +29,8 @@ func TestRPC(t *testing.T) {
 	services := flux.ServiceIDSet{}
 	services.Add(serviceList)
 
-	releases := []platform.ReleaseSpec{
-		platform.ReleaseSpec{
+	expectedDefs := []platform.ServiceDefinition{
+		{
 			ServiceID:     serviceID,
 			NewDefinition: []byte("imagine a definition here"),
 		},
@@ -72,13 +72,13 @@ func TestRPC(t *testing.T) {
 		},
 		SomeServicesAnswer: serviceAnswer,
 
-		ReleaseArgTest: func(specs []platform.ReleaseSpec) error {
-			if !reflect.DeepEqual(releases, specs) {
-				return fmt.Errorf("did not get expected args, got %+v", specs)
+		ApplyArgTest: func(defs []platform.ServiceDefinition) error {
+			if !reflect.DeepEqual(expectedDefs, defs) {
+				return fmt.Errorf("did not get expected args, got %+v", defs)
 			}
 			return nil
 		},
-		ReleaseError: nil,
+		ApplyError: nil,
 	}
 
 	clientConn, serverConn := pipes()
@@ -120,18 +120,18 @@ func TestRPC(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 
-	err = client.Release(releases)
+	err = client.Apply(expectedDefs)
 	if err != nil {
 		t.Error(err)
 	}
 
-	releaseErrors := platform.ReleaseError{
+	applyErrors := platform.ApplyError{
 		serviceID: fmt.Errorf("it just failed"),
 	}
-	mock.ReleaseError = releaseErrors
-	err = client.Release(releases)
-	if !reflect.DeepEqual(err, releaseErrors) {
-		t.Errorf("expected ReleaseError, got %#v", err)
+	mock.ApplyError = applyErrors
+	err = client.Apply(expectedDefs)
+	if !reflect.DeepEqual(err, applyErrors) {
+		t.Errorf("expected ApplyError, got %#v", err)
 	}
 }
 

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -59,6 +59,11 @@ func (p *RPCServer) SomeServices(ids []flux.ServiceID, resp *[]platform.Service)
 	return err
 }
 
+// Regrade is still around for backwards compatibility, though it is called "Release" everywhere else.
+func (p *RPCServer) Regrade(spec []platform.ReleaseSpec, releaseResult *ReleaseResult) error {
+	return p.Release(spec, releaseResult)
+}
+
 func (p *RPCServer) Release(spec []platform.ReleaseSpec, releaseResult *ReleaseResult) error {
 	result := ReleaseResult{}
 	err := p.p.Release(spec)

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -11,7 +11,7 @@ import (
 
 // net/rpc cannot serialise errors, so we transmit strings and
 // reconstitute them on the other side.
-type RegradeResult map[flux.ServiceID]string
+type ReleaseResult map[flux.ServiceID]string
 
 // Server takes a platform and makes it available over RPC.
 type Server struct {
@@ -59,18 +59,18 @@ func (p *RPCServer) SomeServices(ids []flux.ServiceID, resp *[]platform.Service)
 	return err
 }
 
-func (p *RPCServer) Regrade(spec []platform.RegradeSpec, regradeResult *RegradeResult) error {
-	result := RegradeResult{}
-	err := p.p.Regrade(spec)
+func (p *RPCServer) Release(spec []platform.ReleaseSpec, releaseResult *ReleaseResult) error {
+	result := ReleaseResult{}
+	err := p.p.Release(spec)
 	if err != nil {
-		switch regradeErr := err.(type) {
-		case platform.RegradeError:
-			for s, e := range regradeErr {
+		switch releaseErr := err.(type) {
+		case platform.ReleaseError:
+			for s, e := range releaseErr {
 				result[s] = e.Error()
 			}
 			err = nil
 		}
 	}
-	*regradeResult = result
+	*releaseResult = result
 	return err
 }

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -11,7 +11,7 @@ import (
 
 // net/rpc cannot serialise errors, so we transmit strings and
 // reconstitute them on the other side.
-type ReleaseResult map[flux.ServiceID]string
+type ApplyResult map[flux.ServiceID]string
 
 // Server takes a platform and makes it available over RPC.
 type Server struct {
@@ -59,23 +59,23 @@ func (p *RPCServer) SomeServices(ids []flux.ServiceID, resp *[]platform.Service)
 	return err
 }
 
-// Regrade is still around for backwards compatibility, though it is called "Release" everywhere else.
-func (p *RPCServer) Regrade(spec []platform.ReleaseSpec, releaseResult *ReleaseResult) error {
-	return p.Release(spec, releaseResult)
+// Regrade is still around for backwards compatibility, though it is called "Apply" everywhere else.
+func (p *RPCServer) Regrade(defs []platform.ServiceDefinition, applyResult *ApplyResult) error {
+	return p.Apply(defs, applyResult)
 }
 
-func (p *RPCServer) Release(spec []platform.ReleaseSpec, releaseResult *ReleaseResult) error {
-	result := ReleaseResult{}
-	err := p.p.Release(spec)
+func (p *RPCServer) Apply(defs []platform.ServiceDefinition, applyResult *ApplyResult) error {
+	result := ApplyResult{}
+	err := p.p.Apply(defs)
 	if err != nil {
-		switch releaseErr := err.(type) {
-		case platform.ReleaseError:
-			for s, e := range releaseErr {
+		switch applyErr := err.(type) {
+		case platform.ApplyError:
+			for s, e := range applyErr {
 				result[s] = e.Error()
 			}
 			err = nil
 		}
 	}
-	*releaseResult = result
+	*applyResult = result
 	return err
 }

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -120,13 +120,13 @@ func (p *removeablePlatform) SomeServices(ids []flux.ServiceID) (s []Service, er
 	return p.remote.SomeServices(ids)
 }
 
-func (p *removeablePlatform) Regrade(spec []RegradeSpec) (err error) {
+func (p *removeablePlatform) Release(spec []ReleaseSpec) (err error) {
 	defer func() {
 		if _, ok := err.(FatalError); ok {
 			p.closeWithError(err)
 		}
 	}()
-	return p.remote.Regrade(spec)
+	return p.remote.Release(spec)
 }
 
 func (p *removeablePlatform) Ping() (err error) {
@@ -148,7 +148,7 @@ func (p disconnectedPlatform) SomeServices([]flux.ServiceID) ([]Service, error) 
 	return nil, ErrPlatformNotAvailable
 }
 
-func (p disconnectedPlatform) Regrade([]RegradeSpec) error {
+func (p disconnectedPlatform) Release([]ReleaseSpec) error {
 	return ErrPlatformNotAvailable
 }
 

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -120,13 +120,13 @@ func (p *removeablePlatform) SomeServices(ids []flux.ServiceID) (s []Service, er
 	return p.remote.SomeServices(ids)
 }
 
-func (p *removeablePlatform) Release(spec []ReleaseSpec) (err error) {
+func (p *removeablePlatform) Apply(defs []ServiceDefinition) (err error) {
 	defer func() {
 		if _, ok := err.(FatalError); ok {
 			p.closeWithError(err)
 		}
 	}()
-	return p.remote.Release(spec)
+	return p.remote.Apply(defs)
 }
 
 func (p *removeablePlatform) Ping() (err error) {
@@ -148,7 +148,7 @@ func (p disconnectedPlatform) SomeServices([]flux.ServiceID) ([]Service, error) 
 	return nil, ErrPlatformNotAvailable
 }
 
-func (p disconnectedPlatform) Release([]ReleaseSpec) error {
+func (p disconnectedPlatform) Apply([]ServiceDefinition) error {
 	return ErrPlatformNotAvailable
 }
 

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -585,13 +585,13 @@ func (r *Releaser) releaseActionRegradeServices(services []flux.ServiceID, msg s
 				namespace, serviceName := service.Components()
 				switch serviceName {
 				case FluxServiceName, FluxDaemonName:
-					rc.Instance.LogEvent(namespace, serviceName, "Starting regrade (no result expected) "+cause)
+					rc.Instance.LogEvent(namespace, serviceName, "Starting "+cause+". (no result expected)")
 					asyncSpecs = append(asyncSpecs, platform.RegradeSpec{
 						ServiceID:     service,
 						NewDefinition: def,
 					})
 				default:
-					rc.Instance.LogEvent(namespace, serviceName, "Starting regrade "+cause)
+					rc.Instance.LogEvent(namespace, serviceName, "Starting "+cause)
 					specs = append(specs, platform.RegradeSpec{
 						ServiceID:     service,
 						NewDefinition: def,
@@ -623,9 +623,9 @@ func (r *Releaser) releaseActionRegradeServices(services []flux.ServiceID, msg s
 					continue
 				default:
 					if err := results[service]; err == nil { // no entry = nil error
-						rc.Instance.LogEvent(namespace, serviceName, "Regrade due to "+cause+": done")
+						rc.Instance.LogEvent(namespace, serviceName, msg+". done")
 					} else {
-						rc.Instance.LogEvent(namespace, serviceName, "Regrade due to "+cause+": failed: "+err.Error())
+						rc.Instance.LogEvent(namespace, serviceName, msg+". failed: "+err.Error())
 					}
 				}
 			}

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -625,7 +625,7 @@ func (r *Releaser) releaseActionReleaseServices(services []flux.ServiceID, msg s
 					if err := results[service]; err == nil { // no entry = nil error
 						rc.Instance.LogEvent(namespace, serviceName, msg+". done")
 					} else {
-						rc.Instance.LogEvent(namespace, serviceName, msg+". failed: "+err.Error())
+						rc.Instance.LogEvent(namespace, serviceName, msg+". error: "+err.Error()+". failed")
 					}
 				}
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -433,13 +433,13 @@ func (p *loggingPlatform) SomeServices(include []flux.ServiceID) (ss []platform.
 	return p.platform.SomeServices(include)
 }
 
-func (p *loggingPlatform) Regrade(regrades []platform.RegradeSpec) (err error) {
+func (p *loggingPlatform) Release(releases []platform.ReleaseSpec) (err error) {
 	defer func() {
 		if err != nil {
-			p.logger.Log("method", "Regrade", "error", err)
+			p.logger.Log("method", "Release", "error", err)
 		}
 	}()
-	return p.platform.Regrade(regrades)
+	return p.platform.Release(releases)
 }
 
 func (p *loggingPlatform) Ping() (err error) {

--- a/server/server.go
+++ b/server/server.go
@@ -433,13 +433,13 @@ func (p *loggingPlatform) SomeServices(include []flux.ServiceID) (ss []platform.
 	return p.platform.SomeServices(include)
 }
 
-func (p *loggingPlatform) Release(releases []platform.ReleaseSpec) (err error) {
+func (p *loggingPlatform) Apply(defs []platform.ServiceDefinition) (err error) {
 	defer func() {
 		if err != nil {
-			p.logger.Log("method", "Release", "error", err)
+			p.logger.Log("method", "Apply", "error", err)
 		}
 	}()
-	return p.platform.Release(releases)
+	return p.platform.Apply(defs)
 }
 
 func (p *loggingPlatform) Ping() (err error) {


### PR DESCRIPTION
@squaremo wdyt?

I picked release because it matches `fluxctl release`. Deploy might be
more meaningful, but this makes it consistent everywhere, and Release is
still more meaningful than regrade.

---

There are a couple (tangentially related) slack message changes in the first commit, also, which change:
```
default/users: Regrade due to "Release latest images to default/users": done
default/users: Regrade due to "Apply latest config to default/users": done
```
to
```
default/users: Release latest images to default/users. done
default/users: Apply latest config to default/users. done
```
Could take the de-dupe even further, with the service name, but it depends how we want to consolidate output for multiple services, and image versions, etc.