### PR TITLE
WIP: add humane error type

### DIFF
--- a/errors/humane_error.go
+++ b/errors/humane_error.go
@@ -1,0 +1,131 @@
+package errors
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"runtime"
+)
+
+type HumaneError struct {
+	Cause   error       `json:"cause"`   // Another error that caused this one
+	Code    int         `json:"code"`    // Generally (but not necessarily) a HTTP status code.
+	Help    string      `json:"help"`    // A user facing message
+	Details interface{} `json:"details"` // Encode developer messages in here
+	Stack   Stack       `json:"stack"`   // The stack trace for this call
+}
+
+// New returns a smashing humane error
+func New(code int, usrMsg string, details interface{}) *HumaneError {
+	return Wrap(nil, code, usrMsg, details)
+}
+
+// Wrap follows pkg.errors convention and nests an error within a new error
+func Wrap(err error, code int, usrMsg string, details interface{}) *HumaneError {
+	return &HumaneError{
+		Cause:   err,
+		Code:    code,
+		Help:    usrMsg,
+		Details: details,
+		Stack:   stackTrace(),
+	}
+}
+
+func CoverallError(err error) *HumaneError {
+	return Wrap(err, http.StatusInternalServerError,
+		`An error occured for which we don't have a specific message.
+
+	 If you see this, it means we need to come up with a better message! It
+	 would help us if you log an issue at
+	 https://github.com/weaveworks/flux/issues saying what you were doing
+	 when you saw this, and quoting the following:
+
+	     `, nil)
+}
+
+// Error satisfies the error interface.
+func (e *HumaneError) Error() string {
+	return fmt.Sprintf("%s Caused by: %q", e.Help, e.RootCause().Error())
+}
+
+func (e *HumaneError) RootCause() error {
+	if e.Cause == nil {
+		return e
+	}
+	next, isHumane := e.Cause.(*HumaneError)
+	if isHumane {
+		return next.RootCause()
+	}
+	return e.Cause
+}
+
+// For use in logs
+type LogError struct {
+	HumaneError
+}
+
+func (e *LogError) Error() string {
+	var buffer bytes.Buffer
+	buffer.WriteString(fmt.Sprintf("Error %d: %s\n %#v%s", e.Code, e.Help, e.Details, e.Stack.String()))
+	if e.Cause != nil {
+		buffer.WriteString("\n\nCaused by:\n")
+		buffer.WriteString(e.Cause.Error())
+	}
+	return buffer.String()
+}
+
+// For use in HTTP writers
+type JSONError struct {
+	HumaneError
+}
+
+func (e *JSONError) Error() string {
+	b, _ := json.MarshalIndent(e, "", "\t")
+	return string(b)
+}
+
+// Stack represents the full stack trace
+type Stack []StackFrame
+
+// StackFrame represents a single frame of a stack trace
+type StackFrame struct {
+	File     string `json:"file,omitempty"`
+	Line     int    `json:"line,omitempty"`
+	Function string `json:"function,omitempty"`
+}
+
+// String converts a stack trace to a string
+func (s Stack) String() string {
+	var buffer bytes.Buffer
+	for _, v := range s {
+		buffer.WriteString(fmt.Sprintf("\n- %s:%d %s", v.File, v.Line, v.Function))
+	}
+	return buffer.String()
+}
+
+// stackTrace gets the current stack trace
+func stackTrace() Stack {
+	stack := make([]StackFrame, 0)
+	for i := 2; ; i++ {
+		pc, fn, line, ok := runtime.Caller(i)
+		if !ok {
+			// no more frames - we're done
+			break
+		}
+		_, fn = filepath.Split(fn)
+
+		f := StackFrame{File: fn, Line: line, Function: funcName(pc)}
+		stack = append(stack, f)
+	}
+	return stack
+}
+
+// funcName gets the name of the function at pointer or "??" if one can't be found
+func funcName(pc uintptr) string {
+	if f := runtime.FuncForPC(pc); f != nil {
+		return f.Name()
+	}
+	return "??"
+}

--- a/errors/humane_error_test.go
+++ b/errors/humane_error_test.go
@@ -1,0 +1,52 @@
+package errors
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"net/http"
+	"testing"
+)
+
+func TestHumaneError_ErrorInterface(t *testing.T) {
+	err := longError()
+	fmt.Println(err.Error())
+	if err.Error() == "" {
+		t.Fatal("Should not compile, let alone fail.")
+	}
+}
+
+func TestHumaneError_RootCause(t *testing.T) {
+	err := longError()
+	if err.RootCause().Error() != "test error" {
+		t.Fatal("Root cause didn't match the root cause.", err.RootCause())
+	}
+}
+
+func TestHumaneError_Facade(t *testing.T) {
+	// Not much we can test here
+	err := longError()
+	lErr := LogError{
+		HumaneError: *err,
+	}
+	jErr := JSONError{
+		HumaneError: *err,
+	}
+	t.Log(lErr.Error())
+	t.Log(jErr.Error())
+}
+
+func TestHumaneError_Coverall(t *testing.T) {
+	err := CoverallError(errors.New("Some error"))
+	t.Log(err.Error())
+}
+
+func longError() *HumaneError {
+	err := errors.New("test error")
+	he := Wrap(err, http.StatusNoContent, "user message", struct {
+		Test string
+	}{"testData"})
+	return Wrap(he, http.StatusInternalServerError, "top message", struct {
+		User string
+		ID   string
+	}{"Phil", "123"})
+}


### PR DESCRIPTION
This is intended to keep track of errors as they flow back through the system.
They can contain user and developer messages.
User messages are encoded in the traditional Error interface.
Other messages are behind a facade.