### PR TITLE
Instrument image registry operations

### DIFF
--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaveworks/flux/instance"
 	instancedb "github.com/weaveworks/flux/instance/sql"
 	"github.com/weaveworks/flux/jobs"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 	"github.com/weaveworks/flux/platform"
 	"github.com/weaveworks/flux/platform/rpc/nats"
 	"github.com/weaveworks/flux/registry"
@@ -104,28 +105,28 @@ func main() {
 			Name:      "list_services_duration_seconds",
 			Help:      "ListServices method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"namespace", "success"})
+		}, []string{"namespace", fluxmetrics.LabelSuccess})
 		serverMetrics.ListImagesDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "list_images_duration_seconds",
 			Help:      "ListImages method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"service_spec", "success"})
+		}, []string{"service_spec", fluxmetrics.LabelSuccess})
 		serverMetrics.HistoryDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "history_duration_seconds",
 			Help:      "History method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"service_spec", "success"})
+		}, []string{"service_spec", fluxmetrics.LabelSuccess})
 		serverMetrics.RegisterDaemonDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "register_daemon_duration_seconds",
 			Help:      "RegisterDaemon method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"instance_id", "success"})
+		}, []string{fluxmetrics.LabelInstanceID, fluxmetrics.LabelSuccess})
 		serverMetrics.ConnectedDaemons = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
@@ -139,14 +140,14 @@ func main() {
 			Name:      "release_duration_seconds",
 			Help:      "Release method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"release_type", "release_kind", "success"})
+		}, []string{"release_type", "release_kind", fluxmetrics.LabelSuccess})
 		releaseMetrics.ActionDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "release_action_duration_seconds",
 			Help:      "Duration in seconds of each sub-action invoked as part of a non-dry-run release.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"action", "success"})
+		}, []string{"action", fluxmetrics.LabelSuccess})
 		releaseMetrics.StageDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
@@ -160,7 +161,7 @@ func main() {
 			Name:      "release_helper_duration_seconds",
 			Help:      "Duration in seconds of a variety of release helper methods.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"method", "success"})
+		}, []string{"method", fluxmetrics.LabelSuccess})
 		registryMetrics = registry.NewMetrics()
 		busMetrics = platform.NewBusMetrics()
 		historyMetrics = history.NewMetrics()

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -98,14 +98,14 @@ func main() {
 			Name:      "http_request_duration_seconds",
 			Help:      "HTTP request duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"method", "status_code"})
+		}, []string{fluxmetrics.LabelMethod, "status_code"})
 		serverMetrics.ListServicesDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "list_services_duration_seconds",
 			Help:      "ListServices method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"namespace", fluxmetrics.LabelSuccess})
+		}, []string{fluxmetrics.LabelNamespace, fluxmetrics.LabelSuccess})
 		serverMetrics.ListImagesDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
@@ -140,28 +140,28 @@ func main() {
 			Name:      "release_duration_seconds",
 			Help:      "Release method duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"release_type", "release_kind", fluxmetrics.LabelSuccess})
+		}, []string{fluxmetrics.LabelReleaseType, fluxmetrics.LabelSuccess})
 		releaseMetrics.ActionDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "release_action_duration_seconds",
 			Help:      "Duration in seconds of each sub-action invoked as part of a non-dry-run release.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"action", fluxmetrics.LabelSuccess})
+		}, []string{fluxmetrics.LabelAction, fluxmetrics.LabelSuccess})
 		releaseMetrics.StageDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "release_stage_duration_seconds",
 			Help:      "Duration in seconds of each stage of a release, including dry-runs.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"method", "stage"})
+		}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelStage})
 		helperDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "fluxsvc",
 			Name:      "release_helper_duration_seconds",
 			Help:      "Duration in seconds of a variety of release helper methods.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{"method", fluxmetrics.LabelSuccess})
+		}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelSuccess})
 		registryMetrics = registry.NewMetrics()
 		busMetrics = platform.NewBusMetrics()
 		historyMetrics = history.NewMetrics()

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/history"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 	"github.com/weaveworks/flux/platform"
 	"github.com/weaveworks/flux/registry"
 )
