### PR TITLE
Api/flux prefix migration

### DIFF
--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -336,7 +336,9 @@ func main() {
 		logger.Log("addr", *listenAddr)
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
-		mux.Handle("/", transport.NewHandler(server, transport.NewRouter(), logger, httpDuration))
+		handler := transport.NewHandler(server, transport.NewRouter(), logger, httpDuration)
+		mux.Handle("/", handler)
+		mux.Handle("/api/flux/", http.StripPrefix("/api/flux", handler))
 		errc <- http.ListenAndServe(*listenAddr, mux)
 	}()
 

--- a/deploy/standalone/README.md
+++ b/deploy/standalone/README.md
@@ -37,7 +37,7 @@ port, with
 ```
 $ flux_host=$(minikube ip)
 $ flux_port=$(kubectl get service fluxsvc --template '{{ index .spec.ports 0 "nodePort" }}')
-$ export FLUX_URL=http://$flux_host:$flux_port
+$ export FLUX_URL=http://$flux_host:$flux_port/api/flux
 ```
 
 At this point you can see if it's all running by doing:

--- a/deploy/standalone/flux-deployment.yaml
+++ b/deploy/standalone/flux-deployment.yaml
@@ -13,7 +13,7 @@ spec:
       - name: fluxd
         image: quay.io/weaveworks/fluxd:master-6cc08e4
         args:
-        - --fluxsvc-address=ws://localhost:3030
+        - --fluxsvc-address=ws://localhost:3030/api/flux
       - name: fluxsvc
         image: quay.io/weaveworks/fluxsvc:master-6cc08e4
         args:


### PR DESCRIPTION
Make flux respond both at `/` and at `/api/flux` so we can swap authfe over, then remove support for `/`

Part of https://github.com/weaveworks/flux/issues/217