### PR TITLE
refactor(transport): moved APIError to separate package to avoid impo…

### DIFF
--- a/cmd/fluxctl/check_release_cmd.go
+++ b/cmd/fluxctl/check_release_cmd.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/flux"
-	transport "github.com/weaveworks/flux/http"
+	"github.com/weaveworks/flux/http/error"
 	"github.com/weaveworks/flux/jobs"
 )
 
@@ -99,7 +99,7 @@ func (opts *serviceCheckReleaseOpts) RunE(cmd *cobra.Command, args []string) err
 
 		job, err = opts.API.GetRelease(noInstanceID, jobs.JobID(opts.releaseID))
 		if err != nil {
-			if err, ok := errors.Cause(err).(*transport.APIError); ok && err.IsUnavailable() {
+			if err, ok := errors.Cause(err).(*httperror.APIError); ok && err.IsUnavailable() {
 				if time.Since(lastSucceeded) > retryTimeout {
 					stop()
 					fmt.Fprintln(os.Stdout, "Giving up; you can try again with")

--- a/cmd/fluxctl/main.go
+++ b/cmd/fluxctl/main.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 
-	transport "github.com/weaveworks/flux/http"
+	"github.com/weaveworks/flux/http/error"
 )
 
 func run(args []string, stderr io.Writer) int {
@@ -17,7 +17,7 @@ func run(args []string, stderr io.Writer) int {
 	if cmd, err := rootCmd.ExecuteC(); err != nil {
 		err = errors.Cause(err)
 		switch err := err.(type) {
-		case *transport.APIError:
+		case *httperror.APIError:
 			switch {
 			case err.IsMissing():
 				cmd.Println(strings.Join([]string{

--- a/http/error/APIError.go
+++ b/http/error/APIError.go
@@ -1,0 +1,34 @@
+package httperror
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// When an API call fails, we may want to distinguish among the causes
+// by status code. This type can be used as the base error when we get
+// a non-"HTTP 20x" response, retrievable with errors.Cause(err).
+type APIError struct {
+	StatusCode int
+	Status     string
+	Body       string
+}
+
+func (err *APIError) Error() string {
+	return fmt.Sprintf("%s (%s)", err.Status, err.Body)
+}
+
+// Does this error mean the API service is unavailable?
+func (err *APIError) IsUnavailable() bool {
+	switch err.StatusCode {
+	case 502, 503, 504:
+		return true
+	}
+	return false
+}
+
+// Is this API call missing? This usually indicates that there is a
+// version mismatch between the client and the service.
+func (err *APIError) IsMissing() bool {
+	return err.StatusCode == http.StatusNotFound
+}

--- a/http/transport.go
+++ b/http/transport.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/api"
+	"github.com/weaveworks/flux/http/error"
 	"github.com/weaveworks/flux/http/websocket"
 	"github.com/weaveworks/flux/jobs"
 	"github.com/weaveworks/flux/platform"
@@ -76,34 +77,6 @@ func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger, h *stdprome
 		RouteMatcher: r,
 		Duration:     h,
 	}.Wrap(r)
-}
-
-// When an API call fails, we may want to distinguish among the causes
-// by status code. This type can be used as the base error when we get
-// a non-"HTTP 20x" response, retrievable with errors.Cause(err).
-type APIError struct {
-	StatusCode int
-	Status     string
-	Body       string
-}
-
-func (err *APIError) Error() string {
-	return fmt.Sprintf("%s (%s)", err.Status, err.Body)
-}
-
-// Does this error mean the API service is unavailable?
-func (err *APIError) IsUnavailable() bool {
-	switch err.StatusCode {
-	case 502, 503, 504:
-		return true
-	}
-	return false
-}
-
-// Is this API call missing? This usually indicates that there is a
-// version mismatch between the client and the service.
-func (err *APIError) IsMissing() bool {
-	return err.StatusCode == http.StatusNotFound
 }
 
 // The idea here is to place the handleFoo and invokeFoo functions next to each
@@ -845,7 +818,7 @@ func executeRequest(client *http.Client, req *http.Request) (*http.Response, err
 	default:
 		buf, _ := ioutil.ReadAll(resp.Body)
 		body := strings.TrimSpace(string(buf))
-		return nil, &APIError{
+		return nil, &httperror.APIError{
 			StatusCode: resp.StatusCode,
 			Status:     resp.Status,
 			Body:       body,


### PR DESCRIPTION
…rt cycles

This is required so that we can reuse the APIErrors struct and avoid import cycles. Since most requests start at transport.