### PR TITLE
Implement `fluxctl save`

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -20,6 +20,7 @@ type ClientService interface {
 	GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
 	GenerateDeployKey(flux.InstanceID) error
+	Export(inst flux.InstanceID) ([]byte, error)
 }
 
 type DaemonService interface {

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -81,6 +81,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		newServiceUnlock(svcopts).Command(),
 		newGetConfig(opts).Command(),
 		newSetConfig(opts).Command(),
+		newSave(opts).Command(),
 	)
 
 	return cmd

--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -1,0 +1,215 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type saveOpts struct {
+	*rootOpts
+	output string
+}
+
+func newSave(parent *rootOpts) *saveOpts {
+	return &saveOpts{rootOpts: parent}
+}
+
+func (opts *saveOpts) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "save",
+		Short: "save service definitions to local files in platform-native format",
+		Example: makeExample(
+			"fluxctl save",
+		),
+		RunE: opts.RunE,
+	}
+	return cmd
+}
+
+// Deliberately omit fields (e.g. status, metadata.uid) that we don't want to save
+type saveObject struct {
+	APIVersion string `yaml:"apiVersion,omitempty"`
+	Kind       string `yaml:"kind,omitempty"`
+
+	Metadata struct {
+		Annotations map[string]string `yaml:"annotations,omitempty"`
+		Labels      map[string]string `yaml:"labels,omitempty"`
+		Name        string            `yaml:"name,omitempty"`
+		Namespace   string            `yaml:"namespace,omitempty"`
+	} `yaml:"metadata,omitempty"`
+
+	Spec map[interface{}]interface{} `yaml:"spec,omitempty"`
+}
+
+func (opts *saveOpts) RunE(_ *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return errorWantedNoArgs
+	}
+
+	config, err := opts.API.Export(noInstanceID)
+	if err != nil {
+		return errors.Wrap(err, "exporting config")
+	}
+
+	yamls := bufio.NewScanner(bytes.NewReader(config))
+	yamls.Split(splitYAMLDocument)
+
+	for yamls.Scan() {
+		var object saveObject
+		// Most unwanted fields are ignored at this point
+		if err := yaml.Unmarshal(yamls.Bytes(), &object); err != nil {
+			return errors.Wrap(err, "unmarshalling exported yaml")
+		}
+
+		// Filter out remaining unwanted keys from unstructured fields
+		// e.g. .Spec and .Metadata.Annotations
+		filterObject(object)
+
+		if err := saveYAML(object); err != nil {
+			return errors.Wrap(err, "saving yaml object")
+		}
+	}
+
+	if yamls.Err() != nil {
+		return errors.Wrap(yamls.Err(), "splitting exported yaml")
+	}
+
+	return nil
+}
+
+// Remove any data that should not be version controlled
+func filterObject(object saveObject) {
+	delete(object.Metadata.Annotations, "deployment.kubernetes.io/revision")
+	delete(object.Metadata.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	deleteNested(object.Spec, "template", "metadata", "creationTimestamp")
+	deleteEmptyMapValues(object.Spec)
+}
+
+// Recurse through nested maps to remove a key
+func deleteNested(m map[interface{}]interface{}, keys ...string) {
+	switch len(keys) {
+	case 0:
+		return
+	case 1:
+		delete(m, keys[0])
+	default:
+		if v, ok := m[keys[0]].(map[interface{}]interface{}); ok {
+			deleteNested(v, keys[1:]...)
+		}
+	}
+}
+
+// Recursively delete map keys with empty values
+func deleteEmptyMapValues(i interface{}) bool {
+	switch i := i.(type) {
+	case map[interface{}]interface{}:
+		if len(i) == 0 {
+			return true
+		} else {
+			for k, v := range i {
+				if deleteEmptyMapValues(v) {
+					delete(i, k)
+				}
+			}
+		}
+	case []interface{}:
+		if len(i) == 0 {
+			return true
+		} else {
+			for _, e := range i {
+				deleteEmptyMapValues(e)
+			}
+		}
+	case nil:
+		return true
+	}
+	return false
+}
+
+// Save YAML to directory structure
+func saveYAML(object saveObject) error {
+	var path string
+	if object.Kind == "Namespace" {
+		path = fmt.Sprintf("%s-ns.yaml", object.Metadata.Name)
+	} else {
+		dir := object.Metadata.Namespace
+		if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+			return errors.Wrap(err, "making directory for namespace")
+		}
+
+		shortKind := abbreviateKind(object.Kind)
+		path = fmt.Sprintf("%s/%s-%s.yaml", dir, object.Metadata.Name, shortKind)
+	}
+
+	fmt.Printf("Saving %s '%s' to %s\n", object.Kind, object.Metadata.Name, path)
+
+	file, err := os.Create(path)
+	if err != nil {
+		return errors.Wrap(err, "creating yaml file")
+	}
+	defer file.Close()
+
+	buf, err := yaml.Marshal(object)
+	if err != nil {
+		return errors.Wrap(err, "marshalling yaml")
+	}
+
+	if _, err := file.Write(buf); err != nil {
+		return errors.Wrap(err, "writing yaml file")
+	}
+
+	return nil
+}
+
+func abbreviateKind(kind string) string {
+	switch kind {
+	case "Service":
+		return "svc"
+	case "ReplicationController":
+		return "rc"
+	case "Deployment":
+		return "dep"
+	default:
+		return kind
+	}
+}
+
+// Copied from k8s.io/client-go/1.5/pkg/util/yaml/decoder.go
+
+const yamlSeparator = "\n---"
+
+// splitYAMLDocument is a bufio.SplitFunc for splitting YAML streams into individual documents.
+func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	sep := len([]byte(yamlSeparator))
+	if i := bytes.Index(data, []byte(yamlSeparator)); i >= 0 {
+		// We have a potential document terminator
+		i += sep
+		after := data[i:]
+		if len(after) == 0 {
+			// we can't read any more characters
+			if atEOF {
+				return len(data), data[:len(data)-sep], nil
+			}
+			return 0, nil, nil
+		}
+		if j := bytes.IndexByte(after, '\n'); j >= 0 {
+			return i + j + 1, data[0 : i-sep], nil
+		}
+		return 0, nil, nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}

