### PR TITLE
Add a registry cache

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,7 @@
 machine:
   services:
     - docker
+    - memcached
   environment:
     PATH: "/usr/local/go/bin:${HOME}/bin:${PATH}"
     GOROOT: ""
@@ -38,6 +39,7 @@ test:
         background: true
     - go build -v $(glide novendor)
     - go test -v -race $(glide novendor)
+    - go test -v -race -tags integration -timeout 30s $(glide novendor)
   post:
     - |
         cd ${GOPATH}/src/github.com/weaveworks/flux

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -53,7 +52,10 @@ func main() {
 		databaseSource        = fs.String("database-source", "file://fluxy.db", `Database source name; includes the DB driver as the scheme. The default is a temporary, file-based DB`)
 		databaseMigrationsDir = fs.String("database-migrations", "./db/migrations", "Path to database migration scripts, which are in subdirectories named for each driver")
 		natsURL               = fs.String("nats-url", "", `URL on which to connect to NATS, or empty to use the standalone message bus (e.g., "nats://user:pass@nats:4222")`)
-		registryCacheIPs      = fs.String("registry-cache-ips", "", `Space-separated list of memcache IPs to use for caching registry requests, blank means cache disabled.`)
+		memcachedHostname     = fs.String("memcached-hostname", "", "Hostname for memcached service to use when caching chunks. If empty, no memcached will be used.")
+		memcachedTimeout      = fs.Duration("memcached-timeout", 100*time.Millisecond, "Maximum time to wait before giving up on memcached requests.")
+		memcachedService      = fs.String("memcached-service", "memcached", "SRV service used to discover memcache servers.")
+		registryCacheExpiry   = fs.Duration("registry-cache-expiry", 20*time.Minute, "Duration to keep cached registry tag info. Must be < 1 month.")
 		versionFlag           = fs.Bool("version", false, "Get version number")
 	)
 	fs.Parse(os.Args)
@@ -226,17 +228,30 @@ func main() {
 		instanceDB = instance.InstrumentedDB(db, instanceMetrics)
 	}
 
+	var memcacheClient *registry.MemcacheClient
+	if *memcachedHostname != "" {
+		memcacheClient = registry.NewMemcacheClient(registry.MemcacheConfig{
+			Host:           *memcachedHostname,
+			Service:        *memcachedService,
+			Timeout:        *memcachedTimeout,
+			UpdateInterval: 1 * time.Minute,
+			Logger:         log.NewContext(logger).With("component", "memcached"),
+		})
+		defer memcacheClient.Stop()
+	}
+
 	var instancer instance.Instancer
 	{
 		// Instancer, for the instancing of operations
 		instancer = &instance.MultitenantInstancer{
-			DB:               instanceDB,
-			Connecter:        messageBus,
-			Logger:           logger,
-			Histogram:        helperDuration,
-			History:          historyDB,
-			RegistryMetrics:  registryMetrics,
-			RegistryCacheIPs: strings.Fields(*registryCacheIPs),
+			DB:                  instanceDB,
+			Connecter:           messageBus,
+			Logger:              logger,
+			Histogram:           helperDuration,
+			History:             historyDB,
+			RegistryMetrics:     registryMetrics,
+			MemcacheClient:      memcacheClient,
+			RegistryCacheExpiry: *registryCacheExpiry,
 		}
 	}
 

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -52,6 +53,7 @@ func main() {
 		databaseSource        = fs.String("database-source", "file://fluxy.db", `Database source name; includes the DB driver as the scheme. The default is a temporary, file-based DB`)
 		databaseMigrationsDir = fs.String("database-migrations", "./db/migrations", "Path to database migration scripts, which are in subdirectories named for each driver")
 		natsURL               = fs.String("nats-url", "", `URL on which to connect to NATS, or empty to use the standalone message bus (e.g., "nats://user:pass@nats:4222")`)
+		registryCacheIPs      = fs.String("registry-cache-ips", "", `Space-separated list of memcache IPs to use for caching registry requests, blank means cache disabled.`)
 		versionFlag           = fs.Bool("version", false, "Get version number")
 	)
 	fs.Parse(os.Args)