@@ -127,8 +128,8 @@ func (h *Instance) ExactImages(images []flux.ImageID) (ImageMap, error) {
 func (h *Instance) PlatformApply(defs []platform.ServiceDefinition) (err error) {
 	defer func(begin time.Time) {
 		h.duration.With(
-			"method", "PlatformApply",
-			"success", fmt.Sprint(err == nil),
+			fluxmetrics.LabelMethod, "PlatformApply",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -15,11 +15,12 @@ import (
 )
 
 type MultitenantInstancer struct {
-	DB        DB
-	Connecter platform.Connecter
-	Logger    log.Logger
-	Histogram metrics.Histogram
-	History   history.DB
+	DB              DB
+	Connecter       platform.Connecter
+	Logger          log.Logger
+	Histogram       metrics.Histogram
+	History         history.DB
+	RegistryMetrics registry.Metrics
 }
 
 func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error) {
@@ -45,6 +46,7 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 	regClient := &registry.Client{
 		Credentials: creds,
 		Logger:      log.NewContext(instanceLogger).With("component", "registry"),
+		Metrics:     m.RegistryMetrics.WithInstanceID(instanceID),
 	}
 
 	repo := gitRepoFromSettings(c.Settings)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -7,9 +7,11 @@ Labels and so on for metrics used in Flux.
 const (
 	LabelInstanceID = "instance_id"
 	LabelMethod     = "method"
+	LabelNamespace  = "namespace"
 	LabelSuccess    = "success"
 
 	// Labels for release metrics
-	LabelReleaseType = "release_type"
 	LabelAction      = "action"
+	LabelReleaseType = "release_type"
+	LabelStage       = "stage"
 )

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,15 @@
+package metrics
+
+/*
+Labels and so on for metrics used in Flux.
+*/
+
+const (
+	LabelInstanceID = "instance_id"
+	LabelMethod     = "method"
+	LabelSuccess    = "success"
+
+	// Labels for release metrics
+	LabelReleaseType = "release_type"
+	LabelAction      = "action"
+)

--- a/platform/metrics.go
+++ b/platform/metrics.go
@@ -9,11 +9,7 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/weaveworks/flux"
-)
-
-const (
-	LabelMethod  = "method"
-	LabelSuccess = "success"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 )
 
 type Metrics struct {
@@ -28,7 +24,7 @@ func NewMetrics() Metrics {
 			Name:      "request_duration_seconds",
 			Help:      "Request duration in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{LabelMethod, LabelSuccess}),
+		}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelSuccess}),
 	}
 }
 
