### PR TITLE
Don't immediately check automated services

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"fmt"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -227,30 +226,7 @@ func (s *Server) Automate(instID flux.InstanceID, service flux.ServiceID) error 
 	}
 	ns, svc := service.Components()
 	inst.LogEvent(ns, svc, serviceAutomated)
-	if err := recordAutomated(inst, service, true); err != nil {
-		return err
-	}
-
-	// Schedule an immediate check, so things feel snappy for the user.
-	_, err = s.jobs.PutJob(instID, jobs.Job{
-		Queue: jobs.AutomatedServiceJob,
-		// Key stops us getting two jobs for the same service
-		Key: strings.Join([]string{
-			jobs.AutomatedServiceJob,
-			string(instID),
-			string(service),
-		}, "|"),
-		Method: jobs.AutomatedServiceJob,
-		Params: jobs.AutomatedServiceJobParams{
-			ServiceSpec: flux.ServiceSpec(service),
-		},
-		Priority: jobs.PriorityBackground,
-	})
-	if err == jobs.ErrJobAlreadyQueued {
-		// Ignore this error, we're already doing it!
-		err = nil
-	}
-	return err
+	return recordAutomated(inst, service, true)
 }
 
 func (s *Server) Deautomate(instID flux.InstanceID, service flux.ServiceID) error {


### PR DESCRIPTION
Gives users a few seconds to deautomate it again. also it's sort of
pointless duplicate code, and will be impossible if we are doing
automation on a per-instance level.