@@ -228,12 +230,13 @@ func main() {
 	{
 		// Instancer, for the instancing of operations
 		instancer = &instance.MultitenantInstancer{
-			DB:              instanceDB,
-			Connecter:       messageBus,
-			Logger:          logger,
-			Histogram:       helperDuration,
-			History:         historyDB,
-			RegistryMetrics: registryMetrics,
+			DB:               instanceDB,
+			Connecter:        messageBus,
+			Logger:           logger,
+			Histogram:        helperDuration,
+			History:          historyDB,
+			RegistryMetrics:  registryMetrics,
+			RegistryCacheIPs: strings.Fields(*registryCacheIPs),
 		}
 	}
 

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -228,16 +229,17 @@ func main() {
 		instanceDB = instance.InstrumentedDB(db, instanceMetrics)
 	}
 
-	var memcacheClient *registry.MemcacheClient
+	var memcacheClient *memcache.Client
 	if *memcachedHostname != "" {
-		memcacheClient = registry.NewMemcacheClient(registry.MemcacheConfig{
+		mc := registry.NewMemcacheClient(registry.MemcacheConfig{
 			Host:           *memcachedHostname,
 			Service:        *memcachedService,
 			Timeout:        *memcachedTimeout,
 			UpdateInterval: 1 * time.Minute,
 			Logger:         log.NewContext(logger).With("component", "memcached"),
 		})
-		defer memcacheClient.Stop()
+		memcacheClient = mc.Client
+		defer mc.Stop()
 	}
 
 	var instancer instance.Instancer

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -2,6 +2,7 @@ package instance
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
@@ -15,13 +16,14 @@ import (
 )
 
 type MultitenantInstancer struct {
-	DB               DB
-	Connecter        platform.Connecter
-	Logger           log.Logger
-	Histogram        metrics.Histogram
-	History          history.DB
-	RegistryMetrics  registry.Metrics
-	RegistryCacheIPs []string
+	DB                  DB
+	Connecter           platform.Connecter
+	Logger              log.Logger
+	Histogram           metrics.Histogram
+	History             history.DB
+	RegistryMetrics     registry.Metrics
+	MemcacheClient      *registry.MemcacheClient
+	RegistryCacheExpiry time.Duration
 }
 
 func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error) {
@@ -48,7 +50,8 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 		creds,
 		log.NewContext(instanceLogger).With("component", "registry"),
 		m.RegistryMetrics.WithInstanceID(instanceID),
-		m.RegistryCacheIPs,
+		m.MemcacheClient,
+		m.RegistryCacheExpiry,
 	)
 
 	repo := gitRepoFromSettings(c.Settings)

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -15,12 +15,13 @@ import (
 )
 
 type MultitenantInstancer struct {
-	DB              DB
-	Connecter       platform.Connecter
-	Logger          log.Logger
-	Histogram       metrics.Histogram
-	History         history.DB
-	RegistryMetrics registry.Metrics
+	DB               DB
+	Connecter        platform.Connecter
+	Logger           log.Logger
+	Histogram        metrics.Histogram
+	History          history.DB
+	RegistryMetrics  registry.Metrics
+	RegistryCacheIPs []string
 }
 
 func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error) {
@@ -47,6 +48,7 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 		creds,
 		log.NewContext(instanceLogger).With("component", "registry"),
 		m.RegistryMetrics.WithInstanceID(instanceID),
+		m.RegistryCacheIPs,
 	)
 
 	repo := gitRepoFromSettings(c.Settings)

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics"
 	"github.com/pkg/errors"
@@ -22,7 +23,7 @@ type MultitenantInstancer struct {
 	Histogram           metrics.Histogram
 	History             history.DB
 	RegistryMetrics     registry.Metrics
-	MemcacheClient      *registry.MemcacheClient
+	MemcacheClient      *memcache.Client
 	RegistryCacheExpiry time.Duration
 }
 

--- a/registry/cache.go
+++ b/registry/cache.go
@@ -1,0 +1,89 @@
+package registry
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/go-kit/kit/log"
+
+	"github.com/weaveworks/flux"
+)
+
+const (
+	// Memcache requires this to be < 1 month
+	cacheExpiration = 20 * time.Minute
+)
+
+type cache struct {
+	backend
+	c      *memcache.Client
+	creds  Credentials
+	logger log.Logger
+}
+
+// TODO: Add timing metrics
+func NewCache(b backend, creds Credentials, cacheIPs []string, logger log.Logger) *cache {
+	return &cache{
+		backend: b,
+		c:       memcache.New(cacheIPs...),
+		creds:   creds,
+		logger:  logger,
+	}
+}
+
+func (c *cache) Manifest(repository, reference string) (*schema1.SignedManifest, error) {
+	// Don't cache latest. There are probably some other frequently changing tags
+	// we shouldn't cache here as well.
+	if reference == "latest" {
+		return c.backend.Manifest(repository, reference)
+	}
+
+	host, _, _ := flux.ImageID(repository).Components()
+	creds := c.creds.credsFor(host)
+
+	// Try the cache
+	key := strings.Join([]string{
+		// Just the username here means we won't invalidate the cache when user
+		// changes password, but that should be rare. And, it also means we're not
+		// putting user passwords in plaintext into memcache.
+		creds.username,
+		repository,
+		reference,
+	}, "|")
+	cacheItem, err := c.c.Get(key)
+	var m *schema1.SignedManifest
+	if err == nil {
+		// Return the cache item
+		if err := json.Unmarshal(cacheItem.Value, m); err == nil {
+			return m, nil
+		} else {
+			c.logger.Log("err", err.Error)
+		}
+	} else if err != memcache.ErrCacheMiss {
+		// TODO: Log the error here.
+	}
+
+	// fall back to the backend
+	m, err = c.backend.Manifest(repository, reference)
+	if err == nil {
+		// Store positive responses in the cache
+		val, err := json.Marshal(m)
+		if err != nil {
+			c.logger.Log("err", err.Error)
+			return m, nil
+		}
+		if err := c.c.Set(&memcache.Item{
+			Key:        key,
+			Value:      val,
+			Expiration: int32(cacheExpiration.Seconds()),
+		}); err != nil {
+			c.logger.Log("err", err.Error)
+			return m, nil
+		}
+	}
+
+	return m, nil
+}

