### PR TITLE
refactor metrics instantiation in fluxsvc for easier testing

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -9,8 +9,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics/prometheus"
-	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/pflag"
 	"k8s.io/client-go/1.5/rest"
@@ -92,20 +90,6 @@ func main() {
 		k8s = cluster
 	}
 
-	// Instrumentation
-	var (
-		daemonMetrics transport.DaemonMetrics
-	)
-	{
-		k8s = platform.Instrument(k8s, platform.NewMetrics())
-		daemonMetrics.ConnectionDuration = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
-			Namespace: "flux",
-			Subsystem: "fluxd",
-			Name:      "connection_duration_seconds",
-			Help:      "Duration in seconds of the current connection to fluxsvc. Zero means unconnected.",
-		}, []string{"target"})
-	}
-
 	// Connect to fluxsvc
 	daemonLogger := log.NewContext(logger).With("component", "client")
 	daemon, err := transport.NewDaemon(
@@ -115,7 +99,6 @@ func main() {
 		*fluxsvcAddress,
 		k8s,
 		daemonLogger,
-		daemonMetrics,
 	)
 	if err != nil {
 		logger.Log("err", err)

--- a/http/metrics.go
+++ b/http/metrics.go
@@ -1,0 +1,15 @@
+package http
+
+import (
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
+)
+
+var (
+	requestDuration = stdprometheus.NewHistogramVec(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Name:      "request_duration_seconds",
+		Help:      "Time (in seconds) spent serving HTTP requests.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelRoute, "status_code", "ws"})
+)

--- a/http/transport.go
+++ b/http/transport.go
@@ -16,7 +16,6 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
-	stdprometheus "github.com/prometheus/client_golang/prometheus"
 	"github.com/weaveworks/common/middleware"
 
 	"github.com/weaveworks/flux"
@@ -50,7 +49,7 @@ func NewRouter() *mux.Router {
 	return r
 }
 
-func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger, h *stdprometheus.HistogramVec) http.Handler {
+func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger) http.Handler {
 	for method, handlerFunc := range map[string]func(api.FluxService) http.Handler{
 		"ListServices":           handleListServices,
 		"ListImages":             handleListImages,
@@ -78,7 +77,7 @@ func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger, h *stdprome
 
 	return middleware.Instrument{
 		RouteMatcher: r,
-		Duration:     h,
+		Duration:     requestDuration,
 	}.Wrap(r)
 }
 

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
@@ -25,7 +24,6 @@ type Instance struct {
 	Platform platform.Platform
 	Registry registry.Registry
 	Config   Configurer
-	Duration metrics.Histogram
 	Repo     git.Repo
 
 	log.Logger
@@ -39,7 +37,6 @@ func New(
 	config Configurer,
 	gitrepo git.Repo,
 	logger log.Logger,
-	duration metrics.Histogram,
 	events history.EventReader,
 	eventlog history.EventWriter,
 ) *Instance {
@@ -48,7 +45,6 @@ func New(
 		Registry:    registry,
 		Config:      config,
 		Repo:        gitrepo,
-		Duration:    duration,
 		Logger:      logger,
 		EventReader: events,
 		EventWriter: eventlog,
@@ -195,7 +191,7 @@ func (h *Instance) imageExists(imageID flux.ImageID) (bool, error) {
 
 func (h *Instance) PlatformApply(defs []platform.ServiceDefinition) (err error) {
 	defer func(begin time.Time) {
-		h.Duration.With(
+		releaseHelperDuration.With(
 			fluxmetrics.LabelMethod, "PlatformApply",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())

--- a/instance/multi.go
+++ b/instance/multi.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
@@ -18,9 +17,7 @@ type MultitenantInstancer struct {
 	DB                  DB
 	Connecter           platform.Connecter
 	Logger              log.Logger
-	Histogram           metrics.Histogram
 	History             history.DB
-	RegistryMetrics     registry.Metrics
 	MemcacheClient      registry.MemcacheClient
 	RegistryCacheExpiry time.Duration
 }
@@ -49,9 +46,8 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 	reg := registry.NewRegistry(
 		registry.NewRemoteClientFactory(creds, registryLogger, m.MemcacheClient, m.RegistryCacheExpiry),
 		registryLogger,
-		m.RegistryMetrics,
 	)
-	reg = registry.NewInstrumentedRegistry(reg, m.RegistryMetrics)
+	reg = registry.NewInstrumentedRegistry(reg)
 
 	repo := gitRepoFromSettings(c.Settings)
 
@@ -67,7 +63,6 @@ func (m *MultitenantInstancer) Get(instanceID flux.InstanceID) (*Instance, error
 		config,
 		repo,
 		instanceLogger,
-		m.Histogram,
 		eventRW,
 		eventRW,
 	), nil

--- a/instance/standalone.go
+++ b/instance/standalone.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 
 	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/metrics"
-
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/history"
@@ -15,15 +13,14 @@ import (
 
 // StandaloneInstancer is the instancer for standalone mode
 type StandaloneInstancer struct {
-	Instance     flux.InstanceID
-	Connecter    platform.Connecter
-	Registry     registry.Registry
-	Config       Configurer
-	GitRepo      git.Repo
-	EventReader  history.EventReader
-	EventWriter  history.EventWriter
-	BaseLogger   log.Logger
-	BaseDuration metrics.Histogram
+	Instance    flux.InstanceID
+	Connecter   platform.Connecter
+	Registry    registry.Registry
+	Config      Configurer
+	GitRepo     git.Repo
+	EventReader history.EventReader
+	EventWriter history.EventWriter
+	BaseLogger  log.Logger
 }
 
 func (s StandaloneInstancer) Get(inst flux.InstanceID) (*Instance, error) {
@@ -40,7 +37,6 @@ func (s StandaloneInstancer) Get(inst flux.InstanceID) (*Instance, error) {
 		s.Config,
 		s.GitRepo,
 		log.NewContext(s.BaseLogger).With("instanceID", s.Instance),
-		s.BaseDuration,
 		s.EventReader,
 		s.EventWriter,
 	), nil

--- a/jobs/metrics.go
+++ b/jobs/metrics.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/prometheus"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
 
@@ -13,26 +12,35 @@ import (
 )
 
 type instrumentedJobStore struct {
-	js              JobStore
-	RequestDuration metrics.Histogram
+	js JobStore
 }
+
+var (
+	requestDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "jobs",
+		Name:      "request_duration_seconds",
+		Help:      "Request duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelSuccess})
+	jobDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "jobs",
+		Name:      "job_duration_seconds",
+		Help:      "Job duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelSuccess})
+)
 
 func InstrumentedJobStore(js JobStore) JobStore {
 	return &instrumentedJobStore{
 		js: js,
-		RequestDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
-			Namespace: "flux",
-			Subsystem: "jobs",
-			Name:      "request_duration_seconds",
-			Help:      "Request duration in seconds.",
-			Buckets:   stdprometheus.DefBuckets,
-		}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelSuccess}),
 	}
 }
 
 func (i *instrumentedJobStore) GetJob(inst flux.InstanceID, jobID JobID) (j Job, err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "GetJob",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
@@ -42,7 +50,7 @@ func (i *instrumentedJobStore) GetJob(inst flux.InstanceID, jobID JobID) (j Job,
 
 func (i *instrumentedJobStore) PutJob(inst flux.InstanceID, j Job) (jobID JobID, err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "PutJob",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
@@ -52,7 +60,7 @@ func (i *instrumentedJobStore) PutJob(inst flux.InstanceID, j Job) (jobID JobID,
 
 func (i *instrumentedJobStore) PutJobIgnoringDuplicates(inst flux.InstanceID, j Job) (jobID JobID, err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "PutJobIgnoringDuplicates",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
@@ -62,7 +70,7 @@ func (i *instrumentedJobStore) PutJobIgnoringDuplicates(inst flux.InstanceID, j 
 
 func (i *instrumentedJobStore) UpdateJob(j Job) (err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "UpdateJob",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
@@ -72,7 +80,7 @@ func (i *instrumentedJobStore) UpdateJob(j Job) (err error) {
 
 func (i *instrumentedJobStore) Heartbeat(jobID JobID) (err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "Heartbeat",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
@@ -82,7 +90,7 @@ func (i *instrumentedJobStore) Heartbeat(jobID JobID) (err error) {
 
 func (i *instrumentedJobStore) NextJob(queues []string) (j Job, err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "NextJob",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
@@ -92,26 +100,10 @@ func (i *instrumentedJobStore) NextJob(queues []string) (j Job, err error) {
 
 func (i *instrumentedJobStore) GC() (err error) {
 	defer func(begin time.Time) {
-		i.RequestDuration.With(
+		requestDuration.With(
 			fluxmetrics.LabelMethod, "GC",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return i.js.GC()
-}
-
-type WorkerMetrics struct {
-	JobDuration metrics.Histogram
-}
-
-func NewWorkerMetrics() WorkerMetrics {
-	return WorkerMetrics{
-		JobDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
-			Namespace: "flux",
-			Subsystem: "jobs",
-			Name:      "job_duration_seconds",
-			Help:      "Job duration in seconds.",
-			Buckets:   stdprometheus.DefBuckets,
-		}, []string{fluxmetrics.LabelMethod, fluxmetrics.LabelSuccess}),
-	}
 }

--- a/jobs/worker.go
+++ b/jobs/worker.go
@@ -26,7 +26,6 @@ type Handler interface {
 type Worker struct {
 	jobs     JobStore
 	handlers map[string]Handler
-	metrics  WorkerMetrics
 	logger   log.Logger
 	queues   []string
 	stopping chan struct{}
@@ -38,13 +37,11 @@ type Worker struct {
 func NewWorker(
 	jobs JobStore,
 	logger log.Logger,
-	metrics WorkerMetrics,
 	queues []string,
 ) *Worker {
 	return &Worker{
 		jobs:     jobs,
 		handlers: map[string]Handler{},
-		metrics:  metrics,
 		logger:   logger,
 		queues:   queues,
 		stopping: make(chan struct{}),
@@ -95,7 +92,7 @@ func (w *Worker) Work() {
 		} else {
 			followUps, err = handler.Handle(&job, w.jobs)
 		}
-		w.metrics.JobDuration.With(
+		jobDuration.With(
 			fluxmetrics.LabelMethod, job.Method,
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())

--- a/platform/rpc/nats/bus_test.go
+++ b/platform/rpc/nats/bus_test.go
@@ -15,7 +15,7 @@ import (
 
 var testNATS = flag.String("nats-url", "", "NATS connection URL; use NATS' default if empty")
 
-var metrics = platform.NewBusMetrics()
+var metrics = platform.BusMetricsImpl
 
 func setup(t *testing.T) *NATS {
 	flag.Parse()

--- a/platform/standalone_test.go
+++ b/platform/standalone_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestStandaloneMessageBus(t *testing.T) {
 	instID := flux.InstanceID("instance")
-	bus := NewStandaloneMessageBus(NewBusMetrics())
+	bus := NewStandaloneMessageBus(BusMetricsImpl)
 	p := &MockPlatform{}
 
 	done := make(chan error)

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -12,21 +12,19 @@ import (
 type InstrumentedRegistry Registry
 
 type instrumentedRegistry struct {
-	next    Registry
-	metrics Metrics
+	next Registry
 }
 
-func NewInstrumentedRegistry(next Registry, metrics Metrics) InstrumentedRegistry {
+func NewInstrumentedRegistry(next Registry) InstrumentedRegistry {
 	return &instrumentedRegistry{
-		next:    next,
-		metrics: metrics,
+		next: next,
 	}
 }
 
 func (m *instrumentedRegistry) GetRepository(repository Repository) (res []flux.Image, err error) {
 	start := time.Now()
 	res, err = m.next.GetRepository(repository)
-	m.metrics.FetchDuration.With(
+	fetchDuration.With(
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())
 	return
@@ -35,7 +33,7 @@ func (m *instrumentedRegistry) GetRepository(repository Repository) (res []flux.
 func (m *instrumentedRegistry) GetImage(repository Repository, tag string) (res flux.Image, err error) {
 	start := time.Now()
 	res, err = m.next.GetImage(repository, tag)
-	m.metrics.FetchDuration.With(
+	fetchDuration.With(
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())
 	return
@@ -44,21 +42,19 @@ func (m *instrumentedRegistry) GetImage(repository Repository, tag string) (res 
 type InstrumentedRemote Remote
 
 type instrumentedRemote struct {
-	next    Remote
-	metrics Metrics
+	next Remote
 }
 
-func NewInstrumentedRemote(next Remote, metrics Metrics) Remote {
+func NewInstrumentedRemote(next Remote) Remote {
 	return &instrumentedRemote{
-		next:    next,
-		metrics: metrics,
+		next: next,
 	}
 }
 
 func (m *instrumentedRemote) Manifest(repository Repository, tag string) (res flux.Image, err error) {
 	start := time.Now()
 	res, err = m.next.Manifest(repository, tag)
-	m.metrics.RequestDuration.With(
+	requestDuration.With(
 		LabelRequestKind, RequestKindMetadata,
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())
@@ -68,7 +64,7 @@ func (m *instrumentedRemote) Manifest(repository Repository, tag string) (res fl
 func (m *instrumentedRemote) Tags(repository Repository) (res []string, err error) {
 	start := time.Now()
 	res, err = m.next.Tags(repository)
-	m.metrics.RequestDuration.With(
+	requestDuration.With(
 		LabelRequestKind, RequestKindTags,
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -24,15 +24,13 @@ type Registry interface {
 type registry struct {
 	factory RemoteClientFactory
 	Logger  log.Logger
-	Metrics Metrics
 }
 
 // NewClient creates a new registry registry, to use when fetching repositories.
-func NewRegistry(c RemoteClientFactory, l log.Logger, m Metrics) Registry {
+func NewRegistry(c RemoteClientFactory, l log.Logger) Registry {
 	return &registry{
 		factory: c,
 		Logger:  l,
-		Metrics: m,
 	}
 }
 
@@ -78,7 +76,7 @@ func (reg *registry) newRemote(img Repository) (rem Remote, err error) {
 	if err != nil {
 		return
 	}
-	rem = NewInstrumentedRemote(rem, reg.Metrics)
+	rem = NewInstrumentedRemote(rem)
 	return
 }
 

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -13,15 +13,14 @@ import (
 )
 
 var (
-	testTags            = []string{testTagStr, "anotherTag"}
-	mRemote             = NewMockRemote(img, testTags, nil)
-	mRemoteFact         = NewMockRemoteFactory(mRemote, nil)
-	testRegistryMetrics = NewMetrics()
-	testTime, _         = time.Parse(constTime, time.RFC3339Nano)
+	testTags    = []string{testTagStr, "anotherTag"}
+	mRemote     = NewMockRemote(img, testTags, nil)
+	mRemoteFact = NewMockRemoteFactory(mRemote, nil)
+	testTime, _ = time.Parse(constTime, time.RFC3339Nano)
 )
 
 func TestRegistry_GetImage(t *testing.T) {
-	reg := NewRegistry(mRemoteFact, log.NewNopLogger(), testRegistryMetrics)
+	reg := NewRegistry(mRemoteFact, log.NewNopLogger())
 	newImg, err := reg.GetImage(testRepository, img.Tag)
 	if err != nil {
 		t.Fatal(err)
@@ -33,7 +32,7 @@ func TestRegistry_GetImage(t *testing.T) {
 
 func TestRegistry_GetImageFactoryErr(t *testing.T) {
 	errFact := NewMockRemoteFactory(mRemote, errors.New(""))
-	reg := NewRegistry(errFact, nil, testRegistryMetrics)
+	reg := NewRegistry(errFact, nil)
 	_, err := reg.GetImage(testRepository, img.Tag)
 	if err == nil {
 		t.Fatal("Expecting error")
@@ -43,7 +42,7 @@ func TestRegistry_GetImageFactoryErr(t *testing.T) {
 func TestRegistry_GetImageRemoteErr(t *testing.T) {
 	r := NewMockRemote(img, testTags, errors.New(""))
 	errFact := NewMockRemoteFactory(r, nil)
-	reg := NewRegistry(errFact, log.NewNopLogger(), testRegistryMetrics)
+	reg := NewRegistry(errFact, log.NewNopLogger())
 	_, err := reg.GetImage(testRepository, img.Tag)
 	if err == nil {
 		t.Fatal("Expecting error")
@@ -51,7 +50,7 @@ func TestRegistry_GetImageRemoteErr(t *testing.T) {
 }
 
 func TestRegistry_GetRepository(t *testing.T) {
-	reg := NewRegistry(mRemoteFact, log.NewNopLogger(), testRegistryMetrics)
+	reg := NewRegistry(mRemoteFact, log.NewNopLogger())
 	imgs, err := reg.GetRepository(testRepository)
 	if err != nil {
 		t.Fatal(err)
@@ -65,7 +64,7 @@ func TestRegistry_GetRepository(t *testing.T) {
 
 func TestRegistry_GetRepositoryFactoryError(t *testing.T) {
 	errFact := NewMockRemoteFactory(mRemote, errors.New(""))
-	reg := NewRegistry(errFact, nil, testRegistryMetrics)
+	reg := NewRegistry(errFact, nil)
 	_, err := reg.GetRepository(testRepository)
 	if err == nil {
 		t.Fatal("Expecting error")
@@ -75,7 +74,7 @@ func TestRegistry_GetRepositoryFactoryError(t *testing.T) {
 func TestRegistry_GetRepositoryRemoteErr(t *testing.T) {
 	r := NewMockRemote(img, testTags, errors.New(""))
 	errFact := NewMockRemoteFactory(r, nil)
-	reg := NewRegistry(errFact, log.NewNopLogger(), testRegistryMetrics)
+	reg := NewRegistry(errFact, log.NewNopLogger())
 	_, err := reg.GetRepository(testRepository)
 	if err == nil {
 		t.Fatal("Expecting error")
@@ -85,7 +84,7 @@ func TestRegistry_GetRepositoryRemoteErr(t *testing.T) {
 func TestRegistry_GetRepositoryManifestError(t *testing.T) {
 	r := NewMockRemote(img, []string{"valid", "error"}, nil)
 	errFact := NewMockRemoteFactory(r, nil)
-	reg := NewRegistry(errFact, log.NewNopLogger(), testRegistryMetrics)
+	reg := NewRegistry(errFact, log.NewNopLogger())
 	_, err := reg.GetRepository(testRepository)
 	if err == nil {
 		t.Fatal("Expecting error")

--- a/release/metrics.go
+++ b/release/metrics.go
@@ -1,37 +1,29 @@
 package release
 
 import (
-	fluxmetrics "github.com/weaveworks/flux/metrics"
-
 	"github.com/go-kit/kit/metrics"
 	"github.com/go-kit/kit/metrics/prometheus"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
 )
 
-type Metrics struct {
-	ReleaseDuration metrics.Histogram
-	StageDuration   metrics.Histogram
-}
+var (
+	releaseDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "release_duration_seconds",
+		Help:      "Release method duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelReleaseType, fluxmetrics.LabelReleaseKind, fluxmetrics.LabelSuccess})
+	stageDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "release_stage_duration_seconds",
+		Help:      "Duration in seconds of each stage of a release, including dry-runs.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelStage})
+)
 
-func NewMetrics() Metrics {
-	return Metrics{
-		ReleaseDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
-			Namespace: "flux",
-			Subsystem: "fluxsvc",
-			Name:      "release_duration_seconds",
-			Help:      "Release method duration in seconds.",
-			Buckets:   stdprometheus.DefBuckets,
-		}, []string{fluxmetrics.LabelReleaseType, fluxmetrics.LabelReleaseKind, fluxmetrics.LabelSuccess}),
-		StageDuration: prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
-			Namespace: "flux",
-			Subsystem: "fluxsvc",
-			Name:      "release_stage_duration_seconds",
-			Help:      "Duration in seconds of each stage of a release, including dry-runs.",
-			Buckets:   stdprometheus.DefBuckets,
-		}, []string{fluxmetrics.LabelStage}),
-	}
-}
-
-func (m Metrics) NewStageTimer(stage string) *metrics.Timer {
-	return metrics.NewTimer(m.StageDuration.With(fluxmetrics.LabelStage, stage))
+func NewStageTimer(stage string) *metrics.Timer {
+	return metrics.NewTimer(stageDuration.With(fluxmetrics.LabelStage, stage))
 }

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -16,14 +16,7 @@ import (
 	"github.com/weaveworks/flux/registry"
 
 	"github.com/go-kit/kit/log"
-	metrics "github.com/go-kit/kit/metrics/discard"
 )
-
-var discardHistogram = metrics.NewHistogram()
-var testMetrics = Metrics{
-	ReleaseDuration: discardHistogram,
-	StageDuration:   discardHistogram,
-}
 
 func setup(t *testing.T, mocks instance.Instance) (*Releaser, func()) {
 	repo, cleanup := setupRepo(t)
@@ -42,10 +35,9 @@ func setup(t *testing.T, mocks instance.Instance) (*Releaser, func()) {
 	events := history.NewMock()
 	mocks.EventReader, mocks.EventWriter = events, events
 	mocks.Logger = log.NewNopLogger()
-	mocks.Duration = discardHistogram
 
 	instancer := &instance.MockInstancer{&mocks, nil}
-	return NewReleaser(instancer, testMetrics), cleanup
+	return NewReleaser(instancer), cleanup
 }
 
 func TestMissingFromPlatform(t *testing.T) {

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+	fluxmetrics "github.com/weaveworks/flux/metrics"
+)
+
+var (
+	statusDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "status_duration_seconds",
+		Help:      "Status method duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelSuccess})
+	listServicesDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "list_services_duration_seconds",
+		Help:      "ListServices method duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelSuccess})
+	listImagesDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "list_images_duration_seconds",
+		Help:      "ListImages method duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{"service_spec_all", fluxmetrics.LabelSuccess})
+	historyDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "history_duration_seconds",
+		Help:      "History method duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{"service_spec_all", fluxmetrics.LabelSuccess})
+	registerDaemonDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "register_daemon_duration_seconds",
+		Help:      "RegisterDaemon method duration in seconds.",
+		Buckets:   stdprometheus.DefBuckets,
+	}, []string{fluxmetrics.LabelSuccess})
+	connectedDaemons = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		Namespace: "flux",
+		Subsystem: "fluxsvc",
+		Name:      "connected_daemons_count",
+		Help:      "Gauge of the current number of connected daemons",
+	}, []string{})
+)


### PR DESCRIPTION
Created a new method to instantiate all metrics for ease of use.
Moved hardcoded metrics to dedicated metrics files in the same package as the rest of the code.