### PR TITLE
Cleanup and prep for #208

### DIFF
--- a/jobs/job.go
+++ b/jobs/job.go
@@ -151,10 +151,11 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 
 // ReleaseJobParams are the params for a release job
 type ReleaseJobParams struct {
-	ServiceSpec flux.ServiceSpec
-	ImageSpec   flux.ImageSpec
-	Kind        flux.ReleaseKind
-	Excludes    []flux.ServiceID
+	ServiceSpec  flux.ServiceSpec // For backwards compatibility
+	ServiceSpecs []flux.ServiceSpec
+	ImageSpec    flux.ImageSpec
+	Kind         flux.ReleaseKind
+	Excludes     []flux.ServiceID
 }
 
 // AutomatedServiceJobParams are the params for a automated_service job

--- a/release/image_selector.go
+++ b/release/image_selector.go
@@ -1,19 +1,69 @@
 package release
 
 import (
+	"strings"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/platform"
 )
 
-type imageSelector func(*instance.Instance, []platform.Service) (instance.ImageMap, error)
-
-func allLatestImages(h *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
-	return h.CollectAvailableImages(services)
+type imageSelector interface {
+	String() string
+	SelectImages(*instance.Instance, []platform.Service) (instance.ImageMap, error)
 }
 
+func imageSelectorForSpec(spec flux.ImageSpec) imageSelector {
+	switch spec {
+	case flux.ImageSpecLatest:
+		return allLatestImages
+	case flux.ImageSpecNone:
+		return latestConfig
+	default:
+		return exactlyTheseImages([]flux.ImageID{
+			flux.ParseImageID(string(spec)),
+		})
+	}
+}
+
+type funcImageSelector struct {
+	text string
+	f    func(*instance.Instance, []platform.Service) (instance.ImageMap, error)
+}
+
+func (f funcImageSelector) String() string {
+	return f.text
+}
+
+func (f funcImageSelector) SelectImages(inst *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
+	return f.f(inst, services)
+}
+
+var (
+	allLatestImages = funcImageSelector{
+		text: "latest images",
+		f: func(h *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
+			return h.CollectAvailableImages(services)
+		},
+	}
+	latestConfig = funcImageSelector{
+		text: "latest config",
+		f: func(h *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
+			// TODO: Nothing to do here.
+			return instance.ImageMap{}, nil
+		},
+	}
+)
+
 func exactlyTheseImages(images []flux.ImageID) imageSelector {
-	return func(h *instance.Instance, _ []platform.Service) (instance.ImageMap, error) {
-		return h.ExactImages(images)
+	var imageText []string
+	for _, image := range images {
+		imageText = append(imageText, string(image))
+	}
+	return funcImageSelector{
+		text: strings.Join(imageText, ", "),
+		f: func(h *instance.Instance, _ []platform.Service) (instance.ImageMap, error) {
+			return h.ExactImages(images)
+		},
 	}
 }

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -53,6 +53,12 @@ type ReleaseAction struct {
 
 func (r *Releaser) Handle(job *jobs.Job, updater jobs.JobUpdater) (followUps []jobs.Job, err error) {
 	params := job.Params.(jobs.ReleaseJobParams)
+
+	// Backwards compatibility
+	if string(params.ServiceSpec) != "" {
+		params.ServiceSpecs = append(params.ServiceSpecs, params.ServiceSpec)
+	}
+
 	releaseType := "unknown"
 	defer func(begin time.Time) {
 		r.metrics.ReleaseDuration.With(
@@ -91,7 +97,7 @@ func (r *Releaser) plan(inst *instance.Instance, params jobs.ReleaseJobParams) (
 
 	images := imageSelectorForSpec(params.ImageSpec)
 
-	services, err := serviceSelectorForSpec(inst, params.ServiceSpec, params.Excludes)
+	services, err := serviceSelectorForSpecs(inst, params.ServiceSpecs, params.Excludes)
 	if err != nil {
 		return releaseType, nil, err
 	}

--- a/release/service_selector.go
+++ b/release/service_selector.go
@@ -1,21 +1,103 @@
 package release
 
 import (
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/platform"
 )
 
-type serviceSelector func(*instance.Instance) ([]platform.Service, error)
+type serviceSelector interface {
+	String() string
+	SelectServices(*instance.Instance) ([]platform.Service, error)
+}
 
-func exactlyTheseServices(include []flux.ServiceID) serviceSelector {
-	return func(h *instance.Instance) ([]platform.Service, error) {
-		return h.GetServices(include)
+func serviceSelectorForSpec(inst *instance.Instance, includeSpec flux.ServiceSpec, exclude []flux.ServiceID) (serviceSelector, error) {
+	excludeSet := flux.ServiceIDSet{}
+	excludeSet.Add(exclude)
+
+	locked, err := lockedServices(inst)
+	if err != nil {
+		return nil, err
+	}
+	excludeSet.Add(locked)
+
+	if includeSpec == flux.ServiceSpecAll {
+		// If one of the specs is '<all>' we can ignore the rest.
+		return allServicesExcept(excludeSet), nil
+	}
+
+	serviceID, err := flux.ParseServiceID(string(includeSpec))
+	if err != nil {
+		return nil, errors.Wrapf(err, "parsing service ID from params %q", spec)
+	}
+ include := flux.ServiceIDSet{}
+	include.Add([]flux.ServiceID{serviceID})
+	return exactlyTheseServices(include.Without(excludeSet)), nil
+}
+
+type funcServiceQuery struct {
+	text string
+	f    func(inst *instance.Instance) ([]platform.Service, error)
+}
+
+func (f funcServiceQuery) String() string {
+	return f.text
+}
+
+func (f funcServiceQuery) SelectServices(inst *instance.Instance) ([]platform.Service, error) {
+	return f.f(inst)
+}
+
+func exactlyTheseServices(include flux.ServiceIDSet) serviceSelector {
+	var (
+		idText  []string
+		idSlice []flux.ServiceID
+	)
+	for id := range include {
+		idText = append(idText, string(id))
+		idSlice = append(idSlice, id)
+	}
+	return funcServiceQuery{
+		text: strings.Join(idText, ", "),
+		f: func(h *instance.Instance) ([]platform.Service, error) {
+			return h.GetServices(idSlice)
+		},
 	}
 }
 
 func allServicesExcept(exclude flux.ServiceIDSet) serviceSelector {
-	return func(h *instance.Instance) ([]platform.Service, error) {
-		return h.GetAllServicesExcept("", exclude)
+	text := "all services"
+	if len(exclude) > 0 {
+		var idText []string
+		for id := range exclude {
+			idText = append(idText, string(id))
+		}
+		text += fmt.Sprintf(" (except: %s)", strings.Join(idText, ", "))
 	}
+	return funcServiceQuery{
+		text: text,
+		f: func(h *instance.Instance) ([]platform.Service, error) {
+			return h.GetAllServicesExcept("", exclude)
+		},
+	}
+}
+
+func lockedServices(inst *instance.Instance) ([]flux.ServiceID, error) {
+	config, err := inst.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	ids := []flux.ServiceID{}
+	for id, s := range config.Services {
+		if s.Locked {
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
 }

--- a/service.go
+++ b/service.go
@@ -87,16 +87,48 @@ func (s ServiceIDSet) Add(ids []ServiceID) {
 	}
 }
 
+func (s ServiceIDSet) Without(others ServiceIDSet) ServiceIDSet {
+	if s == nil || len(s) == 0 || others == nil || len(others) == 0 {
+		return s
+	}
+	res := ServiceIDSet{}
+	for id := range s {
+		if !others.Contains(id) {
+			res[id] = struct{}{}
+		}
+	}
+	return res
+}
+
 func (s ServiceIDSet) Contains(id ServiceID) bool {
+	if s == nil {
+		return false
+	}
 	_, ok := s[id]
 	return ok
 }
 
+func (s ServiceIDSet) Intersection(others ServiceIDSet) ServiceIDSet {
+	if s == nil {
+		return others
+	}
+	if others == nil {
+		return s
+	}
+	result := ServiceIDSet{}
+	for id := range s {
+		if _, ok := others[id]; ok {
+			result[id] = struct{}{}
+		}
+	}
+	return result
+}
+
 type ServiceIDs []ServiceID
 
-func (ids ServiceIDs) Without(set ServiceIDSet) (res ServiceIDs) {
+func (ids ServiceIDs) Without(others ServiceIDSet) (res ServiceIDs) {
 	for _, id := range ids {
-		if !set.Contains(id) {
+		if !others.Contains(id) {
 			res = append(res, id)
 		}
 	}
@@ -107,6 +139,12 @@ func (ids ServiceIDs) Contains(id ServiceID) bool {
 	set := ServiceIDSet{}
 	set.Add(ids)
 	return set.Contains(id)
+}
+
+func (ids ServiceIDs) Intersection(others ServiceIDSet) ServiceIDSet {
+	set := ServiceIDSet{}
+	set.Add(ids)
+	return set.Intersection(others)
 }
 
 type ImageID string // "quay.io/weaveworks/helloworld:v1"


### PR DESCRIPTION
Clean up releaser code, and prep stuff for fixing #208

With this, the automator can specify an image (or latest), and list of services to update in a single go. Instead of scheduling a release-latest for each which would each check images for each one.