### PR TITLE
updated to the latest versions of fluxd and fluxsvc

### DIFF
--- a/deploy/standalone/flux-deployment.yaml
+++ b/deploy/standalone/flux-deployment.yaml
@@ -11,11 +11,11 @@ spec:
     spec:
       containers:
       - name: fluxd
-        image: quay.io/weaveworks/fluxd:master-6cc08e4
+        image: quay.io/weaveworks/fluxd:master-952c028
         args:
         - --fluxsvc-address=ws://localhost:3030/api/flux
       - name: fluxsvc
-        image: quay.io/weaveworks/fluxsvc:master-6cc08e4
+        image: quay.io/weaveworks/fluxsvc:master-952c028
         args:
         - --database-source=file://flux.db
         - --memcached-hostname=memcached.default.svc.cluster.local


### PR DESCRIPTION
The deploy instructions for the standalone Flux were failing because they were running an old version of Flux. This PR updates both containers to their latest version.