### PR TITLE
Fix a couple bugs in AutomatedInstanceJob with individual failing services

### DIFF
--- a/instance/instance.go
+++ b/instance/instance.go
@@ -115,6 +115,11 @@ func (h *Instance) CollectAvailableImages(services []platform.Service) (ImageMap
 	return images, nil
 }
 
+// GetRepository exposes this instance's registry's GetRepository method directly.
+func (h *Instance) GetRepository(repo string) ([]flux.ImageDescription, error) {
+	return h.registry.GetRepository(repo)
+}
+
 // Create an image map containing exact images. At present this
 // assumes they exist; but it may in the future be made to verify so.
 func (h *Instance) ExactImages(images []flux.ImageID) (ImageMap, error) {


### PR DESCRIPTION
If one image or service failed (e.g. could not be found) it would stop all the automated services from being updated. D'oh!