### PR TITLE
Async releases and shutdown

### DIFF
--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -304,6 +304,7 @@ func main() {
 		worker.Register(jobs.ReleaseJob, release.NewReleaser(instancer, releaseMetrics))
 
 		defer func() {
+			logger.Log("stopping", "true")
 			if err := worker.Stop(shutdownTimeout); err != nil {
 				logger.Log("err", err)
 			}

--- a/deploy/standalone/flux-deployment.yaml
+++ b/deploy/standalone/flux-deployment.yaml
@@ -4,11 +4,25 @@ metadata:
   name: flux
 spec:
   replicas: 1
+
+  # Having maxSurge 0 and maxUnavailable 1 means the deployment will update one
+  # replica at a time as it will have to stop one (making one unavailable)
+  # before it can start one (surge of zero)
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+
   template:
     metadata:
       labels:
         name: flux
     spec:
+      # Give fluxsvc up to 10 minutes grace to finish jobs in progress and exit
+      # cleanly. Service is available during this time, as long as we don't
+      # stop too many replicas at once.
+      terminationGracePeriodSeconds: 600
+
       containers:
       - name: fluxd
         image: quay.io/weaveworks/fluxd:master-952c028

--- a/deploy/standalone/flux-deployment.yaml
+++ b/deploy/standalone/flux-deployment.yaml
@@ -7,7 +7,8 @@ spec:
 
   # Having maxSurge 0 and maxUnavailable 1 means the deployment will update one
   # replica at a time as it will have to stop one (making one unavailable)
-  # before it can start one (surge of zero)
+  # before it can start one (surge of zero). This means if we have > 1 replica,
+  # we will stay available while deploying.
   strategy:
     rollingUpdate:
       maxSurge: 0

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -356,7 +356,7 @@ func (c *Cluster) Apply(defs []platform.ServiceDefinition) error {
 					continue
 				}
 
-				plan, err := controller.newApply(newDef)
+				plan, err := controller.newApply(newDef, def.Async)
 				if err != nil {
 					applyErr[def.ServiceID] = errors.Wrap(err, "creating release")
 					continue

--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -88,9 +88,9 @@ func (c *Cluster) doApplyCommand(logger log.Logger, newDefinition *apiObject, ar
 
 func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject, async bool) applyExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
-		err := make(chan error)
+		errc := make(chan error)
 		go func() {
-			err <- c.doApplyCommand(
+			errc <- c.doApplyCommand(
 				logger,
 				newDef,
 				"rolling-update",
@@ -103,7 +103,7 @@ func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject, async
 		if async {
 			return nil
 		}
-		return <-err
+		return <-errc
 	}
 }
 

--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -95,6 +95,7 @@ func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject, async
 				newDef,
 				"rolling-update",
 				"--update-period", "3s",
+				"--namespace", def.Namespace,
 				def.Name,
 				"-f", "-", // take definition from stdin
 			)

--- a/platform/kubernetes/release.go
+++ b/platform/kubernetes/release.go
@@ -16,7 +16,7 @@ import (
 	"github.com/weaveworks/flux/platform"
 )
 
-func (c podController) newApply(newDefinition *apiObject) (*apply, error) {
+func (c podController) newApply(newDefinition *apiObject, async bool) (*apply, error) {
 	k := c.kind()
 	if newDefinition.Kind != k {
 		return nil, fmt.Errorf(`Expected new definition of kind %q, to match old definition; got %q`, k, newDefinition.Kind)
@@ -24,10 +24,10 @@ func (c podController) newApply(newDefinition *apiObject) (*apply, error) {
 
 	var result apply
 	if c.Deployment != nil {
-		result.exec = deploymentExec(c.Deployment, newDefinition)
+		result.exec = deploymentExec(c.Deployment, newDefinition, async)
 		result.summary = "Applying deployment"
 	} else if c.ReplicationController != nil {
-		result.exec = rollingUpgradeExec(c.ReplicationController, newDefinition)
+		result.exec = rollingUpgradeExec(c.ReplicationController, newDefinition, async)
 		result.summary = "Rolling upgrade"
 	} else {
 		return nil, platform.ErrNoMatching
@@ -86,20 +86,27 @@ func (c *Cluster) doApplyCommand(logger log.Logger, newDefinition *apiObject, ar
 	return err
 }
 
-func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject) applyExecFunc {
+func rollingUpgradeExec(def *api.ReplicationController, newDef *apiObject, async bool) applyExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
-		return c.doApplyCommand(
-			logger,
-			newDef,
-			"rolling-update",
-			"--update-period", "3s",
-			def.Name,
-			"-f", "-", // take definition from stdin
-		)
+		err := make(chan error)
+		go func() {
+			err <- c.doApplyCommand(
+				logger,
+				newDef,
+				"rolling-update",
+				"--update-period", "3s",
+				def.Name,
+				"-f", "-", // take definition from stdin
+			)
+		}()
+		if async {
+			return nil
+		}
+		return <-err
 	}
 }
 
-func deploymentExec(def *apiext.Deployment, newDef *apiObject) applyExecFunc {
+func deploymentExec(def *apiext.Deployment, newDef *apiObject, async bool) applyExecFunc {
 	return func(c *Cluster, logger log.Logger) error {
 		err := c.doApplyCommand(
 			logger,
@@ -107,6 +114,9 @@ func deploymentExec(def *apiext.Deployment, newDef *apiObject) applyExecFunc {
 			"apply",
 			"-f", "-", // take definition from stdin
 		)
+		if async {
+			return err
+		}
 
 		if err == nil {
 			args := []string{

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -117,6 +117,7 @@ var (
 type ServiceDefinition struct {
 	ServiceID     flux.ServiceID
 	NewDefinition []byte // of the pod controller e.g. deployment
+	Async         bool   // Should this definition be applied without waiting for the result.
 }
 
 type ApplyError map[flux.ServiceID]error

--- a/registry/memcached.go
+++ b/registry/memcached.go
@@ -81,19 +81,18 @@ func (c *memcacheClient) Stop() {
 	c.wait.Wait()
 }
 
-func (c *memcacheClient) updateLoop(updateInterval time.Duration) error {
+func (c *memcacheClient) updateLoop(updateInterval time.Duration) {
 	defer c.wait.Done()
 	ticker := time.NewTicker(updateInterval)
-	var err error
+	defer ticker.Stop()
 	for {
 		select {
 		case <-ticker.C:
-			err = c.updateMemcacheServers()
-			if err != nil {
+			if err := c.updateMemcacheServers(); err != nil {
 				c.logger.Log("err", errors.Wrap(err, "error updating memcache servers"))
 			}
 		case <-c.quit:
-			ticker.Stop()
+			return
 		}
 	}
 }

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -524,6 +524,7 @@ func (r *Releaser) releaseActionReleaseServices(services []flux.ServiceID, msg s
 					asyncDefs = append(asyncDefs, platform.ServiceDefinition{
 						ServiceID:     service,
 						NewDefinition: def,
+						Async:         true,
 					})
 				default:
 					rc.Instance.LogEvent(namespace, serviceName, "Starting "+cause)
@@ -573,9 +574,7 @@ func (r *Releaser) releaseActionReleaseServices(services []flux.ServiceID, msg s
 			// shutdown. So the only thing that goes missing is the
 			// result from this release call.
 			if len(asyncDefs) > 0 {
-				go func() {
-					rc.Instance.PlatformApply(asyncDefs)
-				}()
+				rc.Instance.PlatformApply(asyncDefs)
 			}
 
 			return "", transactionErr


### PR DESCRIPTION
Unfortunately, [this](https://github.com/weaveworks/flux/pull/415) added a race with the slack notification when releasing flux itself. This fixes that.

Need to move the yaml changes out to everywhere (launch-generator, and service-conf).