### PR TITLE
Add a shorter timeout on fluxd connecting

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/metrics/prometheus"
@@ -105,7 +106,7 @@ func main() {
 	// Connect to fluxsvc
 	daemonLogger := log.NewContext(logger).With("component", "client")
 	daemon, err := transport.NewDaemon(
-		http.DefaultClient,
+		&http.Client{Timeout: 10 * time.Second},
 		flux.Token(*token),
 		transport.NewRouter(),
 		*fluxsvcAddress,

--- a/http/websocket/client.go
+++ b/http/websocket/client.go
@@ -1,6 +1,7 @@
 package websocket
 
 import (
+	"net"
 	"net/http"
 	"net/url"
 
@@ -33,6 +34,9 @@ func Dial(client *http.Client, token flux.Token, u *url.URL) (Websocket, error) 
 
 func dialer(client *http.Client) *websocket.Dialer {
 	return &websocket.Dialer{
+		NetDial: func(network, addr string) (net.Conn, error) {
+			return net.DialTimeout(network, addr, client.Timeout)
+		},
 		HandshakeTimeout: client.Timeout,
 		Jar:              client.Jar,
 		// TODO: TLSClientConfig: client.TLSClientConfig,


### PR DESCRIPTION
Makes it reconnect quicker when fluxsvc reboots/gets upgraded.

When developing, it was a pain every time you updated fluxsvc because fluxd would take ages to retry connecting.