### PR TITLE
Move ServiceSpec release handling into the http transport instead of the releaser

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -103,10 +103,10 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	id, err := opts.API.PostRelease(noInstanceID, jobs.ReleaseJobParams{
-		ServiceSpec: service,
-		ImageSpec:   image,
-		Kind:        kind,
-		Excludes:    excludes,
+		ServiceSpecs: []flux.ServiceSpec{service},
+		ImageSpec:    image,
+		Kind:         kind,
+		Excludes:     excludes,
 	})
 	if err != nil {
 		return err

--- a/http/transport.go
+++ b/http/transport.go
@@ -246,10 +246,10 @@ func handlePostRelease(s api.FluxService) http.Handler {
 		}
 
 		id, err := s.PostRelease(inst, jobs.ReleaseJobParams{
-			ServiceSpec: serviceSpec,
-			ImageSpec:   imageSpec,
-			Kind:        releaseKind,
-			Excludes:    excludes,
+			ServiceSpecs: []flux.ServiceSpec{serviceSpec},
+			ImageSpec:    imageSpec,
+			Kind:         releaseKind,
+			Excludes:     excludes,
 		})
 		if err != nil {
 			w.WriteHeader(http.StatusInternalServerError)
@@ -270,7 +270,10 @@ func handlePostRelease(s api.FluxService) http.Handler {
 }
 
 func invokePostRelease(client *http.Client, t flux.Token, router *mux.Router, endpoint string, s jobs.ReleaseJobParams) (jobs.JobID, error) {
-	args := []string{"service", string(s.ServiceSpec), "image", string(s.ImageSpec), "kind", string(s.Kind)}
+	args := []string{"image", string(s.ImageSpec), "kind", string(s.Kind)}
+	for _, spec := range s.ServiceSpecs {
+		args = append(args, "service", string(spec))
+	}
 	for _, ex := range s.Excludes {
 		args = append(args, "exclude", string(ex))
 	}

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -151,11 +151,14 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 
 // ReleaseJobParams are the params for a release job
 type ReleaseJobParams struct {
-	ServiceSpec  flux.ServiceSpec // For backwards compatibility
 	ServiceSpecs []flux.ServiceSpec
 	ImageSpec    flux.ImageSpec
 	Kind         flux.ReleaseKind
 	Excludes     []flux.ServiceID
+
+	// Backwards Compatibility, remove once no more jobs
+	// TODO: Remove this once there are no more jobs with ServiceSpec, only ServiceSpecs
+	ServiceSpec flux.ServiceSpec
 }
 
 // AutomatedInstanceJobParams are the params for an automated_instance job

--- a/jobs/job_test.go
+++ b/jobs/job_test.go
@@ -18,9 +18,9 @@ func TestJobEncodingDecoding(t *testing.T) {
 		Queue:    DefaultQueue,
 		Method:   ReleaseJob,
 		Params: ReleaseJobParams{
-			ServiceSpec: flux.ServiceSpecAll,
-			ImageSpec:   flux.ImageSpecLatest,
-			Kind:        flux.ReleaseKindExecute,
+			ServiceSpecs: []flux.ServiceSpec{flux.ServiceSpecAll},
+			ImageSpec:    flux.ImageSpecLatest,
+			Kind:         flux.ReleaseKindExecute,
 		},
 		ScheduledAt: now,
 		Priority:    PriorityInteractive,

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -55,6 +55,7 @@ func (r *Releaser) Handle(job *jobs.Job, updater jobs.JobUpdater) (followUps []j
 	params := job.Params.(jobs.ReleaseJobParams)
 
 	// Backwards compatibility
+	// TODO: Remove this once there are no more jobs with ServiceSpec, only ServiceSpecs
 	if string(params.ServiceSpec) != "" {
 		params.ServiceSpecs = append(params.ServiceSpecs, params.ServiceSpec)
 	}


### PR DESCRIPTION
* Left in params.ServiceSpec while migrating