### PR TITLE
Include service version in status output

### DIFF
--- a/cmd/fluxctl/status_cmd.go
+++ b/cmd/fluxctl/status_cmd.go
@@ -54,7 +54,6 @@ func (opts *statusOpts) RunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Since we always want to output whatever we got, use UnsafeInstanceConfig
 	bytes, err := marshal(status)
 	if err != nil {
 		return errors.Wrap(err, "marshalling to output format "+opts.output)

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -322,7 +322,7 @@ func main() {
 	}
 
 	// The server.
-	server := server.New(instancer, instanceDB, messageBus, jobStore, logger, serverMetrics)
+	server := server.New(version, instancer, instanceDB, messageBus, jobStore, logger, serverMetrics)
 
 	// Mechanical components.
 	errc := make(chan error)

--- a/server/server.go
+++ b/server/server.go
@@ -30,6 +30,7 @@ const (
 )
 
 type Server struct {
+	version     string
 	instancer   instance.Instancer
 	config      instance.DB
 	messageBus  platform.MessageBus
@@ -51,6 +52,7 @@ type Metrics struct {
 }
 
 func New(
+	version string,
 	instancer instance.Instancer,
 	config instance.DB,
 	messageBus platform.MessageBus,
@@ -60,6 +62,7 @@ func New(
 ) *Server {
 	metrics.ConnectedDaemons.Set(0)
 	return &Server{
+		version:     version,
 		instancer:   instancer,
 		config:      config,
 		messageBus:  messageBus,
@@ -100,6 +103,7 @@ func (s *Server) Status(inst flux.InstanceID) (res flux.Status, err error) {
 		res.Git.Error = strings.Replace(stderr.String(), "\r", "", -1)
 	}
 
+	res.Fluxsvc = flux.FluxsvcStatus{Version: s.version}
 	res.Fluxd.Version, err = helper.Version()
 	res.Fluxd.Connected = (err == nil)
 

--- a/service.go
+++ b/service.go
@@ -248,8 +248,13 @@ type HistoryEntry struct {
 
 // TODO: How similar should this be to the `get-config` result?
 type Status struct {
-	Fluxd FluxdStatus `json:"fluxd" yaml:"fluxd"`
-	Git   GitStatus   `json:"git" yaml:"git"`
+	Fluxsvc FluxsvcStatus `json:"fluxsvc" yaml:"fluxsvc"`
+	Fluxd   FluxdStatus   `json:"fluxd" yaml:"fluxd"`
+	Git     GitStatus     `json:"git" yaml:"git"`
+}
+
+type FluxsvcStatus struct {
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 }
 
 type FluxdStatus struct {


### PR DESCRIPTION
Handy for troubleshooting.

I've wired it directly through `server.New`, which seemed like the most direct way.