### PR TITLE
Cleaning up and refactoring the release package

### DIFF
--- a/git/releasing.go
+++ b/git/releasing.go
@@ -10,9 +10,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-func clone(workingDir, keyPath, repoURL, repoBranch string) (path string, err error) {
+func clone(workingDir, keyData, repoURL, repoBranch string) (path string, err error) {
+	keyPath, err := writeKey(keyData)
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(keyPath)
 	repoPath := filepath.Join(workingDir, "repo")
-	if err := gitCmd("", keyPath, "clone", "--branch", repoBranch, repoURL, repoPath).Run(); err != nil {
+	args := []string{"clone"}
+	if repoBranch != "" {
+		args = append(args, "--branch", repoBranch)
+	}
+	args = append(args, repoURL, repoPath)
+	if err := gitCmd(workingDir, keyPath, args...).Run(); err != nil {
 		return "", errors.Wrap(err, "git clone")
 	}
 	return repoPath, nil
@@ -30,7 +40,12 @@ func commit(workingDir, commitMessage string) error {
 	return nil
 }
 
-func push(keyPath, repoBranch, workingDir string) error {
+func push(keyData, repoBranch, workingDir string) error {
+	keyPath, err := writeKey(keyData)
+	if err != nil {
+		return err
+	}
+	defer os.Remove(keyPath)
 	if err := gitCmd(workingDir, keyPath, "push", "origin", repoBranch).Run(); err != nil {
 		return errors.Wrap(err, fmt.Sprintf("git push origin %s", repoBranch))
 	}
@@ -63,8 +78,18 @@ func check(workingDir, subdir string) bool {
 	return diff.Run() != nil
 }
 
-func writeKey(workingDir, keyData string) (string, error) {
-	keyPath := filepath.Join(workingDir, "id-rsa")
-	err := ioutil.WriteFile(keyPath, []byte(keyData), 0400)
-	return keyPath, err
+func writeKey(keyData string) (string, error) {
+	f, err := ioutil.TempFile("", "flux-key")
+	if err != nil {
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	if err := ioutil.WriteFile(f.Name(), []byte(keyData), 0400); err != nil {
+		os.Remove(f.Name())
+		return "", err
+	}
+	return f.Name(), nil
 }

--- a/git/repo.go
+++ b/git/repo.go
@@ -22,27 +22,22 @@ type Repo struct {
 	Path string
 }
 
-func (r Repo) Clone() (path string, key string, err error) {
+func (r Repo) Clone() (path string, err error) {
 	workingDir, err := ioutil.TempDir(os.TempDir(), "flux-gitclone")
 	if err != nil {
-		return "", "", err
+		return "", err
 	}
 
-	keyFile, err := writeKey(workingDir, r.Key)
-	if err != nil {
-		return "", "", err
-	}
-
-	repoDir, err := clone(workingDir, keyFile, r.URL, r.Branch)
-	return repoDir, keyFile, err
+	repoDir, err := clone(workingDir, r.Key, r.URL, r.Branch)
+	return repoDir, err
 }
 
-func (r Repo) CommitAndPush(path, keyFile, commitMessage string) (string, error) {
+func (r Repo) CommitAndPush(path, commitMessage string) (string, error) {
 	if !check(path, r.Path) {
 		return "no changes made to files", nil
 	}
 	if err := commit(path, commitMessage); err != nil {
 		return "", err
 	}
-	return "", push(keyFile, r.Branch, path)
+	return "", push(r.Key, r.Branch, path)
 }

--- a/release/context.go
+++ b/release/context.go
@@ -1,0 +1,47 @@
+package release
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/instance"
+)
+
+type ReleaseContext struct {
+	Instance       *instance.Instance
+	WorkingDir     string
+	KeyPath        string
+	PodControllers map[flux.ServiceID][]byte
+}
+
+func NewReleaseContext(inst *instance.Instance) *ReleaseContext {
+	return &ReleaseContext{
+		Instance:       inst,
+		PodControllers: map[flux.ServiceID][]byte{},
+	}
+}
+
+func (rc *ReleaseContext) CloneConfig() error {
+	path, keyfile, err := rc.Instance.ConfigRepo().Clone()
+	if err != nil {
+		return err
+	}
+	rc.WorkingDir = path
+	rc.KeyPath = keyfile
+	return nil
+}
+
+func (rc *ReleaseContext) CommitAndPush(msg string) (string, error) {
+	return rc.Instance.ConfigRepo().CommitAndPush(rc.WorkingDir, rc.KeyPath, msg)
+}
+
+func (rc *ReleaseContext) ConfigPath() string {
+	return filepath.Join(rc.WorkingDir, rc.Instance.ConfigRepo().Path)
+}
+
+func (rc *ReleaseContext) Clean() {
+	if rc.WorkingDir != "" {
+		os.RemoveAll(rc.WorkingDir)
+	}
+}

--- a/release/context.go
+++ b/release/context.go
@@ -11,7 +11,6 @@ import (
 type ReleaseContext struct {
 	Instance       *instance.Instance
 	WorkingDir     string
-	KeyPath        string
 	PodControllers map[flux.ServiceID][]byte
 }
 
@@ -22,21 +21,20 @@ func NewReleaseContext(inst *instance.Instance) *ReleaseContext {
 	}
 }
 
-func (rc *ReleaseContext) CloneConfig() error {
-	path, keyfile, err := rc.Instance.ConfigRepo().Clone()
+func (rc *ReleaseContext) CloneRepo() error {
+	path, err := rc.Instance.ConfigRepo().Clone()
 	if err != nil {
 		return err
 	}
 	rc.WorkingDir = path
-	rc.KeyPath = keyfile
 	return nil
 }
 
 func (rc *ReleaseContext) CommitAndPush(msg string) (string, error) {
-	return rc.Instance.ConfigRepo().CommitAndPush(rc.WorkingDir, rc.KeyPath, msg)
+	return rc.Instance.ConfigRepo().CommitAndPush(rc.WorkingDir, msg)
 }
 
-func (rc *ReleaseContext) ConfigPath() string {
+func (rc *ReleaseContext) RepoPath() string {
 	return filepath.Join(rc.WorkingDir, rc.Instance.ConfigRepo().Path)
 }
 

--- a/release/image_selector.go
+++ b/release/image_selector.go
@@ -1,0 +1,19 @@
+package release
+
+import (
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/instance"
+	"github.com/weaveworks/flux/platform"
+)
+
+type imageSelector func(*instance.Instance, []platform.Service) (instance.ImageMap, error)
+
+func allLatestImages(h *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
+	return h.CollectAvailableImages(services)
+}
+
+func exactlyTheseImages(images []flux.ImageID) imageSelector {
+	return func(h *instance.Instance, _ []platform.Service) (instance.ImageMap, error) {
+		return h.ExactImages(images)
+	}
+}

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -335,7 +335,7 @@ func (r *Releaser) releaseActionClone() ReleaseAction {
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
-			err = rc.CloneConfig()
+			err = rc.CloneRepo()
 			if err != nil {
 				return "", errors.Wrap(err, "clone the config repo")
 			}
@@ -355,7 +355,7 @@ func (r *Releaser) releaseActionFindPodController(service flux.ServiceID) Releas
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
-			resourcePath := rc.ConfigPath()
+			resourcePath := rc.RepoPath()
 			if fi, err := os.Stat(resourcePath); err != nil || !fi.IsDir() {
 				return "", fmt.Errorf("the resource path (%s) is not valid", resourcePath)
 			}
@@ -400,7 +400,7 @@ func (r *Releaser) releaseActionUpdatePodController(service flux.ServiceID, upda
 				).Observe(time.Since(begin).Seconds())
 			}(time.Now())
 
-			resourcePath := rc.ConfigPath()
+			resourcePath := rc.RepoPath()
 			if fi, err := os.Stat(resourcePath); err != nil || !fi.IsDir() {
 				return "", fmt.Errorf("the resource path (%s) is not valid", resourcePath)
 			}
@@ -466,9 +466,6 @@ func (r *Releaser) releaseActionCommitAndPush(msg string) ReleaseAction {
 
 			if fi, err := os.Stat(rc.WorkingDir); err != nil || !fi.IsDir() {
 				return "", fmt.Errorf("the repo path (%s) is not valid", rc.WorkingDir)
-			}
-			if _, err := os.Stat(rc.KeyPath); err != nil {
-				return "", fmt.Errorf("the repo key (%s) is not valid: %v", rc.KeyPath, err)
 			}
 			result, err := rc.CommitAndPush(msg)
 			if err == nil && result == "" {

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -49,44 +48,6 @@ type ReleaseAction struct {
 	Description string                                `json:"description"`
 	Do          func(*ReleaseContext) (string, error) `json:"-"`
 	Result      string                                `json:"result"`
-}
-
-type ReleaseContext struct {
-	Instance       *instance.Instance
-	WorkingDir     string
-	KeyPath        string
-	PodControllers map[flux.ServiceID][]byte
-}
-
-func NewReleaseContext(inst *instance.Instance) *ReleaseContext {
-	return &ReleaseContext{
-		Instance:       inst,
-		PodControllers: map[flux.ServiceID][]byte{},
-	}
-}
-
-func (rc *ReleaseContext) CloneConfig() error {
-	path, keyfile, err := rc.Instance.ConfigRepo().Clone()
-	if err != nil {
-		return err
-	}
-	rc.WorkingDir = path
-	rc.KeyPath = keyfile
-	return nil
-}
-
-func (rc *ReleaseContext) CommitAndPush(msg string) (string, error) {
-	return rc.Instance.ConfigRepo().CommitAndPush(rc.WorkingDir, rc.KeyPath, msg)
-}
-
-func (rc *ReleaseContext) ConfigPath() string {
-	return filepath.Join(rc.WorkingDir, rc.Instance.ConfigRepo().Path)
-}
-
-func (rc *ReleaseContext) Clean() {
-	if rc.WorkingDir != "" {
-		os.RemoveAll(rc.WorkingDir)
-	}
 }
 
 type serviceQuery func(*instance.Instance) ([]platform.Service, error)

--- a/release/service_selector.go
+++ b/release/service_selector.go
@@ -1,0 +1,21 @@
+package release
+
+import (
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/instance"
+	"github.com/weaveworks/flux/platform"
+)
+
+type serviceSelector func(*instance.Instance) ([]platform.Service, error)
+
+func exactlyTheseServices(include []flux.ServiceID) serviceSelector {
+	return func(h *instance.Instance) ([]platform.Service, error) {
+		return h.GetServices(include)
+	}
+}
+
+func allServicesExcept(exclude flux.ServiceIDSet) serviceSelector {
+	return func(h *instance.Instance) ([]platform.Service, error) {
+		return h.GetAllServicesExcept("", exclude)
+	}
+}


### PR DESCRIPTION
Largely just moving stuff to it's own files to organize things.

More contentiously, instead of writing the key file once, this writes it to a temp file (and removes it!) for each action that needs it. This keeps the key file contained in the `git` package. It would be even nicer to use a go git client, where we didn't *need* to write the keys to disk, but that's a bigger project.