### PR TITLE
api to provide automated deploy key insertion

### DIFF
--- a/integrations/github/github.go
+++ b/integrations/github/github.go
@@ -1,0 +1,89 @@
+package github
+
+import (
+	"fmt"
+	gh "github.com/google/go-github/github"
+	"github.com/weaveworks/flux/http/error"
+	"golang.org/x/oauth2"
+	"net/http"
+)
+
+var (
+	deployKeyName   = "flux-generated"
+	errUnauthorized = httperror.APIError{
+		Body: "Unable to list deploy keys. Permission deined. Check user token.",
+	}
+	errNotFound = httperror.APIError{
+		Body: "Cannot find owner or repository. Check spelling.",
+	}
+	errGeneric = httperror.APIError{
+		Body: "Unable to perform GH action. Check error message.",
+	}
+)
+
+type github struct {
+	client *gh.Client
+}
+
+// NewGithubClient instantiates a GH client from a provided OAuth token.
+func NewGithubClient(token string) *github {
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: token},
+	)
+	tc := oauth2.NewClient(oauth2.NoContext, ts)
+
+	return &github{
+		client: gh.NewClient(tc),
+	}
+}
+
+// InsertDeployKey will create a new deploy key for the given owner,
+// repo, token using the key deployKey.
+// If a key already exists with that name it will be deleted.
+func (g *github) InsertDeployKey(ownerName string, repoName string, deployKey string) error {
+	// Get list of keys
+	keys, resp, err := g.client.Repositories.ListKeys(ownerName, repoName, nil)
+	if err != nil {
+		return parseError(resp, err)
+	}
+	for _, k := range keys {
+		// If key already exists, delete
+		if *k.Title == deployKeyName {
+			resp, err := g.client.Repositories.DeleteKey(ownerName, repoName, *k.ID)
+			if err != nil {
+				return parseError(resp, err)
+			}
+			break
+		}
+	}
+
+	// Create new key
+	key := gh.Key{
+		Title: &deployKeyName,
+		Key:   &deployKey,
+	}
+	_, resp, err = g.client.Repositories.CreateKey(ownerName, repoName, &key)
+	if err != nil {
+		return parseError(resp, err)
+	}
+	return nil
+}
+
+func populateError(err httperror.APIError, resp *gh.Response) *httperror.APIError {
+	err.StatusCode = resp.StatusCode
+	err.Status = resp.Status
+	return &err
+}
+
+func parseError(resp *gh.Response, err error) error {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized:
+		return populateError(errUnauthorized, resp)
+	case http.StatusNotFound:
+		return populateError(errNotFound, resp)
+	default:
+		e := populateError(errGeneric, resp)
+		e.Body = fmt.Sprintf("%s - %s", e.Body, err.Error())
+		return e
+	}
+}

--- a/integrations/github/github_test.go
+++ b/integrations/github/github_test.go
@@ -1,0 +1,115 @@
+package github
+
+import (
+	"fmt"
+	gh "github.com/google/go-github/github"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+var (
+	// mux is the HTTP request multiplexer used with the test server.
+	mux *http.ServeMux
+
+	// client is the GitHub client being tested.
+	client *gh.Client
+
+	// server is a test HTTP server used to provide mock API responses.
+	server *httptest.Server
+)
+
+// setup sets up a test HTTP server along with a github.Client that is
+// configured to talk to that test server. Tests should register handlers on
+// mux which provide mock responses for the API method being tested.
+func setup() {
+	// test server
+	mux = http.NewServeMux()
+	server = httptest.NewServer(mux)
+
+	// github client configured to use test server
+	client = gh.NewClient(nil)
+	url, _ := url.Parse(server.URL)
+	client.BaseURL = url
+	client.UploadURL = url
+}
+
+// teardown closes the test HTTP server.
+func teardown() {
+	server.Close()
+}
+
+var didGET, didPOST, didDELETE bool
+
+func initHandlers(t *testing.T, keyTitle string) {
+	mux.HandleFunc("/repos/o/r/keys", func(w http.ResponseWriter, r *http.Request) {
+		t.Log(r.Method, r.URL)
+		if r.Method == "GET" {
+			fmt.Fprint(w, `[{"id":1,"title":"`+keyTitle+`"}]`)
+			didGET = true
+		} else if r.Method == "POST" {
+			didPOST = true
+		}
+	})
+
+	mux.HandleFunc("/repos/o/r/keys/1", func(w http.ResponseWriter, r *http.Request) {
+		t.Log(r.Method, r.URL)
+		testMethod(t, r, "DELETE")
+		didDELETE = true
+	})
+}
+
+func TestInsertDeployKey_KeyDoesntExist(t *testing.T) {
+	setup()
+	defer teardown()
+	initHandlers(t, "doesntMatch")
+
+	g := github{
+		client: client,
+	}
+
+	err := g.InsertDeployKey("o", "r", "ssh-rsa AAA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if didGET != true {
+		t.Fatal("Should have requested keys")
+	}
+	if didPOST != true {
+		t.Fatal("Should have created key")
+	}
+	if didDELETE != false {
+		t.Fatal("Should have not deleted key")
+	}
+}
+
+func TestInsertDeployKey_KeyDoesExist(t *testing.T) {
+	setup()
+	defer teardown()
+	initHandlers(t, deployKeyName)
+
+	g := github{
+		client: client,
+	}
+
+	err := g.InsertDeployKey("o", "r", "ssh-rsa AAA")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if didGET != true {
+		t.Fatal("Should have requested keys")
+	}
+	if didPOST != true {
+		t.Fatal("Should have created key")
+	}
+	if didDELETE != true {
+		t.Fatal("Should have deleted key")
+	}
+}
+
+func testMethod(t *testing.T, r *http.Request, want string) {
+	if got := r.Method; got != want {
+		t.Errorf("Request method: %v, want %v", got, want)
+	}
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -363,6 +363,23 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/google/go-github",
+			"repository": "https://github.com/google/go-github",
+			"vcs": "git",
+			"revision": "dfd20fd7fa6edec56447fcb049acd5e17a78ec2e",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/google/go-querystring/query",
+			"repository": "https://github.com/google/go-querystring",
+			"vcs": "git",
+			"revision": "53e6ce116135b80d037921a7fdd5138cf32d7a8a",
+			"branch": "master",
+			"path": "/query",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/googleapis/gax-go",
 			"repository": "https://github.com/googleapis/gax-go",
 			"vcs": "git",


### PR DESCRIPTION
This code provides an api for inserting a deploy key.

It is intended that this code is forwarded by authfe. The GH authorisation token is injected by authfe.

But the code can be called manually with:
```
curl -XPOST -H "GithubToken: ${TOKEN}" http://192.168.99.100:31470/v5/integrations/github\?owner\=philwinder\&repository\=flux-example -v
```
Where `${TOKEN}` is your token and the repository has been altered.

This will insert a new deploy key called `flux-generated`. If the key already exists, it will be overwritten (by deleting and recreating).

This has been tested alongside the change to authfe (https://github.com/weaveworks/service/pull/1102)