@@ -44,8 +40,8 @@ func Instrument(p Platform, m Metrics) Platform {
 func (i *instrumentedPlatform) AllServices(maybeNamespace string, ignored flux.ServiceIDSet) (svcs []Service, err error) {
 	defer func(begin time.Time) {
 		i.m.RequestDuration.With(
-			LabelMethod, "AllServices",
-			LabelSuccess, fmt.Sprint(err == nil),
+			fluxmetrics.LabelMethod, "AllServices",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return i.p.AllServices(maybeNamespace, ignored)
@@ -54,8 +50,8 @@ func (i *instrumentedPlatform) AllServices(maybeNamespace string, ignored flux.S
 func (i *instrumentedPlatform) SomeServices(ids []flux.ServiceID) (svcs []Service, err error) {
 	defer func(begin time.Time) {
 		i.m.RequestDuration.With(
-			LabelMethod, "SomeServices",
-			LabelSuccess, fmt.Sprint(err == nil),
+			fluxmetrics.LabelMethod, "SomeServices",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return i.p.SomeServices(ids)
@@ -64,8 +60,8 @@ func (i *instrumentedPlatform) SomeServices(ids []flux.ServiceID) (svcs []Servic
 func (i *instrumentedPlatform) Apply(defs []ServiceDefinition) (err error) {
 	defer func(begin time.Time) {
 		i.m.RequestDuration.With(
-			LabelMethod, "Release",
-			LabelSuccess, fmt.Sprint(err == nil),
+			fluxmetrics.LabelMethod, "Release",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return i.p.Apply(defs)
@@ -74,8 +70,8 @@ func (i *instrumentedPlatform) Apply(defs []ServiceDefinition) (err error) {
 func (i *instrumentedPlatform) Ping() (err error) {
 	defer func(begin time.Time) {
 		i.m.RequestDuration.With(
-			LabelMethod, "Ping",
-			LabelSuccess, fmt.Sprint(err == nil),
+			fluxmetrics.LabelMethod, "Ping",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return i.p.Ping()
@@ -93,10 +89,10 @@ func NewBusMetrics() BusMetrics {
 			Subsystem: "bus",
 			Name:      "kick_total",
 			Help:      "Count of bus subscriptions kicked off by a newer subscription.",
-		}, []string{"instanceID"}),
+		}, []string{fluxmetrics.LabelInstanceID}),
 	}
 }
 
 func (m BusMetrics) IncrKicks(inst flux.InstanceID) {
-	m.KickCount.With("instanceID", string(inst)).Add(1)
+	m.KickCount.With(fluxmetrics.LabelInstanceID, string(inst)).Add(1)
 }

--- a/registry/metrics.go
+++ b/registry/metrics.go
@@ -1,0 +1,52 @@
+package registry
+
+import (
+	"github.com/go-kit/kit/metrics"
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+
+	"github.com/weaveworks/flux"
+)
+
+type Metrics struct {
+	// Latency of image fetch, that is getting *all* information about
+	// an image
+	FetchDuration metrics.Histogram
+	// Counts of particular kinds of request
+	RequestDuration metrics.Histogram
+}
+
+const (
+	LabelInstanceID  = "instanceID"
+	LabelRepository  = "repository"
+	LabelRequestKind = "kind"
+	LabelSuccess     = "success"
+
+	RequestKindTags     = "tags"
+	RequestKindMetadata = "metadata"
+)
+
+func NewMetrics() Metrics {
+	return Metrics{
+		FetchDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: "flux",
+			Subsystem: "registry",
+			Name:      "fetch_duration_seconds",
+			Help:      "Duration of image metadata fetches, in seconds.",
+			Buckets:   stdprometheus.DefBuckets,
+		}, []string{LabelInstanceID, LabelRepository, LabelSuccess}),
+		RequestDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+			Namespace: "flux",
+			Subsystem: "registry",
+			Name:      "request_duration_seconds",
+			Help:      "Duration of HTTP requests made in the course of fetching image metadata",
+		}, []string{LabelInstanceID, LabelRepository, LabelRequestKind, LabelSuccess}),
+	}
+}
+
+func (m Metrics) WithInstanceID(instanceID flux.InstanceID) Metrics {
+	return Metrics{
+		FetchDuration:   m.FetchDuration.With(LabelInstanceID, string(instanceID)),
+		RequestDuration: m.RequestDuration.With(LabelInstanceID, string(instanceID)),
+	}
+}

--- a/registry/metrics.go
+++ b/registry/metrics.go
@@ -6,6 +6,7 @@ import (
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
 	"github.com/weaveworks/flux"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 )
 
 type Metrics struct {
@@ -17,10 +18,8 @@ type Metrics struct {
 }
 
 const (
-	LabelInstanceID  = "instanceID"
 	LabelRepository  = "repository"
 	LabelRequestKind = "kind"
-	LabelSuccess     = "success"
 
 	RequestKindTags     = "tags"
 	RequestKindMetadata = "metadata"
@@ -34,19 +33,19 @@ func NewMetrics() Metrics {
 			Name:      "fetch_duration_seconds",
 			Help:      "Duration of image metadata fetches, in seconds.",
 			Buckets:   stdprometheus.DefBuckets,
-		}, []string{LabelInstanceID, LabelRepository, LabelSuccess}),
+		}, []string{fluxmetrics.LabelInstanceID, LabelRepository, fluxmetrics.LabelSuccess}),
 		RequestDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 			Namespace: "flux",
 			Subsystem: "registry",
 			Name:      "request_duration_seconds",
 			Help:      "Duration of HTTP requests made in the course of fetching image metadata",
-		}, []string{LabelInstanceID, LabelRepository, LabelRequestKind, LabelSuccess}),
+		}, []string{fluxmetrics.LabelInstanceID, LabelRepository, LabelRequestKind, fluxmetrics.LabelSuccess}),
 	}
 }
 
 func (m Metrics) WithInstanceID(instanceID flux.InstanceID) Metrics {
 	return Metrics{
-		FetchDuration:   m.FetchDuration.With(LabelInstanceID, string(instanceID)),
-		RequestDuration: m.RequestDuration.With(LabelInstanceID, string(instanceID)),
+		FetchDuration:   m.FetchDuration.With(fluxmetrics.LabelInstanceID, string(instanceID)),
+		RequestDuration: m.RequestDuration.With(fluxmetrics.LabelInstanceID, string(instanceID)),
 	}
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -19,6 +19,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 
 	"github.com/weaveworks/flux"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 )
 
 const (
@@ -60,7 +61,7 @@ func (c *Client) GetRepository(repository string) (_ []flux.ImageDescription, er
 	defer func(start time.Time) {
 		c.Metrics.FetchDuration.With(
 			LabelRepository, repository,
-			LabelSuccess, strconv.FormatBool(err == nil),
+			fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 		).Observe(time.Since(start).Seconds())
 	}(time.Now())
 
@@ -120,7 +121,7 @@ func (c *Client) GetRepository(repository string) (_ []flux.ImageDescription, er
 	c.Metrics.RequestDuration.With(
 		LabelRepository, repository,
 		LabelRequestKind, RequestKindTags,
-		LabelSuccess, strconv.FormatBool(err == nil),
+		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())
 	if err != nil {
 		cancel()
@@ -146,7 +147,7 @@ func (c *Client) lookupImage(client *dockerregistry.Registry, lookupName, imageN
 	c.Metrics.RequestDuration.With(
 		LabelRepository, imageName,
 		LabelRequestKind, RequestKindMetadata,
-		LabelSuccess, strconv.FormatBool(err == nil),
+		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())
 	if err != nil {
 		return img, err

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,6 +39,7 @@ type Credentials struct {
 type Client struct {
 	Credentials Credentials
 	Logger      log.Logger
+	Metrics     Metrics
 }
 
 type roundtripperFunc func(*http.Request) (*http.Response, error)
@@ -54,7 +56,14 @@ func (f roundtripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
 //   foo/helloworld         -> index.docker.io/foo/helloworld
 //   quay.io/foo/helloworld -> quay.io/foo/helloworld
 //
-func (c *Client) GetRepository(repository string) ([]flux.ImageDescription, error) {
+func (c *Client) GetRepository(repository string) (_ []flux.ImageDescription, err error) {
+	defer func(start time.Time) {
+		c.Metrics.FetchDuration.With(
+			LabelRepository, repository,
+			LabelSuccess, strconv.FormatBool(err == nil),
+		).Observe(time.Since(start).Seconds())
+	}(time.Now())
+
 	var host, org, image string
 	parts := strings.Split(repository, "/")
 	switch len(parts) {
@@ -106,7 +115,13 @@ func (c *Client) GetRepository(repository string) ([]flux.ImageDescription, erro
 		Logf: dockerregistry.Quiet,
 	}
 
+	start := time.Now()
 	tags, err := client.Tags(hostlessImageName)
+	c.Metrics.RequestDuration.With(
+		LabelRepository, repository,
+		LabelRequestKind, RequestKindTags,
+		LabelSuccess, strconv.FormatBool(err == nil),
+	).Observe(time.Since(start).Seconds())
 	if err != nil {
 		cancel()
 		return nil, err
@@ -126,7 +141,13 @@ func (c *Client) lookupImage(client *dockerregistry.Registry, lookupName, imageN
 	id := flux.MakeImageID("", imageName, tag)
 	img := flux.ImageDescription{ID: id}
 
+	start := time.Now()
 	meta, err := client.Manifest(lookupName, tag)
+	c.Metrics.RequestDuration.With(
+		LabelRepository, imageName,
+		LabelRequestKind, RequestKindMetadata,
+		LabelSuccess, strconv.FormatBool(err == nil),
+	).Observe(time.Since(start).Seconds())
 	if err != nil {
 		return img, err
 	}

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -16,6 +16,7 @@ import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/jobs"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 	"github.com/weaveworks/flux/platform"
 	"github.com/weaveworks/flux/platform/kubernetes"
 )
@@ -119,9 +120,8 @@ func (r *Releaser) Handle(job *jobs.Job, updater jobs.JobUpdater) (err error) {
 	releaseType := "unknown"
 	defer func(begin time.Time) {
 		r.metrics.ReleaseDuration.With(
-			"release_type", releaseType,
-			"release_kind", fmt.Sprint(params.Kind),
-			"success", fmt.Sprint(err == nil),
+			fluxmetrics.LabelReleaseType, releaseType,
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
@@ -379,8 +379,8 @@ func (r *Releaser) releaseActionPrintf(format string, args ...interface{}) Relea
 		Do: func(_ *ReleaseContext) (res string, err error) {
 			defer func(begin time.Time) {
 				r.metrics.ActionDuration.With(
-					"action", "printf",
-					"success", fmt.Sprint(err == nil),
+					fluxmetrics.LabelAction, "printf",
+					fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
@@ -395,8 +395,8 @@ func (r *Releaser) releaseActionClone() ReleaseAction {
 		Do: func(rc *ReleaseContext) (res string, err error) {
 			defer func(begin time.Time) {
 				r.metrics.ActionDuration.With(
-					"action", "clone",
-					"success", fmt.Sprint(err == nil),
+					fluxmetrics.LabelAction, "clone",
+					fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
@@ -415,8 +415,8 @@ func (r *Releaser) releaseActionFindPodController(service flux.ServiceID) Releas
 		Do: func(rc *ReleaseContext) (res string, err error) {
 			defer func(begin time.Time) {
 				r.metrics.ActionDuration.With(
-					"action", "find_pod_controller",
-					"success", fmt.Sprint(err == nil),
+					fluxmetrics.LabelAction, "find_pod_controller",
+					fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
@@ -460,8 +460,8 @@ func (r *Releaser) releaseActionUpdatePodController(service flux.ServiceID, upda
 		Do: func(rc *ReleaseContext) (res string, err error) {
 			defer func(begin time.Time) {
 				r.metrics.ActionDuration.With(
-					"action", "update_pod_controller",
-					"success", fmt.Sprint(err == nil),
+					fluxmetrics.LabelAction, "update_pod_controller",
+					fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
@@ -524,8 +524,8 @@ func (r *Releaser) releaseActionCommitAndPush(msg string) ReleaseAction {
 		Do: func(rc *ReleaseContext) (res string, err error) {
 			defer func(begin time.Time) {
 				r.metrics.ActionDuration.With(
-					"action", "commit_and_push",
-					"success", fmt.Sprint(err == nil),
+					fluxmetrics.LabelAction, "commit_and_push",
+					fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
@@ -558,8 +558,8 @@ func (r *Releaser) releaseActionReleaseServices(services []flux.ServiceID, msg s
 		Do: func(rc *ReleaseContext) (res string, err error) {
 			defer func(begin time.Time) {
 				r.metrics.ActionDuration.With(
-					"action", "release_services",
-					"success", fmt.Sprint(err == nil),
+					fluxmetrics.LabelAction, "release_services",
+					fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 

--- a/server/server.go
+++ b/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/weaveworks/flux/history"
 	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/jobs"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 	"github.com/weaveworks/flux/platform"
 )
 
@@ -72,7 +73,7 @@ func (s *Server) ListServices(inst flux.InstanceID, namespace string) (res []flu
 	defer func(begin time.Time) {
 		s.metrics.ListServicesDuration.With(
 			"namespace", namespace,
-			"success", fmt.Sprint(err == nil),
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
@@ -123,7 +124,7 @@ func (s *Server) ListImages(inst flux.InstanceID, spec flux.ServiceSpec) (res []
 	defer func(begin time.Time) {
 		s.metrics.ListImagesDuration.With(
 			"service_spec", fmt.Sprint(spec),
-			"success", fmt.Sprint(err == nil),
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
@@ -179,7 +180,7 @@ func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec) (res []flu
 	defer func(begin time.Time) {
 		s.metrics.HistoryDuration.With(
 			"service_spec", fmt.Sprint(spec),
-			"success", fmt.Sprint(err == nil),
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 
@@ -381,8 +382,8 @@ func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.Platfo
 		}
 
 		s.metrics.RegisterDaemonDuration.With(
-			"instance_id", fmt.Sprint(instID),
-			"success", fmt.Sprint(err == nil),
+			fluxmetrics.LabelInstanceID, fmt.Sprint(instID),
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 		s.metrics.ConnectedDaemons.Set(float64(atomic.AddInt32(&s.connected, -1)))
 	}(time.Now())

--- a/server/server.go
+++ b/server/server.go
@@ -72,7 +72,7 @@ func New(
 func (s *Server) ListServices(inst flux.InstanceID, namespace string) (res []flux.ServiceStatus, err error) {
 	defer func(begin time.Time) {
 		s.metrics.ListServicesDuration.With(
-			"namespace", namespace,
+			fluxmetrics.LabelNamespace, namespace,
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())


### PR DESCRIPTION
As a prelude to introducing a cache, or otherwise improving on the
fetching of image metadata, this commit adds some metrics to the
registry client.

We're interested in

 * how long fetching image metadata takes overall
 * how many requests are made, and of what kind (fetching the list of
   tags, and fetching each tags' metadata)

firstly to see if they are really problematic, and secondarily since
the main improvements will likely come from lowering these.