### PR TITLE
Update the docker-registry-client

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -386,7 +386,7 @@
 			"importpath": "github.com/heroku/docker-registry-client",
 			"repository": "https://github.com/heroku/docker-registry-client",
 			"vcs": "git",
-			"revision": "62e650e32756ca5bef4193e2fd5e48b0a52073af",
+			"revision": "36bd5f538a6b9e70f2d863c9a8f6bf955a98eddc",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
No particularly important changes afaict: https://github.com/heroku/docker-registry-client/compare/62e650e32756ca5bef4193e2fd5e48b0a52073af...36bd5f538a6b9e70f2d863c9a8f6bf955a98eddc