--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -188,6 +188,9 @@ func saveYAML(object saveObject, out string) error {
 	}
 	defer file.Close()
 
+	// We prepend a document separator, because it helps when files
+	// are cat'd together, and is otherwise harmless.
+	fmt.Fprintln(file, "---")
 	if _, err := file.Write(buf); err != nil {
 		return errors.Wrap(err, "writing yaml file")
 	}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -106,6 +106,12 @@ func (c *client) Status(_ flux.InstanceID) (flux.Status, error) {
 	return res, err
 }
 
+func (c *client) Export(_ flux.InstanceID) ([]byte, error) {
+	var res []byte
+	err := c.get(&res, "Export")
+	return res, err
+}
+
 // post is a simple query-param only post request
 func (c *client) post(route string, queryParams ...string) error {
 	return c.postWithBody(route, nil, queryParams...)

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -48,6 +48,7 @@ func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger) http.Handle
 		"RegisterDaemonV4":       handle.RegisterV4,
 		"RegisterDaemonV5":       handle.RegisterV5,
 		"IsConnected":            handle.IsConnected,
+		"Export":                 handle.Export,
 	} {
 		handler := logging(handlerMethod, log.NewContext(logger).With("method", method))
 		r.Get(method).Handler(handler)
@@ -408,6 +409,17 @@ func (s HTTPService) IsConnected(w http.ResponseWriter, r *http.Request) {
 	default:
 		errorResponse(w, r, err)
 	}
+}
+
+func (s HTTPService) Export(w http.ResponseWriter, r *http.Request) {
+	inst := getInstanceID(r)
+	status, err := s.service.Export(inst)
+	if err != nil {
+		errorResponse(w, r, err)
+		return
+	}
+
+	jsonResponse(w, r, status)
 }
 
 // --- end handlers

