### PR TITLE
Increase k8s client-go rate limits

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -68,6 +68,9 @@ func main() {
 			os.Exit(1)
 		}
 
+		restClientConfig.QPS = 50.0
+		restClientConfig.Burst = 100
+
 		// When adding a new platform, don't just bash it in. Create a Platform
 		// or Cluster interface in package platform, and have kubernetes.Cluster
 		// and your new platform implement that interface.


### PR DESCRIPTION
By default the k8s client is throttled to 5 QPS, which is insufficient
given that listing services costs three queries per namespace. Increase
the default by an order of magnitude as a workaround until we move to
the client-side caching framework.