### PR TITLE
Finish the bus implementation of platform.Version

### DIFF
--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -257,6 +257,10 @@ func (n *NATS) Subscribe(instID flux.InstanceID, remote platform.Platform, done 
 					err = remote.Ping()
 				}
 				n.enc.Publish(request.Reply, PingResponse{makeErrorResponse(err)})
+			case strings.HasSuffix(request.Subject, methodVersion):
+				var vsn string
+				vsn, err = remote.Version()
+				n.enc.Publish(request.Reply, VersionResponse{vsn, makeErrorResponse(err)})
 			case strings.HasSuffix(request.Subject, methodAllServices):
 				var (
 					req fluxrpc.AllServicesRequest

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -76,6 +76,7 @@ func TestMethods(t *testing.T) {
 
 	instA := flux.InstanceID("steamy-windows-89")
 	mockA := &platform.MockPlatform{
+		VersionAnswer:     "a-version-123",
 		AllServicesAnswer: []platform.Service{platform.Service{}},
 		ApplyError:        platform.ApplyError{flux.ServiceID("foo/bar"): errors.New("foo barred")},
 	}
@@ -85,6 +86,14 @@ func TestMethods(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	vsn, err := plat.Version()
+	if err != nil {
+		t.Error(err)
+	} else if vsn != mockA.VersionAnswer {
+		t.Errorf(`expected version "%s", got "%s"`, mockA.VersionAnswer, vsn)
+	}
+
 	ss, err := plat.AllServices("", nil)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The NATS bus implementation has two main parts: a client that encodes each method as a message and sends it as a request over NATS, and a server which listens for all requests to a certain instance, and relays it over the RPC connection.

This commit completes the implementation of Version in the bus by adding the server part, and a test for it.