### PR TITLE
READY - Push binaries to GH releases upon a release

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ $ gvt fetch <dependency>
 recursively; so, it should be sufficient to just add packages you
 import.
 
+### Releasing
+
+See the [release docs](./docs/releasing.md) for instructions about how to release a version of flux.
+
 ### Contribution
 
 Flux follows a typical PR workflow.

--- a/bin/upload-binaries
+++ b/bin/upload-binaries
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+## Uploads the built binaries to the GH release
+## Requires github-release
+
+set -e
+
+GITHUB_USER=${GITHUB_USER:-"${CIRCLE_PROJECT_USERNAME}"}
+GITHUB_REPO=${GITHUB_REPO:-"${CIRCLE_PROJECT_REPONAME}"}
+GITHUB_TAG=${GITHUB_TAG:-"${CIRCLE_TAG}"}
+
+for arch in amd64; do
+	for os in linux darwin; do
+		echo "= Uploading fluxctl_${os}_${arch} to GH release ${GITHUB_TAG}"
+		github-release upload \
+			--user ${GITHUB_USER} \
+			--repo ${GITHUB_REPO} \
+			--tag ${GITHUB_TAG} \
+			--name "fluxctl_${os}_${arch}" \
+			--file "build/fluxctl_${os}_${arch}"
+		echo "* Finished pushing fluxctl_${os}_${arch} for ${GITHUB_TAG}"
+	done
+done

--- a/circle.yml
+++ b/circle.yml
@@ -30,6 +30,7 @@ dependencies:
     - go get github.com/Masterminds/glide
     - go get github.com/FiloSottile/gvt
     - go get github.com/nats-io/gnatsd
+    - go get github.com/weaveworks/github-release
     - gvt restore
 
 test:
@@ -58,3 +59,8 @@ deployment:
           echo Pushing $IMAGE_TAG
           docker tag weaveworks/fluxsvc "$IMAGE_TAG"
           docker push "$IMAGE_TAG"
+  release:
+    tag: /v[0-9]+(\.[0-9]+)*/
+    commands:
+      - make release-bins
+      - bin/upload-binaries

--- a/docker/image-tag
+++ b/docker/image-tag
@@ -9,6 +9,14 @@ if [ "${1:-}" = '--show-diff' ]; then
     OUTPUT=
 fi
 
+# If a tagged version, just print that tag
+HEAD_TAGS=$(git tag --points-at HEAD)
+if [ ${HEAD_TAGS} ] ; then
+	echo ${HEAD_TAGS}
+	exit 0
+fi
+
+
 WORKING_SUFFIX=$(if ! git diff --exit-code ${OUTPUT} HEAD >&2; \
                  then echo "-WIP"; \
                  else echo ""; \

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -15,8 +15,6 @@ This process will create a new tagged release of flux, push dockerfiles and uplo
 
 Circle will then run the build and upload the built binaries to the "Downloads" section of the release.
 
-Circle will also create a new tag called "latest_release" which points to the same commit and contains the same binaries as those just built.
-
 ## Outputs
 
 The most recent binaries are always available at: https://github.com/weaveworks/flux/releases/latest

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,22 @@
+# How to make a release of flux
+
+This process will create a new tagged release of flux, push dockerfiles and upload the `fluxctl` binary to GitHub releases.
+
+## Requirements
+- Circle CI must have a secret environmental variable called `GITHUB_TOKEN` which is a personal access token.
+
+## Release process
+
+1. Alter and commit the /CHANGELOG.md file to signify what has changed in this version.
+2. Create a new release: https://github.com/weaveworks/flux/releases/new
+4. Fill in the version number for the name and tag. The version number should be semantic in the form `v1.2.3`.
+5. Fill in the Description field (possibly a copy paste from the CHANGELOG.md)
+6. Click "Publish release"
+
+Circle will then run the build and upload the built binaries to the "Downloads" section of the release.
+
+Circle will also create a new tag called "latest_release" which points to the same commit and contains the same binaries as those just built.
+
+## Outputs
+
+The most recent binaries are always available at: https://github.com/weaveworks/flux/releases/latest


### PR DESCRIPTION
Requires a: `GITHUB_TOKEN` env var, which is a GH personal access token, to be added to the circle environment vars.

Creating a new release will prompt circle to upload binaries to release.
Added release docs.
Added changelog.
Added script to upload files to GH releases.
Alterted circle.yml to build on tagged releases

Fixes #248 