--- a/registry/cache.go
+++ b/registry/cache.go
@@ -17,12 +17,12 @@ type Cache struct {
 	backend
 	creds  Credentials
 	expiry time.Duration
-	Client *MemcacheClient
+	Client *memcache.Client
 	logger log.Logger
 }
 
 // TODO: Add timing metrics
-func NewCache(b backend, creds Credentials, cache *MemcacheClient, expiry time.Duration, logger log.Logger) *Cache {
+func NewCache(b backend, creds Credentials, cache *memcache.Client, expiry time.Duration, logger log.Logger) *Cache {
 	return &Cache{
 		backend: b,
 		creds:   creds,

--- a/registry/cache_test.go
+++ b/registry/cache_test.go
@@ -1,0 +1,104 @@
+// +build integration
+
+package registry
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/docker/distribution/manifest/schema1"
+	"github.com/go-kit/kit/log"
+)
+
+var (
+	memcachedIPs = flag.String("memcached-ips", "127.0.0.1:11211", "space-separated host:port values for memcached to connect to")
+)
+
+// Setup sets up stuff for testing
+func Setup(t *testing.T) *memcache.Client {
+	fmt.Printf("Memcache IPs: %v\n", strings.Fields(*memcachedIPs))
+	mc := memcache.New(strings.Fields(*memcachedIPs)...)
+	if err := mc.FlushAll(); err != nil {
+		t.Fatal(err)
+	}
+	return mc
+}
+
+// Cleanup cleans up after a test
+func Cleanup(t *testing.T) {
+}
+
+type MockBackend struct {
+	tags     func(repository string) ([]string, error)
+	manifest func(repository, reference string) ([]schema1.History, error)
+}
+
+func (m *MockBackend) Tags(repository string) ([]string, error) {
+	return m.tags(repository)
+}
+
+func (m *MockBackend) Manifest(repository, reference string) ([]schema1.History, error) {
+	return m.manifest(repository, reference)
+}
+
+func TestCache(t *testing.T) {
+	mc := Setup(t)
+	defer Cleanup(t)
+
+	manifestCalled := 0
+	c := NewCache(
+		&MockBackend{
+			manifest: func(repo, ref string) ([]schema1.History, error) {
+				manifestCalled++
+				return []schema1.History{{`{"test":"json"}`}}, nil
+			},
+		},
+		NoCredentials(),
+		mc,
+		20*time.Minute,
+		log.NewLogfmtLogger(log.NewSyncWriter(os.Stdout)),
+	)
+
+	// It should fetch stuff from the backend
+	response, err := c.Manifest("weaveworks/foorepo", "tag1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(response) != 1 {
+		t.Fatalf("Expected 1 history item, got %v", response)
+	}
+	expected := schema1.History{`{"test":"json"}`}
+	if response[0] != expected {
+		t.Fatalf("Expected  history item: %v, got %v", expected, response[0])
+	}
+	if manifestCalled != 1 {
+		t.Errorf("Expected 1 call to the backend, got %d", manifestCalled)
+	}
+
+	// It should cache on the way through
+	_, err = mc.Get(strings.Join([]string{
+		"registryhistoryv1",
+		"", // no username
+		"weaveworks/foorepo",
+		"tag1",
+	}, "|"))
+	if err != nil {
+		// Will catch ErrCacheMiss
+		t.Fatal(err)
+	}
+
+	// it should prefer cached data
+	_, err = c.Manifest("weaveworks/foorepo", "tag1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// still 1 call
+	if manifestCalled != 1 {
+		t.Errorf("Expected 1 call to the backend, got %d", manifestCalled)
+	}
+}

--- a/registry/heroku_wrapper.go
+++ b/registry/heroku_wrapper.go
@@ -13,11 +13,11 @@ type herokuWrapper struct {
 // vendored library so go freaks out. Eugh.
 // TODO: The only thing we care about here for now is history. Frankly it might
 // be easier to convert it to JSON and back.
-func (h herokuWrapper) Manifest(repository, reference string) (*schema1.SignedManifest, error) {
+func (h herokuWrapper) Manifest(repository, reference string) ([]schema1.History, error) {
 	manifest, err := h.Registry.Manifest(repository, reference)
-	result := &schema1.SignedManifest{}
+	var result []schema1.History
 	for _, item := range manifest.History {
-		result.Manifest.History = append(result.Manifest.History, schema1.History{item.V1Compatibility})
+		result = append(result, schema1.History{item.V1Compatibility})
 	}
 	return result, err
 }

--- a/registry/heroku_wrapper.go
+++ b/registry/heroku_wrapper.go
@@ -1,0 +1,23 @@
+package registry
+
+import (
+	"github.com/docker/distribution/manifest/schema1"
+	dockerregistry "github.com/heroku/docker-registry-client/registry"
+)
+
+type herokuWrapper struct {
+	*dockerregistry.Registry
+}
+
+// Convert between types. dockerregistry returns the *same* type but from a
+// vendored library so go freaks out. Eugh.
+// TODO: The only thing we care about here for now is history. Frankly it might
+// be easier to convert it to JSON and back.
+func (h herokuWrapper) Manifest(repository, reference string) (*schema1.SignedManifest, error) {
+	manifest, err := h.Registry.Manifest(repository, reference)
+	result := &schema1.SignedManifest{}
+	for _, item := range manifest.History {
+		result.Manifest.History = append(result.Manifest.History, schema1.History{item.V1Compatibility})
+	}
+	return result, err
+}

--- a/registry/memcached.go
+++ b/registry/memcached.go
@@ -1,0 +1,100 @@
+package registry
+
+import (
+	"fmt"
+	"net"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/bradfitz/gomemcache/memcache"
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
+)
+
+// MemcacheClient is a memcache client that gets its server list from SRV
+// records, and periodically updates that ServerList.
+type MemcacheClient struct {
+	*memcache.Client
+	serverList *memcache.ServerList
+	hostname   string
+	service    string
+	logger     log.Logger
+
+	quit chan struct{}
+	wait sync.WaitGroup
+}
+
+// MemcacheConfig defines how a MemcacheClient should be constructed.
+type MemcacheConfig struct {
+	Host           string
+	Service        string
+	Timeout        time.Duration
+	UpdateInterval time.Duration
+	Logger         log.Logger
+}
+
+func NewMemcacheClient(config MemcacheConfig) *MemcacheClient {
+	var servers memcache.ServerList
+	client := memcache.NewFromSelector(&servers)
+	client.Timeout = config.Timeout
+
+	newClient := &MemcacheClient{
+		Client:     client,
+		serverList: &servers,
+		hostname:   config.Host,
+		service:    config.Service,
+		logger:     config.Logger,
+		quit:       make(chan struct{}),
+	}
+
+	err := newClient.updateMemcacheServers()
+	if err != nil {
+		config.Logger.Log("err", errors.Wrapf(err, "Error setting memcache servers to '%v'", config.Host))
+	}
+
+	newClient.wait.Add(1)
+	go newClient.updateLoop(config.UpdateInterval)
+	return newClient
+}
+
+// Stop the memcache client.
+func (c *MemcacheClient) Stop() {
+	close(c.quit)
+	c.wait.Wait()
+}
+
+func (c *MemcacheClient) updateLoop(updateInterval time.Duration) error {
+	defer c.wait.Done()
+	ticker := time.NewTicker(updateInterval)
+	var err error
+	for {
+		select {
+		case <-ticker.C:
+			err = c.updateMemcacheServers()
+			if err != nil {
+				c.logger.Log("err", errors.Wrap(err, "error updating memcache servers"))
+			}
+		case <-c.quit:
+			ticker.Stop()
+		}
+	}
+}
+
+// updateMemcacheServers sets a memcache server list from SRV records. SRV
+// priority & weight are ignored.
+func (c *MemcacheClient) updateMemcacheServers() error {
+	_, addrs, err := net.LookupSRV(c.service, "tcp", c.hostname)
+	if err != nil {
+		return err
+	}
+	var servers []string
+	for _, srv := range addrs {
+		servers = append(servers, fmt.Sprintf("%s:%d", srv.Target, srv.Port))
+	}
+	// ServerList deterministically maps keys to _index_ of the server list.
+	// Since DNS returns records in different order each time, we sort to
+	// guarantee best possible match between nodes.
+	sort.Strings(servers)
+	return c.serverList.SetServers(servers...)
+}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/distribution/manifest/schema1"
 	"github.com/go-kit/kit/log"
 	dockerregistry "github.com/heroku/docker-registry-client/registry"
 	"github.com/jonboulle/clockwork"
@@ -58,6 +59,11 @@ func NewClient(c Credentials, l log.Logger, m Metrics) Client {
 		Logger:      l,
 		Metrics:     m,
 	}
+}
+
+type backend interface {
+	Tags(repository string) ([]string, error)
+	Manifest(repository, reference string) (*schema1.SignedManifest, error)
 }
 
 type roundtripperFunc func(*http.Request) (*http.Response, error)

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/bradfitz/gomemcache/memcache"
 	"github.com/docker/distribution/manifest/schema1"
 	"github.com/go-kit/kit/log"
 	dockerregistry "github.com/heroku/docker-registry-client/registry"
@@ -50,12 +51,12 @@ type client struct {
 	Credentials    Credentials
 	Logger         log.Logger
 	Metrics        Metrics
-	MemcacheClient *MemcacheClient
+	MemcacheClient *memcache.Client
 	CacheExpiry    time.Duration
 }
 
 // NewClient creates a new registry client, to use when fetching repositories.
-func NewClient(c Credentials, l log.Logger, m Metrics, mc *MemcacheClient, ce time.Duration) Client {
+func NewClient(c Credentials, l log.Logger, m Metrics, mc *memcache.Client, ce time.Duration) Client {
 	return &client{
 		Credentials:    c,
 		Logger:         l,

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -59,6 +59,15 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/bradfitz/gomemcache/memcache",
+			"repository": "https://github.com/bradfitz/gomemcache",
+			"vcs": "git",
+			"revision": "2fafb84a66c4911e11a8f50955b01e74fe3ab9c5",
+			"branch": "master",
+			"path": "/memcache",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/circonus-labs/circonus-gometrics",
 			"repository": "https://github.com/circonus-labs/circonus-gometrics",
 			"vcs": "git",


### PR DESCRIPTION
Not a massive time-save:
```
$ time fluxctl list-images -s monitoring/kubediff
SERVICE              CONTAINER  IMAGE                CREATED
monitoring/kubediff  git-sync   tomwilkie/git-sync
                                '-> f6165715ce9d     02 Jun 16 12:39 UTC
                                    latest           02 Jun 16 12:39 UTC
                     kubediff   weaveworks/kubediff
                                |   latest           16 Nov 16 14:57 UTC
                                |   master-d658306   16 Nov 16 14:57 UTC
                                |   master-8ac1b99   06 Nov 16 17:34 UTC
                                |   master-15b51e6   18 Oct 16 12:58 UTC
                                |   master-d82bdad   18 Oct 16 11:55 UTC
                                |   master-af2af60   18 Oct 16 11:03 UTC
                                |   master-f332982   18 Oct 16 10:53 UTC
                                |   master-139e1ee   05 Oct 16 01:19 UTC
fluxctl list-images -s monitoring/kubediff  0.01s user 0.01s system 0% cpu 3.084 total

# Next time, cached...
$ time fluxctl list-images -s monitoring/kubediff
SERVICE              CONTAINER  IMAGE                CREATED
monitoring/kubediff  git-sync   tomwilkie/git-sync
                                '-> f6165715ce9d     02 Jun 16 12:39 UTC
                                    latest           02 Jun 16 12:39 UTC
                     kubediff   weaveworks/kubediff
                                |   latest           16 Nov 16 14:57 UTC
                                |   master-d658306   16 Nov 16 14:57 UTC
                                |   master-8ac1b99   06 Nov 16 17:34 UTC
                                |   master-15b51e6   18 Oct 16 12:58 UTC
                                |   master-d82bdad   18 Oct 16 11:55 UTC
                                |   master-af2af60   18 Oct 16 11:03 UTC
                                |   master-f332982   18 Oct 16 10:53 UTC
                                |   master-139e1ee   05 Oct 16 01:19 UTC
fluxctl list-images -s monitoring/kubediff  0.01s user 0.01s system 0% cpu 1.872 total
```
but should reduce quite a few round-trips to the registry.

Note, I've just picked 20 minutes as the time to cache entries for. Completely out of the air, no data basis for that. but it *should* lead to a 1/20th of the requests.

Note: to deploy, need to add memcached first, then add the flags. If memcached-host flag is not set, no behaviour change.