### PR TITLE
Remove migration code for AutomatedServiceJobs

### DIFF
--- a/automator/automator.go
+++ b/automator/automator.go
@@ -71,9 +71,6 @@ func (a *Automator) hasAutomatedServices(services map[flux.ServiceID]instance.Se
 func (a *Automator) Handle(j *jobs.Job, _ jobs.JobUpdater) ([]jobs.Job, error) {
 	logger := log.NewContext(a.cfg.Logger).With("job", j.ID)
 	switch j.Method {
-	case jobs.AutomatedServiceJob:
-		// Clean up automated service jobs. They're being replaced
-		return nil, nil
 	case jobs.AutomatedInstanceJob:
 		return a.handleAutomatedInstanceJob(logger, j)
 	default:

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -277,12 +277,10 @@ func main() {
 	for _, queue := range []string{
 		jobs.DefaultQueue,
 		jobs.ReleaseJob,
-		jobs.AutomatedServiceJob,
 		jobs.AutomatedInstanceJob,
 	} {
 		logger := log.NewContext(logger).With("component", "worker", "queues", fmt.Sprint([]string{queue}))
 		worker := jobs.NewWorker(jobStore, logger, jobWorkerMetrics, []string{queue})
-		worker.Register(jobs.AutomatedServiceJob, auto)
 		worker.Register(jobs.AutomatedInstanceJob, auto)
 		worker.Register(jobs.ReleaseJob, release.NewReleaser(instancer, releaseMetrics))
 

--- a/jobs/db_store.go
+++ b/jobs/db_store.go
@@ -329,10 +329,6 @@ func (s *DatabaseStore) scanParams(method string, params []byte) (interface{}, e
 		var p ReleaseJobParams
 		err := json.Unmarshal(params, &p)
 		return p, err
-	case AutomatedServiceJob:
-		var p AutomatedServiceJobParams
-		err := json.Unmarshal(params, &p)
-		return p, err
 	case AutomatedInstanceJob:
 		var p AutomatedInstanceJobParams
 		err := json.Unmarshal(params, &p)

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -16,9 +16,6 @@ const (
 	// ReleaseJob is the method for a release job
 	ReleaseJob = "release"
 
-	// AutomatedServiceJob is the method for a check automated service job
-	AutomatedServiceJob = "automated_service"
-
 	// AutomatedInstanceJob is the method for a check automated instance job
 	AutomatedInstanceJob = "automated_instance"
 
@@ -159,12 +156,6 @@ type ReleaseJobParams struct {
 	ImageSpec    flux.ImageSpec
 	Kind         flux.ReleaseKind
 	Excludes     []flux.ServiceID
-}
-
-// AutomatedServiceJobParams are the params for a automated_service job
-// job
-type AutomatedServiceJobParams struct {
-	ServiceSpec flux.ServiceSpec
 }
 
 // AutomatedInstanceJobParams are the params for an automated_instance job


### PR DESCRIPTION
Now that AutomatedInstanceJobs have been deployed through to prod, and all AutomatedServiceJobs have been replaced.

Cleanup from #349