### PR TITLE
use *time.Time, so that json omitempty works right in go

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -90,7 +90,11 @@ func (opts *serviceShowOpts) RunE(_ *cobra.Command, args []string) error {
 					fmt.Fprintf(out, "\t\t%s\t\n", ":")
 				}
 				if printLine {
-					fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, tag, available.CreatedAt.Format(time.RFC822))
+					createdAt := ""
+					if available.CreatedAt != nil {
+						createdAt = available.CreatedAt.Format(time.RFC822)
+					}
+					fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, tag, createdAt)
 				}
 			}
 			serviceName = ""

--- a/server/server.go
+++ b/server/server.go
@@ -211,7 +211,7 @@ func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec) (res []flu
 	res = make([]flux.HistoryEntry, len(events))
 	for i, event := range events {
 		res[i] = flux.HistoryEntry{
-			Stamp: event.Stamp,
+			Stamp: &event.Stamp,
 			Type:  "v0",
 			Data:  fmt.Sprintf("%s: %s", event.Service, event.Msg),
 		}

--- a/service.go
+++ b/service.go
@@ -230,12 +230,12 @@ type Container struct {
 
 type ImageDescription struct {
 	ID        ImageID
-	CreatedAt time.Time
+	CreatedAt *time.Time `json:",omitempty"`
 }
 
 // Ask me for more details.
 type HistoryEntry struct {
-	Stamp time.Time
+	Stamp *time.Time `json:",omitempty"`
 	Type  string
 	Data  string
 }


### PR DESCRIPTION
Fixes #331