### PR TITLE
Use git output in errors

### DIFF
--- a/git/repo.go
+++ b/git/repo.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"io"
 	"io/ioutil"
 	"os"
 )
@@ -23,13 +22,13 @@ type Repo struct {
 	Path string
 }
 
-func (r Repo) Clone(stderr io.Writer) (path string, err error) {
+func (r Repo) Clone() (path string, err error) {
 	workingDir, err := ioutil.TempDir(os.TempDir(), "flux-gitclone")
 	if err != nil {
 		return "", err
 	}
 
-	repoDir, err := clone(stderr, workingDir, r.Key, r.URL, r.Branch)
+	repoDir, err := clone(workingDir, r.Key, r.URL, r.Branch)
 	return repoDir, err
 }
 

--- a/release/context.go
+++ b/release/context.go
@@ -22,7 +22,7 @@ func NewReleaseContext(inst *instance.Instance) *ReleaseContext {
 }
 
 func (rc *ReleaseContext) CloneRepo() error {
-	path, err := rc.Instance.ConfigRepo().Clone(nil)
+	path, err := rc.Instance.ConfigRepo().Clone()
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bytes"
 	"fmt"
 	"strings"
 	"sync/atomic"
@@ -97,10 +96,9 @@ func (s *Server) Status(inst flux.InstanceID) (res flux.Status, err error) {
 	}
 	res.Git.Configured = config.Settings.Git.URL != "" && config.Settings.Git.Key != ""
 
-	stderr := &bytes.Buffer{}
-	if _, err := helper.ConfigRepo().Clone(stderr); err != nil {
+	if _, err := helper.ConfigRepo().Clone(); err != nil {
 		// Remove \r, so it prints as a yaml block
-		res.Git.Error = strings.Replace(stderr.String(), "\r", "", -1)
+		res.Git.Error = strings.Replace(err.Error(), "\r", "", -1)
 	}
 
 	res.Fluxsvc = flux.FluxsvcStatus{Version: s.version}


### PR DESCRIPTION
At the minute, if the git commands (in particular, clone and push)
fail, the user is presented with the error from os/exec.Run() which is
more or less an opaque exit code.

To be a bit more informative, we can instead take the output to stderr
and look for a "fatal:" line, which generally gives a compact
description of what actually went wrong.

This affects `fluxctl status` and `fluxctl release`.

Before:
```
$ fluxctl release --service=default/helloworld --update-image=quay.io/weaveworks/helloworld:master-a000002
Submitting release job...
Release job submitted, ID aea26bcf-3fc6-89ad-f1dc-36ab4e19b14d
Status: Failed: clone the config repo: git clone: exit status 128

Here's as far as we got:
 1) Queued.
 2) Calculating release actions.
 3) Release quay.io/weaveworks/helloworld:master-a000002 to default/helloworld
 4) Clone the config repo.
 5) clone the config repo: git clone: exit status 128
 6) Failed: clone the config repo: git clone: exit status 128
Took 2.769526s
```

After:
```
$ fluxctl release --service=default/helloworld --update-image=quay.io/weaveworks/helloworld:master-a000002
Submitting release job...
Release job submitted, ID 976d74b3-3538-1af1-d528-dea75daf4a2b
Status: Failed: clone the config repo: git clone: fatal: Could not read from remote repository.

Here's as far as we got:
 1) Queued.
 2) Calculating release actions.
 3) Release quay.io/weaveworks/helloworld:master-a000002 to default/helloworld
 4) Clone the config repo.
 5) clone the config repo: git clone: fatal: Could not read from remote repository.
 6) Failed: clone the config repo: git clone: fatal: Could not read from remote repository.
Took 3.447257s
```