### PR TITLE
Periodically boot web socket connections

### DIFF
--- a/http/transport.go
+++ b/http/transport.go
@@ -494,7 +494,7 @@ func handleRegister(s api.FluxService) http.Handler {
 
 		// Clean up
 		// TODO: Handle the error here
-		rpcClient.Close()
+		rpcClient.Close() // also closes the underlying socket
 	})
 }
 

--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -340,7 +340,6 @@ func (n *NATS) Subscribe(instID flux.InstanceID, remote platform.Platform, done 
 			// consequence of asynchronous request handling. The error will get
 			// selected and handled soon enough.
 			case err := <-errc:
-				close(errc)
 				sub.Unsubscribe()
 				close(requests)
 				done <- err

--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -15,7 +15,13 @@ import (
 )
 
 const (
-	timeout      = 5 * time.Second
+	// We give subscriptions an age limit, because if we have very
+	// long-lived connections we don't get fine-enough-grained usage
+	// metrics
+	maxAge  = 2 * time.Hour
+	timeout = 5 * time.Second
+	// Apply can take minutes, simply because some deployments take a
+	// while to roll out for whatever reason
 	applyTimeout = 20 * time.Minute
 	presenceTick = 50 * time.Millisecond
 	encoderType  = nats.JSON_ENCODER
@@ -321,6 +327,8 @@ func (n *NATS) Subscribe(instID flux.InstanceID, remote platform.Platform, done 
 	}
 
 	go func() {
+		forceReconnect := time.NewTimer(maxAge)
+		defer forceReconnect.Stop()
 		for {
 			select {
 			// If both an error and a request are available, the runtime may
@@ -342,6 +350,11 @@ func (n *NATS) Subscribe(instID flux.InstanceID, remote platform.Platform, done 
 				// dispatch in a goroutine and deliver any errors back to us so that we can
 				// clean up on any hard failures.
 				go processRequest(request)
+			case <-forceReconnect.C:
+				sub.Unsubscribe()
+				close(requests)
+				done <- nil
+				return
 			}
 		}
 	}()

--- a/server/server.go
+++ b/server/server.go
@@ -412,7 +412,6 @@ func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.Platfo
 	done := make(chan error)
 	s.messageBus.Subscribe(instID, s.instrumentPlatform(instID, platform), done)
 	err = <-done
-	close(done)
 	return err
 }
 


### PR DESCRIPTION
For usage stats, we report on HTTP transactions; and websocket
connections are effectively long-running HTTP transactions. Naively,
if a websocket is open over several days, it will get counted as a
"use" only at the end, so only once.

To get more accurate stats, we can limit the age of websocket
connections, so connections are reported more often. The limit will of
course affect how many transactions are reported; however, the thing
we generally care about is _distinct_ connections, i.e., the number of
daemons connected. A limit of two hours is somewhat arbitrary --
anything (much) less than a day would do.

The disconnection is done on the application layer (in bus.go), so
that it doesn't happen in the middle of an operation. Exiting there
prompts the server to close the RPC client, which itself closes the
underlying websocket, to which the daemon responds by reconnecting
immediately.

Fixes #290.