--- a/http/transport.go
+++ b/http/transport.go
@@ -42,6 +42,7 @@ func NewRouter() *mux.Router {
 	r.NewRoute().Name("RegisterDaemonV4").Methods("GET").Path("/v4/daemon")
 	r.NewRoute().Name("RegisterDaemonV5").Methods("GET").Path("/v5/daemon")
 	r.NewRoute().Name("IsConnected").Methods("HEAD", "GET").Path("/v4/ping")
+	r.NewRoute().Name("Export").Methods("HEAD", "GET").Path("/v5/export")
 
 	// We assume every request that doesn't match a route is a client
 	// calling an old or hitherto unsupported API.

--- a/instance/instance.go
+++ b/instance/instance.go
@@ -215,3 +215,7 @@ func (h *Instance) GetConfig() (Config, error) {
 func (h *Instance) UpdateConfig(update UpdateFunc) error {
 	return h.Config.Update(update)
 }
+
+func (h *Instance) Export() ([]byte, error) {
+	return h.Platform.Export()
+}

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -5,10 +5,12 @@
 package kubernetes
 
 import (
+	"bytes"
 	"os"
 	"os/exec"
 	"sync"
 
+	k8syaml "github.com/ghodss/yaml"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
@@ -436,7 +438,76 @@ func (c *Cluster) Version() (string, error) {
 }
 
 func (c *Cluster) Export() ([]byte, error) {
-	return nil, errors.Errorf("not implemented")
+	var config bytes.Buffer
+	list, err := c.client.Namespaces().List(api.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrap(err, "getting namespaces")
+	}
+	for _, ns := range list.Items {
+		err := appendYAML(&config, "v1", "Namespace", ns)
+		if err != nil {
+			return nil, errors.Wrap(err, "marshalling namespace to YAML")
+		}
+
+		deployments, err := c.client.Deployments(ns.Name).List(api.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "getting deployments")
+		}
+		for _, deployment := range deployments.Items {
+			if isAddon(&deployment) {
+				continue
+			}
+			err := appendYAML(&config, "extensions/v1beta1", "Deployment", deployment)
+			if err != nil {
+				return nil, errors.Wrap(err, "marshalling deployment to YAML")
+			}
+		}
+
+		rcs, err := c.client.ReplicationControllers(ns.Name).List(api.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "getting replication controllers")
+		}
+		for _, rc := range rcs.Items {
+			if isAddon(&rc) {
+				continue
+			}
+			err := appendYAML(&config, "v1", "ReplicationController", rc)
+			if err != nil {
+				return nil, errors.Wrap(err, "marshalling replication controller to YAML")
+			}
+		}
+
+		services, err := c.client.Services(ns.Name).List(api.ListOptions{})
+		if err != nil {
+			return nil, errors.Wrap(err, "getting services")
+		}
+		for _, service := range services.Items {
+			if isAddon(&service) {
+				continue
+			}
+			err := appendYAML(&config, "v1", "Service", service)
+			if err != nil {
+				return nil, errors.Wrap(err, "marshalling service to YAML")
+			}
+		}
+	}
+	return config.Bytes(), nil
+}
+
+// kind & apiVersion must be passed separately as the object's TypeMeta is not populated
+func appendYAML(buffer *bytes.Buffer, apiVersion, kind string, object interface{}) error {
+	yamlBytes, err := k8syaml.Marshal(object)
+	if err != nil {
+		return err
+	}
+	buffer.WriteString("---\n")
+	buffer.WriteString("apiVersion: ")
+	buffer.WriteString(apiVersion)
+	buffer.WriteString("\nkind: ")
+	buffer.WriteString(kind)
+	buffer.WriteString("\n")
+	buffer.Write(yamlBytes)
+	return nil
 }
 
 // --- end platform API

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -435,6 +435,10 @@ func (c *Cluster) Version() (string, error) {
 	return c.version, nil
 }
 
+func (c *Cluster) Export() ([]byte, error) {
+	return nil, errors.Errorf("not implemented")
+}
+
 // --- end platform API
 
 type statusMap struct {

--- a/platform/metrics.go
+++ b/platform/metrics.go
@@ -80,6 +80,16 @@ func (i *instrumentedPlatform) Version() (v string, err error) {
 	return i.p.Version()
 }
 
+func (i *instrumentedPlatform) Export() (config []byte, err error) {
+	defer func(begin time.Time) {
+		requestDuration.With(
+			fluxmetrics.LabelMethod, "Export",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
+		).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	return i.p.Export()
+}
+
 // BusMetrics has metrics for messages buses.
 type BusMetrics struct {
 	KickCount metrics.Counter

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -20,6 +20,9 @@ type MockPlatform struct {
 
 	VersionAnswer string
 	VersionError  error
+
+	ExportAnswer []byte
+	ExportError  error
 }
 
 func (p *MockPlatform) AllServices(ns string, ss flux.ServiceIDSet) ([]Service, error) {
@@ -55,4 +58,8 @@ func (p *MockPlatform) Ping() error {
 
 func (p *MockPlatform) Version() (string, error) {
 	return p.VersionAnswer, p.VersionError
+}
+
+func (p *MockPlatform) Export() ([]byte, error) {
+	return p.ExportAnswer, p.ExportError
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -22,8 +22,8 @@ type PlatformV4 interface {
 
 type PlatformV5 interface {
 	PlatformV4
-
 	// Additional methods accumulate here as we develop V5
+	Export() ([]byte, error)
 }
 
 // Platform is the interface various platforms fulfill, e.g.

--- a/platform/rpc/baseclient.go
+++ b/platform/rpc/baseclient.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"github.com/pkg/errors"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/platform"
 )
@@ -28,4 +29,9 @@ func (bc baseClient) Ping() error {
 
 func (bc baseClient) Version() (string, error) {
 	return "", platform.UpgradeNeededError(errors.New("Version method not implemented"))
+}
+
+// Export is used to get service configuration in platform-specific format
+func (p baseClient) Export() ([]byte, error) {
+	return nil, platform.UpgradeNeededError(errors.New("Export method not implemented"))
 }

--- a/platform/rpc/clientV5.go
+++ b/platform/rpc/clientV5.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"io"
+	"net/rpc"
 
 	"github.com/weaveworks/flux/platform"
 )
@@ -20,3 +21,13 @@ func NewClientV5(conn io.ReadWriteCloser) *RPCClientV5 {
 }
 
 // Additional/overridden methods go here
+
+// Export is used to get service configuration in platform-specific format
+func (p *RPCClientV5) Export() ([]byte, error) {
+	var config []byte
+	err := p.client.Call("RPCServer.Export", struct{}{}, &config)
+	if _, ok := err.(rpc.ServerError); !ok && err != nil {
+		return nil, platform.FatalError{err}
+	}
+	return config, err
+}

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -65,6 +65,12 @@ func (p *RPCServer) SomeServices(ids []flux.ServiceID, resp *[]platform.Service)
 	return err
 }
 
+func (p *RPCServer) Export(_ struct{}, resp *[]byte) error {
+	v, err := p.p.Export()
+	*resp = v
+	return err
+}
+
 // Regrade is still around for backwards compatibility, though it is called "Apply" everywhere else.
 func (p *RPCServer) Regrade(defs []platform.ServiceDefinition, applyResult *ApplyResult) error {
 	return p.Apply(defs, applyResult)

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -168,6 +168,15 @@ func (p *removeablePlatform) Version() (v string, err error) {
 	return p.remote.Version()
 }
 
+func (p *removeablePlatform) Export() (config []byte, err error) {
+	defer func() {
+		if _, ok := err.(FatalError); ok {
+			p.closeWithError(err)
+		}
+	}()
+	return p.remote.Export()
+}
+
 type disconnectedPlatform struct{}
 
 func (p disconnectedPlatform) AllServices(string, flux.ServiceIDSet) ([]Service, error) {
@@ -188,4 +197,8 @@ func (p disconnectedPlatform) Ping() error {
 
 func (p disconnectedPlatform) Version() (string, error) {
 	return "", errNotSubscribed
+}
+
+func (p disconnectedPlatform) Export() ([]byte, error) {
+	return nil, errNotSubscribed
 }

--- a/server/server.go
+++ b/server/server.go
@@ -415,6 +415,20 @@ func (s *Server) RegisterDaemon(instID flux.InstanceID, platform platform.Platfo
 	return err
 }
 
+func (s *Server) Export(inst flux.InstanceID) (res []byte, err error) {
+	helper, err := s.instancer.Get(inst)
+	if err != nil {
+		return res, errors.Wrapf(err, "getting instance")
+	}
+
+	res, err = helper.Export()
+	if err != nil {
+		return res, errors.Wrapf(err, "exporting %s", inst)
+	}
+
+	return res, nil
+}
+
 func (s *Server) instrumentPlatform(instID flux.InstanceID, p platform.Platform) platform.Platform {
 	return &loggingPlatform{
 		platform.Instrument(p),

--- a/server/server.go
+++ b/server/server.go
@@ -475,3 +475,13 @@ func (p *loggingPlatform) Version() (v string, err error) {
 	}()
 	return p.platform.Version()
 }
+
+func (p *loggingPlatform) Export() (config []byte, err error) {
+	defer func() {
+		if err != nil {
+			// Omit config as it could be large
+			p.logger.Log("method", "Export", "error", err)
+		}
+	}()
+	return p.platform.Export()
+}

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -243,6 +243,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/ghodss/yaml",
+			"repository": "https://github.com/ghodss/yaml",
+			"vcs": "git",
+			"revision": "04f313413ffd65ce25f2541bfd2b2ceec5c0908c",
+			"branch": "master",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/go-kit/kit/endpoint",
 			"repository": "https://github.com/go-kit/kit",
 			"vcs": "git",


### PR DESCRIPTION
Implement `fluxctl save` command that exports k8s objects to YAML files in the current directory:

* Handles Namespaces, Deployments, Services and ReplicationControllers
* Filters out add-ons from `kube-system`
* Creates directory structure as per service-conf/k8s
* Attributes that should not be persisted in version control (e.g status, uid, automatically maintained annotations, creationTimestamp etc) are filtered prior to writing

Sample output:
```
$ fluxctl save
Saving Namespace 'default' to default-ns.yaml
Saving Deployment 'flux' to default/flux-dep.yaml
Saving Deployment 'memcached' to default/memcached-dep.yaml
Saving Service 'fluxsvc' to default/fluxsvc-svc.yaml
Saving Service 'kubernetes' to default/kubernetes-svc.yaml
Saving Service 'memcached' to default/memcached-svc.yaml
Saving Namespace 'kube-system' to kube-system-ns.yaml
```

Outstanding questions:

* Do we want to add any CLI options, e.g. ability to specify a target directory, include add-ons, don't filter attributes
* Do we want to tackle implementing Export as a new protocol (as discussed below) as part of this PR?
* Should Export include type & version information so that consumers can change their behaviour accordingly?
* Are there any other things that we should filter out of objects?
* Should we abort if target files already exist? Current implementation overwrites without warning

Fixes #460.