### PR TITLE
Automated instance job

### DIFF
--- a/automator/automator.go
+++ b/automator/automator.go
@@ -8,7 +8,9 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/jobs"
+	"github.com/weaveworks/flux/release"
 )
 
 const (
@@ -45,81 +47,138 @@ func (a *Automator) checkAll(errorLogger log.Logger) {
 		return
 	}
 	for _, inst := range insts {
-		for service, conf := range inst.Config.Services {
-			if conf.Policy() != flux.PolicyAutomated {
-				continue
-			}
-			_, err := a.cfg.Jobs.PutJob(inst.ID, automatedServiceJob(inst.ID, service, time.Now()))
-			if err != nil && err != jobs.ErrJobAlreadyQueued {
-				errorLogger.Log("err", errors.Wrapf(err, "queueing automated service job"))
-			}
+		errorLogger.Log("checking_instance", inst.ID, "has_automated_services", a.hasAutomatedServices(inst.Config.Services))
+		if !a.hasAutomatedServices(inst.Config.Services) {
+			continue
+		}
+
+		_, err := a.cfg.Jobs.PutJob(inst.ID, automatedInstanceJob(inst.ID, time.Now()))
+		if err != nil && err != jobs.ErrJobAlreadyQueued {
+			errorLogger.Log("err", errors.Wrapf(err, "queueing automated instance job"))
 		}
 	}
 }
 
+func (a *Automator) hasAutomatedServices(services map[flux.ServiceID]instance.ServiceConfig) bool {
+	for _, service := range services {
+		if service.Policy() == flux.PolicyAutomated {
+			return true
+		}
+	}
+	return false
+}
+
 func (a *Automator) Handle(j *jobs.Job, _ jobs.JobUpdater) ([]jobs.Job, error) {
-	params := j.Params.(jobs.AutomatedServiceJobParams)
-
-	serviceID, err := flux.ParseServiceID(string(params.ServiceSpec))
-	if err != nil {
-		// I don't see how we could ever expect this to work, so let's not
-		// reschedule.
-		return nil, errors.Wrapf(err, "parsing service ID from spec %s", params.ServiceSpec)
+	logger := log.NewContext(a.cfg.Logger).With("job", j.ID)
+	switch j.Method {
+	case jobs.AutomatedServiceJob:
+		// Clean up automated service jobs. They're being replaced
+		return nil, nil
+	case jobs.AutomatedInstanceJob:
+		return a.handleAutomatedInstanceJob(logger, j)
+	default:
+		return nil, jobs.ErrUnknownJobMethod
 	}
+}
 
-	followUps := []jobs.Job{
-		automatedServiceJob(j.Instance, flux.ServiceID(params.ServiceSpec), time.Now()),
-	}
+func (a *Automator) handleAutomatedInstanceJob(logger log.Logger, j *jobs.Job) ([]jobs.Job, error) {
+	followUps := []jobs.Job{automatedInstanceJob(j.Instance, time.Now())}
+	params := j.Params.(jobs.AutomatedInstanceJobParams)
 
-	config, err := a.cfg.InstanceDB.GetConfig(j.Instance)
+	config, err := a.cfg.InstanceDB.GetConfig(params.InstanceID)
 	if err != nil {
 		return followUps, errors.Wrap(err, "getting instance config")
 	}
 
-	s := config.Services[serviceID]
-	if !s.Automated {
-		// Job is not automated, don't reschedule
-		return nil, nil
-	}
-	if s.Locked {
-		return followUps, nil
+	automatedServiceIDs := flux.ServiceIDSet{}
+	for id, service := range config.Services {
+		if service.Policy() == flux.PolicyAutomated {
+			automatedServiceIDs.Add([]flux.ServiceID{id})
+		}
 	}
 
-	followUps = append(followUps, jobs.Job{
-		Queue: jobs.ReleaseJob,
-		// Key stops us getting two jobs queued for the same service. That way if a
-		// release is slow the automator won't queue a horde of jobs to upgrade it.
-		Key: strings.Join([]string{
-			jobs.ReleaseJob,
-			string(j.Instance),
-			string(params.ServiceSpec),
-			string(flux.ImageSpecLatest),
-			"automated",
-		}, "|"),
-		Method:   jobs.ReleaseJob,
-		Priority: jobs.PriorityBackground,
-		Params: jobs.ReleaseJobParams{
-			ServiceSpec: params.ServiceSpec,
-			ImageSpec:   flux.ImageSpecLatest,
-			Kind:        flux.ReleaseKindExecute,
-		},
-	})
+	if len(automatedServiceIDs) == 0 {
+		return nil, nil
+	}
+
+	inst, err := a.cfg.Instancer.Get(params.InstanceID)
+	if err != nil {
+		return followUps, errors.Wrap(err, "getting job instance")
+	}
+
+	// Get all automated services
+	// TODO: This should check the repo so it will pick up newly defined or
+	// non-running services.
+	services, err := release.ExactlyTheseServices(automatedServiceIDs).SelectServices(inst)
+	if err != nil {
+		return followUps, errors.Wrap(err, "getting services")
+	}
+
+	if len(services) == 0 {
+		// No automated services are defined, don't reschedule.
+		return nil, nil
+	}
+
+	// Get the images used for each automated service
+	// TODO: This should not fail all images if we are lacking permissions for one image.
+	images, err := release.AllLatestImages.SelectImages(inst, services)
+	if err != nil {
+		return followUps, errors.Wrap(err, "getting images")
+	}
+
+	updateMap := release.CalculateUpdates(services, images, func(format string, args ...interface{}) { /* noop */ })
+	releases := map[flux.ImageID]flux.ServiceIDSet{}
+	for serviceID, updates := range updateMap {
+		for _, update := range updates {
+			if releases[update.Target] == nil {
+				releases[update.Target] = flux.ServiceIDSet{}
+			}
+			releases[update.Target].Add([]flux.ServiceID{serviceID})
+		}
+	}
+
+	// Schedule the release for each image. Will be a noop if all services are
+	// running latest of that image.
+	for imageID, serviceIDSet := range releases {
+		var serviceSpecs []flux.ServiceSpec
+		for id := range serviceIDSet {
+			serviceSpecs = append(serviceSpecs, flux.ServiceSpec(id))
+		}
+		followUps = append(followUps, jobs.Job{
+			Queue: jobs.ReleaseJob,
+			// Key stops us getting two jobs queued for the same service. That way if a
+			// release is slow the automator won't queue a horde of jobs to upgrade it.
+			Key: strings.Join([]string{
+				jobs.ReleaseJob,
+				string(params.InstanceID),
+				string(imageID),
+				"automated",
+			}, "|"),
+			Method:   jobs.ReleaseJob,
+			Priority: jobs.PriorityBackground,
+			Params: jobs.ReleaseJobParams{
+				ServiceSpecs: serviceSpecs,
+				ImageSpec:    flux.ImageSpec(imageID),
+				Kind:         flux.ReleaseKindExecute,
+			},
+		})
+	}
+
 	return followUps, nil
 }
 
-func automatedServiceJob(instanceID flux.InstanceID, serviceID flux.ServiceID, now time.Time) jobs.Job {
+func automatedInstanceJob(instanceID flux.InstanceID, now time.Time) jobs.Job {
 	return jobs.Job{
-		Queue: jobs.AutomatedServiceJob,
-		// Key stops us getting two jobs for the same service
+		Queue: jobs.AutomatedInstanceJob,
+		// Key stops us getting two jobs for the same instance
 		Key: strings.Join([]string{
-			jobs.AutomatedServiceJob,
+			jobs.AutomatedInstanceJob,
 			string(instanceID),
-			string(serviceID),
 		}, "|"),
-		Method:   jobs.AutomatedServiceJob,
+		Method:   jobs.AutomatedInstanceJob,
 		Priority: jobs.PriorityBackground,
-		Params: jobs.AutomatedServiceJobParams{
-			ServiceSpec: flux.ServiceSpec(serviceID),
+		Params: jobs.AutomatedInstanceJobParams{
+			InstanceID: instanceID,
 		},
 		ScheduledAt: now.UTC().Add(automationCycle),
 	}

--- a/automator/config.go
+++ b/automator/config.go
@@ -14,6 +14,7 @@ import (
 type Config struct {
 	Jobs       jobs.JobReadPusher
 	InstanceDB instance.DB
+	Instancer  instance.Instancer
 	Logger     log.Logger
 }
 

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -255,8 +255,12 @@ func main() {
 	// release jobs can't interfere with slow automated service jobs, or vice
 	// versa. This is probably not optimal. Really all jobs should be quick and
 	// recoverable.
-	for _, queue := range []string{jobs.DefaultQueue, jobs.ReleaseJob, jobs.AutomatedServiceJob} {
-		logger := log.NewContext(logger).With("component", "worker", "queues", []string{queue})
+	for _, queue := range []string{
+		jobs.DefaultQueue,
+		jobs.ReleaseJob,
+		jobs.AutomatedServiceJob,
+	} {
+		logger := log.NewContext(logger).With("component", "worker", "queues", fmt.Sprint([]string{queue}))
 		worker := jobs.NewWorker(jobStore, logger, []string{queue})
 		worker.Register(jobs.AutomatedServiceJob, auto)
 		worker.Register(jobs.ReleaseJob, release.NewReleaser(instancer, releaseMetrics))

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -260,10 +260,12 @@ func main() {
 		jobs.DefaultQueue,
 		jobs.ReleaseJob,
 		jobs.AutomatedServiceJob,
+		jobs.AutomatedInstanceJob,
 	} {
 		logger := log.NewContext(logger).With("component", "worker", "queues", fmt.Sprint([]string{queue}))
 		worker := jobs.NewWorker(jobStore, logger, jobWorkerMetrics, []string{queue})
 		worker.Register(jobs.AutomatedServiceJob, auto)
+		worker.Register(jobs.AutomatedInstanceJob, auto)
 		worker.Register(jobs.ReleaseJob, release.NewReleaser(instancer, releaseMetrics))
 
 		defer func() {

--- a/jobs/db_store.go
+++ b/jobs/db_store.go
@@ -333,6 +333,10 @@ func (s *DatabaseStore) scanParams(method string, params []byte) (interface{}, e
 		var p AutomatedServiceJobParams
 		err := json.Unmarshal(params, &p)
 		return p, err
+	case AutomatedInstanceJob:
+		var p AutomatedInstanceJobParams
+		err := json.Unmarshal(params, &p)
+		return p, err
 	default:
 		return nil, ErrUnknownJobMethod
 	}

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -19,6 +19,9 @@ const (
 	// AutomatedServiceJob is the method for a check automated service job
 	AutomatedServiceJob = "automated_service"
 
+	// AutomatedInstanceJob is the method for a check automated instance job
+	AutomatedInstanceJob = "automated_instance"
+
 	// PriorityBackground is priority for background jobs
 	PriorityBackground = 100
 
@@ -162,4 +165,9 @@ type ReleaseJobParams struct {
 // job
 type AutomatedServiceJobParams struct {
 	ServiceSpec flux.ServiceSpec
+}
+
+// AutomatedInstanceJobParams are the params for an automated_instance job
+type AutomatedInstanceJobParams struct {
+	InstanceID flux.InstanceID
 }

--- a/release/image_selector.go
+++ b/release/image_selector.go
@@ -8,19 +8,19 @@ import (
 	"github.com/weaveworks/flux/platform"
 )
 
-type imageSelector interface {
+type ImageSelector interface {
 	String() string
 	SelectImages(*instance.Instance, []platform.Service) (instance.ImageMap, error)
 }
 
-func imageSelectorForSpec(spec flux.ImageSpec) imageSelector {
+func ImageSelectorForSpec(spec flux.ImageSpec) ImageSelector {
 	switch spec {
 	case flux.ImageSpecLatest:
-		return allLatestImages
+		return AllLatestImages
 	case flux.ImageSpecNone:
-		return latestConfig
+		return LatestConfig
 	default:
-		return exactlyTheseImages([]flux.ImageID{
+		return ExactlyTheseImages([]flux.ImageID{
 			flux.ParseImageID(string(spec)),
 		})
 	}
@@ -40,13 +40,13 @@ func (f funcImageSelector) SelectImages(inst *instance.Instance, services []plat
 }
 
 var (
-	allLatestImages = funcImageSelector{
+	AllLatestImages = funcImageSelector{
 		text: "latest images",
 		f: func(h *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
 			return h.CollectAvailableImages(services)
 		},
 	}
-	latestConfig = funcImageSelector{
+	LatestConfig = funcImageSelector{
 		text: "latest config",
 		f: func(h *instance.Instance, services []platform.Service) (instance.ImageMap, error) {
 			// TODO: Nothing to do here.
@@ -55,7 +55,7 @@ var (
 	}
 )
 
-func exactlyTheseImages(images []flux.ImageID) imageSelector {
+func ExactlyTheseImages(images []flux.ImageID) ImageSelector {
 	var imageText []string
 	for _, image := range images {
 		imageText = append(imageText, string(image))

--- a/release/service_selector.go
+++ b/release/service_selector.go
@@ -11,12 +11,12 @@ import (
 	"github.com/weaveworks/flux/platform"
 )
 
-type serviceSelector interface {
+type ServiceSelector interface {
 	String() string
 	SelectServices(*instance.Instance) ([]platform.Service, error)
 }
 
-func serviceSelectorForSpecs(inst *instance.Instance, includeSpecs []flux.ServiceSpec, exclude []flux.ServiceID) (serviceSelector, error) {
+func ServiceSelectorForSpecs(inst *instance.Instance, includeSpecs []flux.ServiceSpec, exclude []flux.ServiceID) (ServiceSelector, error) {
 	excludeSet := flux.ServiceIDSet{}
 	excludeSet.Add(exclude)
 
@@ -30,7 +30,7 @@ func serviceSelectorForSpecs(inst *instance.Instance, includeSpecs []flux.Servic
 	for _, spec := range includeSpecs {
 		if spec == flux.ServiceSpecAll {
 			// If one of the specs is '<all>' we can ignore the rest.
-			return allServicesExcept(excludeSet), nil
+			return AllServicesExcept(excludeSet), nil
 		}
 		serviceID, err := flux.ParseServiceID(string(spec))
 		if err != nil {
@@ -38,7 +38,7 @@ func serviceSelectorForSpecs(inst *instance.Instance, includeSpecs []flux.Servic
 		}
 		include.Add([]flux.ServiceID{serviceID})
 	}
-	return exactlyTheseServices(include.Without(excludeSet)), nil
+	return ExactlyTheseServices(include.Without(excludeSet)), nil
 }
 
 type funcServiceQuery struct {
@@ -54,7 +54,7 @@ func (f funcServiceQuery) SelectServices(inst *instance.Instance) ([]platform.Se
 	return f.f(inst)
 }
 
-func exactlyTheseServices(include flux.ServiceIDSet) serviceSelector {
+func ExactlyTheseServices(include flux.ServiceIDSet) ServiceSelector {
 	var (
 		idText  []string
 		idSlice []flux.ServiceID
@@ -75,7 +75,7 @@ func exactlyTheseServices(include flux.ServiceIDSet) serviceSelector {
 	}
 }
 
-func allServicesExcept(exclude flux.ServiceIDSet) serviceSelector {
+func AllServicesExcept(exclude flux.ServiceIDSet) ServiceSelector {
 	text := "all services"
 	if len(exclude) > 0 {
 		var idText []string


### PR DESCRIPTION
Part of #208

Replace AutomatedServiceJob with AutomatedInstanceJob, to check all instance services (and images) at once, for efficiency.

Still have to cleanup, and remove the AutomatedServiceJob code once deployed.