### PR TITLE
Package and command for diffing Kubernetes objects

### DIFF
--- a/cmd/fluxctl/diff_cmd.go
+++ b/cmd/fluxctl/diff_cmd.go
@@ -24,7 +24,13 @@ func (opts *diffOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff",
 		Short: "Show differences between one platform config and another",
-		RunE:  opts.RunE,
+		Example: `# Diff the resource(s) from two files
+fluxctl diff dev/resource.yml prod/resource.yml
+
+# Diff the resource(s) in directory dev vs directory prod, recursively
+fluxctl diff dev prod
+`,
+		RunE: opts.RunE,
 	}
 	cmd.Flags().BoolVarP(&opts.quiet, "quiet", "q", false, "just report which files differ")
 	return cmd

--- a/cmd/fluxctl/diff_cmd.go
+++ b/cmd/fluxctl/diff_cmd.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/weaveworks/flux/diff"
+	"github.com/weaveworks/flux/platform/kubernetes/resource"
+)
+
+type diffOpts struct {
+	*rootOpts
+	format string
+}
+
+func newDiff(root *rootOpts) *diffOpts {
+	return &diffOpts{rootOpts: root}
+}
+
+func (opts *diffOpts) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "diff",
+		Short: "Show differences between one platform config and another",
+		RunE:  opts.RunE,
+	}
+	cmd.Flags().StringVarP(&opts.format, "output", "o", "text", "(yaml|json|text) whether to output differences in YAML or JSON, or just summarise in text")
+	return cmd
+}
+
+func (opts *diffOpts) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) != 2 {
+		return newUsageError("please supply two filenames")
+	}
+
+	output := func(diffs diff.ObjectSetDiff) error {
+		diffs.Summarise(cmd.OutOrStdout())
+		return nil
+	}
+
+	switch opts.format {
+	case "text":
+		// already output
+	case "raw":
+		output = func(diffs diff.ObjectSetDiff) error {
+			fmt.Fprintf(cmd.OutOrStdout(), "%#v\n", diffs)
+			return nil
+		}
+	case "json":
+		output = func(diffs diff.ObjectSetDiff) error {
+			bytes, err := json.Marshal(diffs)
+			if err != nil {
+				return err
+			}
+			cmd.OutOrStdout().Write(bytes)
+			return nil
+		}
+	case "yaml":
+		output = func(diffs diff.ObjectSetDiff) error {
+			bytes, err := yaml.Marshal(diffs)
+			if err != nil {
+				return err
+			}
+			cmd.OutOrStdout().Write(bytes)
+			return nil
+		}
+	default:
+		return newUsageError("output format --output,-o must be 'raw', 'text', 'json' or 'yaml'")
+	}
+
+	a, err := resource.Load(args[0])
+	if err != nil {
+		return err
+	}
+	b, err := resource.Load(args[1])
+	if err != nil {
+		return err
+	}
+
+	diffs, err := diff.DiffSet(a, b)
+	if err != nil {
+		return err
+	}
+
+	return output(diffs)
+}

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -70,6 +70,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 	cmd.AddCommand(
 		newVersionCommand(),
 		newStatus(opts).Command(),
+		newDiff(opts).Command(),
 		newServiceShow(svcopts).Command(),
 		newServiceList(svcopts).Command(),
 		newServiceRelease(svcopts).Command(),

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -1,0 +1,287 @@
+package diff
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"reflect"
+	"sort"
+	"strings"
+)
+
+// Difference represents an individual difference between two
+// `Object`s. This is an interface because
+type Difference interface {
+	Summarise(out io.Writer)
+}
+
+type Changed struct {
+	A, B interface{}
+	Path string
+}
+
+type Added struct {
+	Value interface{}
+	Path  string
+}
+
+type Removed struct {
+	Value interface{}
+	Path  string
+}
+
+// the value has changed, but don't report the before or after
+type OpaqueChanged struct {
+	Path string
+}
+
+// Objects are considered unique by {Namespace, Kind, Name}
+type ObjectID struct {
+	Namespace string
+	Kind      string
+	Name      string
+}
+
+type Object interface {
+	ID() ObjectID
+	Source() string
+}
+
+// ObjectSet is a set of several objects which can be diffed
+// collectively.
+type ObjectSet struct {
+	Source  string
+	Objects map[ObjectID]Object
+}
+
+func MakeObjectSet(source string) *ObjectSet {
+	return &ObjectSet{
+		Source:  source,
+		Objects: map[ObjectID]Object{},
+	}
+}
+
+type ObjectSetDiff struct {
+	A, B      *ObjectSet
+	OnlyA     []Object
+	OnlyB     []Object
+	Different map[ObjectID][]Difference
+}
+
+func MakeObjectSetDiff(a, b *ObjectSet) ObjectSetDiff {
+	return ObjectSetDiff{
+		A:         a,
+		B:         b,
+		Different: map[ObjectID][]Difference{},
+	}
+}
+
+// Diff calculates the differences between one model and another
+func DiffSet(a, b *ObjectSet) (ObjectSetDiff, error) {
+	diff := MakeObjectSetDiff(a, b)
+
+	// A - B and A ^ B at the same time
+	for id, objA := range a.Objects {
+		if objB, found := b.Objects[id]; found {
+			objDiff, err := DiffObject(objA, objB)
+			if err != nil {
+				return diff, err
+			}
+			if len(objDiff) > 0 {
+				diff.Different[id] = objDiff
+			}
+		} else {
+			diff.OnlyA = append(diff.OnlyA, objA)
+		}
+	}
+	// now, B - A
+	for id, objB := range b.Objects {
+		if _, found := a.Objects[id]; !found {
+			diff.OnlyB = append(diff.OnlyB, objB)
+		}
+	}
+	return diff, nil
+}
+
+type Differ interface {
+	Diff(a Differ, path string) ([]Difference, error)
+}
+
+var ErrNotDiffable = errors.New("values are not diffable")
+
+// Diff one object with another. This assumes that the objects being
+// compared are supposed to represent the same logical object, i.e.,
+// they were identified with the same ID. An error indicates they are
+// not comparable.
+func DiffObject(a, b Object) ([]Difference, error) {
+	if a.ID() != b.ID() {
+		return nil, errors.New("objects being compared do not have the same ID")
+	}
+
+	// Special case at the top: if these have different runtime types,
+	// they are not comparable.
+	typA, typB := reflect.TypeOf(a), reflect.TypeOf(b)
+	if typA != typB {
+		return nil, ErrNotDiffable
+	}
+	return diffObj(reflect.ValueOf(a), reflect.ValueOf(b), typA, "")
+}
+
+var differType = reflect.TypeOf((*Differ)(nil)).Elem()
+
+// Compare two values and compile a list of differences between them.
+func diffObj(a, b reflect.Value, typ reflect.Type, path string) ([]Difference, error) {
+	if typ.Implements(differType) {
+		differA, differB := a.Interface().(Differ), b.Interface().(Differ)
+		return differA.Diff(differB, path)
+	}
+
+	switch typ.Kind() {
+	case reflect.Array:
+		fallthrough
+	case reflect.Slice:
+		return diffArrayOrSlice(a, b, typ, path)
+	case reflect.Interface:
+		return nil, errors.New("interface diff not implemented")
+	case reflect.Ptr:
+		a, b, typ = reflect.Indirect(a), reflect.Indirect(b), typ.Elem()
+		return diffObj(a, b, typ, path)
+	case reflect.Struct:
+		return diffStruct(a, b, typ, path)
+	case reflect.Map:
+		return diffMap(a, b, typ.Elem(), path)
+	case reflect.Func:
+		return nil, errors.New("func diff not implemented (and not implementable)")
+	default: // all ground types
+		if a.Interface() != b.Interface() {
+			return []Difference{Changed{a.Interface(), b.Interface(), path}}, nil
+		}
+		return nil, nil
+	}
+}
+
+// diff each exported field individually
+func diffStruct(a, b reflect.Value, structTyp reflect.Type, path string) ([]Difference, error) {
+	var diffs []Difference
+
+	for i := 0; i < structTyp.NumField(); i++ {
+		field := structTyp.Field(i)
+		if field.PkgPath == "" { // i.e., is an exported field
+			fieldDiffs, err := diffObj(a.Field(i), b.Field(i), field.Type, path+"."+field.Name)
+			if err != nil {
+				return nil, err
+			}
+			diffs = append(diffs, fieldDiffs...)
+		}
+	}
+	return diffs, nil
+}
+
+// diff each element, report over- or underbite
+func diffArrayOrSlice(a, b reflect.Value, sliceTyp reflect.Type, path string) ([]Difference, error) {
+	var diffs []Difference
+	elemTyp := sliceTyp.Elem()
+
+	i := 0
+	for ; i < a.Len() && i < b.Len(); i++ {
+		d, err := diffObj(a.Index(i), b.Index(i), elemTyp, fmt.Sprintf("%s[%d]", path, i))
+		if err != nil {
+			return nil, err
+		}
+		diffs = append(diffs, d...)
+	}
+
+	for j := i; j < a.Len(); j++ {
+		diffs = append(diffs, Removed{a.Index(j).Interface(), fmt.Sprintf("%s[%d]", path, j)})
+	}
+	for j := i; j < b.Len(); j++ {
+		diffs = append(diffs, Added{b.Index(j).Interface(), fmt.Sprintf("%s[%d]", path, j)})
+	}
+	return diffs, nil
+}
+
+func diffMap(a, b reflect.Value, elemTyp reflect.Type, path string) ([]Difference, error) {
+	if a.Kind() != reflect.Map || b.Kind() != reflect.Map {
+		return nil, errors.New("both values must be maps")
+	}
+
+	var diffs []Difference
+	var zero reflect.Value
+	for _, keyA := range a.MapKeys() {
+		valA := a.MapIndex(keyA)
+		if valB := b.MapIndex(keyA); valB != zero {
+			moreDiffs, err := diffObj(valA, valB, elemTyp, fmt.Sprintf(`%s[%v]`, path, keyA))
+			if err != nil {
+				return nil, err
+			}
+			diffs = append(diffs, moreDiffs...)
+		} else {
+			diffs = append(diffs, Removed{valA.Interface(), fmt.Sprintf(`%s[%v]`, path, keyA)})
+		}
+	}
+	for _, keyB := range b.MapKeys() {
+		valB := b.MapIndex(keyB)
+		if valA := a.MapIndex(keyB); valA == zero {
+			diffs = append(diffs, Added{valB.Interface(), fmt.Sprintf(`%s[%v]`, path, keyB)})
+		}
+	}
+
+	sort.Sort(sorted(diffs))
+	return diffs, nil
+}
+
+// It helps to return the differences for a map in a stable order
+type sorted []Difference
+
+func (d sorted) Len() int {
+	return len(d)
+}
+
+// Sort order for changes: Removed < {Changed, OpaqueChanged} < Added,
+// then lexicographic on Path
+
+func (d sorted) Less(i, j int) bool {
+	switch a := d[i].(type) {
+	case Removed:
+		switch b := d[j].(type) {
+		case Removed:
+			return strings.Compare(a.Path, b.Path) == -1
+		default:
+			return true
+		}
+	case Changed:
+		switch b := d[j].(type) {
+		case Removed:
+			return false
+		case Changed:
+			return strings.Compare(a.Path, b.Path) == -1
+		case OpaqueChanged:
+			return strings.Compare(a.Path, b.Path) == -1
+		default:
+			return true
+		}
+	case OpaqueChanged:
+		switch b := d[j].(type) {
+		case Removed:
+			return false
+		case Changed:
+			return strings.Compare(a.Path, b.Path) == -1
+		case OpaqueChanged:
+			return strings.Compare(a.Path, b.Path) == -1
+		default:
+			return true
+		}
+	case Added:
+		switch b := d[j].(type) {
+		case Added:
+			return strings.Compare(a.Path, b.Path) == -1
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+func (d sorted) Swap(a, b int) {
+	d[a], d[b] = d[b], d[a]
+}

--- a/diff/diff.go
+++ b/diff/diff.go
@@ -42,6 +42,13 @@ type ObjectID struct {
 	Name      string
 }
 
+func (id ObjectID) String() string {
+	if id.Namespace == "" {
+		return id.Kind + " " + id.Name
+	}
+	return fmt.Sprintf("%s %s/%s", id.Kind, id.Namespace, id.Name)
+}
+
 type Object interface {
 	ID() ObjectID
 	Source() string

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -1,0 +1,194 @@
+package diff
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// --- test diffing objects
+
+type base struct {
+	Kind, Namespace, Name string
+}
+
+func (b base) ID() ObjectID {
+	return ObjectID{b.Kind, b.Namespace, b.Name}
+}
+
+func (b base) Source() string {
+	return "fake"
+}
+
+type TestValue struct {
+	base
+	ignoreUnexported string
+	StringField      string
+	IntField         int
+	Differ           TestDiffer
+	DifferStar       *TestDiffer
+	Embedded         struct {
+		NestedValue bool
+	}
+}
+
+type TestDiffer struct {
+	CaseInsensitive string
+}
+
+func (t TestDiffer) Diff(d Differ, path string) ([]Difference, error) {
+	var other *TestDiffer
+	switch d := d.(type) {
+	case TestDiffer:
+		other = &d
+	case *TestDiffer:
+		other = d
+	default:
+		return nil, errors.New("not diffable values")
+	}
+
+	if !strings.EqualFold(t.CaseInsensitive, other.CaseInsensitive) {
+		return []Difference{Changed{t.CaseInsensitive, other.CaseInsensitive, path}}, nil
+	}
+	return nil, nil
+}
+
+func TestFieldwiseDiff(t *testing.T) {
+	id := base{"TestFieldwise", "namespace", "testcase"}
+
+	a := TestValue{
+		base:             id,
+		ignoreUnexported: "one value",
+		StringField:      "ground value",
+		IntField:         5,
+		Differ:           TestDiffer{"case-insensitive"},
+		DifferStar:       &TestDiffer{"case-insensitive"},
+	}
+	a.Embedded.NestedValue = true
+
+	b := TestValue{
+		base:             id,
+		ignoreUnexported: "completely different value",
+		StringField:      "a different ground value",
+		IntField:         7,
+		Differ:           TestDiffer{"CASE-INSENSITIVE"},
+		DifferStar:       &TestDiffer{"CASE-INSENSITIVE"},
+	}
+	b.Embedded.NestedValue = false
+
+	diffs, err := DiffObject(a, a)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(diffs) > 0 {
+		t.Errorf("expected no diffs, got %#v", diffs)
+	}
+
+	diffs, err = DiffObject(a, b)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(diffs) != 3 {
+		t.Errorf("expected three diffs, got:\n%#v", diffs)
+	}
+}
+
+// --- test whole `ObjectSet`s
+
+func TestEmptyVsEmpty(t *testing.T) {
+	setA := MakeObjectSet("A")
+	setB := MakeObjectSet("B")
+	diff, err := DiffSet(setA, setB)
+	if err != nil {
+		t.Error(err)
+	}
+	if len(diff.OnlyA) > 0 || len(diff.OnlyB) > 0 || len(diff.Different) > 0 {
+		t.Errorf("expected no differences, got %#v", diff)
+	}
+}
+
+func TestSomeVsNone(t *testing.T) {
+	objA := base{"Deployment", "a-namespace", "a-name"}
+
+	setA := MakeObjectSet("A")
+	setA.Objects[objA.ID()] = objA
+	setB := MakeObjectSet("B")
+
+	diff, err := DiffSet(setA, setB)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := MakeObjectSetDiff(setA, setB)
+	expected.OnlyA = []Object{objA}
+	if !reflect.DeepEqual(expected, diff) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v", expected, diff)
+	}
+}
+
+func TestNoneVsSome(t *testing.T) {
+	objB := base{"Deployment", "b-namespace", "b-name"}
+
+	setA := MakeObjectSet("A")
+	setB := MakeObjectSet("B")
+	setB.Objects[objB.ID()] = objB
+
+	diff, err := DiffSet(setA, setB)
+	if err != nil {
+		t.Error(err)
+	}
+
+	expected := MakeObjectSetDiff(setA, setB)
+	expected.OnlyB = []Object{objB}
+	if !reflect.DeepEqual(expected, diff) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v", expected, diff)
+	}
+}
+
+func TestSliceDiff(t *testing.T) {
+	a := []string{"a", "b", "c"}
+	b := []string{"a", "b'"}
+	diffs, err := diffObj(reflect.ValueOf(a), reflect.ValueOf(b), reflect.TypeOf(a), "slice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(diffs) == 0 {
+		t.Fatal("expected more than zero differences, but got zero")
+	}
+
+	expected := []Difference{
+		Changed{"b", "b'", "slice[1]"},
+		Removed{"c", "slice[2]"},
+	}
+	if !reflect.DeepEqual(expected, diffs) {
+		t.Errorf("expected diff:\n%#v\ngot:\n%#v\n", expected, diffs)
+	}
+}
+
+func TestMapDiff(t *testing.T) {
+	a := map[string]string{
+		"one":   "foo",
+		"two":   "bar",
+		"three": "baz",
+	}
+	b := map[string]string{
+		"one":  "foo",
+		"two":  "bart",
+		"four": "shamu",
+	}
+
+	diffs, err := diffObj(reflect.ValueOf(a), reflect.ValueOf(b), reflect.TypeOf(a), "map")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := []Difference{
+		Removed{"baz", "map[three]"},
+		Changed{"bar", "bart", "map[two]"},
+		Added{"shamu", "map[four]"},
+	}
+	if !reflect.DeepEqual(expected, diffs) {
+		t.Errorf("expected diff:\n%#v\ngot:\n%#v\n", expected, diffs)
+	}
+}

--- a/diff/diff_test.go
+++ b/diff/diff_test.go
@@ -49,7 +49,7 @@ func (t TestDiffer) Diff(d Differ, path string) ([]Difference, error) {
 	}
 
 	if !strings.EqualFold(t.CaseInsensitive, other.CaseInsensitive) {
-		return []Difference{Changed{t.CaseInsensitive, other.CaseInsensitive, path}}, nil
+		return []Difference{Changed(t.CaseInsensitive, other.CaseInsensitive, path)}, nil
 	}
 	return nil, nil
 }
@@ -148,8 +148,8 @@ func TestNoneVsSome(t *testing.T) {
 
 func TestSliceDiff(t *testing.T) {
 	a := []string{"a", "b", "c"}
-	b := []string{"a", "b'"}
-	diffs, err := diffObj(reflect.ValueOf(a), reflect.ValueOf(b), reflect.TypeOf(a), "slice")
+	b := []string{"a", "B"}
+	diffs, err := diffValue(reflect.ValueOf(a), reflect.ValueOf(b), reflect.TypeOf(a), "slice")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -158,8 +158,8 @@ func TestSliceDiff(t *testing.T) {
 	}
 
 	expected := []Difference{
-		Changed{"b", "b'", "slice[1]"},
-		Removed{"c", "slice[2]"},
+		Changed("b", "B", "slice[1]"),
+		Removed("c", "slice[2]"),
 	}
 	if !reflect.DeepEqual(expected, diffs) {
 		t.Errorf("expected diff:\n%#v\ngot:\n%#v\n", expected, diffs)
@@ -178,15 +178,15 @@ func TestMapDiff(t *testing.T) {
 		"four": "shamu",
 	}
 
-	diffs, err := diffObj(reflect.ValueOf(a), reflect.ValueOf(b), reflect.TypeOf(a), "map")
+	diffs, err := diffValue(reflect.ValueOf(a), reflect.ValueOf(b), reflect.TypeOf(a), "map")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	expected := []Difference{
-		Removed{"baz", "map[three]"},
-		Changed{"bar", "bart", "map[two]"},
-		Added{"shamu", "map[four]"},
+		Added("shamu", "map[four]"),
+		Removed("baz", "map[three]"),
+		Changed("bar", "bart", "map[two]"),
 	}
 	if !reflect.DeepEqual(expected, diffs) {
 		t.Errorf("expected diff:\n%#v\ngot:\n%#v\n", expected, diffs)

--- a/diff/doc.go
+++ b/diff/doc.go
@@ -1,0 +1,6 @@
+package diff
+
+// Procedures for diffing configuration objects. At the most general,
+// these operate on in memory data structures. To get other varieties,
+// files can be read into those structures, or config exported from a
+// running system.

--- a/diff/lines.go
+++ b/diff/lines.go
@@ -1,0 +1,110 @@
+package diff
+
+import (
+	"fmt"
+)
+
+// TODO: coalesce `-` followed by `+` into a change (if it looks
+// similar?)
+func DiffLines(a, b []string, path string) ([]Difference, error) {
+	if len(a) == 0 && len(b) == 0 {
+		return nil, nil
+	}
+
+	var diffs []Difference
+	addIndex, removeIndex := 0, 0
+
+	chunks := diffChunks(a, b)
+	for _, chunk := range chunks {
+		for i, line := range chunk.Deleted {
+			diffs = append(diffs, Removed{line, fmt.Sprintf("%s[%d]", path, removeIndex+i)})
+		}
+		removeIndex += len(chunk.Deleted) + len(chunk.Equal)
+
+		for i, line := range chunk.Added {
+			diffs = append(diffs, Added{line, fmt.Sprintf("%s[%d]", path, addIndex+i)})
+		}
+		addIndex += len(chunk.Added) + len(chunk.Equal)
+	}
+	return diffs, nil
+}
+
+// Taken from https://gowalker.org/github.com/kylelemons/godebug/diff
+func diffChunks(A, B []string) []Chunk {
+	// algorithm: http://www.xmailserver.org/diff2.pdf
+	N, M := len(A), len(B)
+	MAX := N + M
+	V := make([]int, 2*MAX+1)
+	Vs := make([][]int, 0, 8)
+
+	var D int
+dLoop:
+	for D = 0; D <= MAX; D++ {
+		for k := -D; k <= D; k += 2 {
+			var x int
+			if k == -D || (k != D && V[MAX+k-1] < V[MAX+k+1]) {
+				x = V[MAX+k+1]
+			} else {
+				x = V[MAX+k-1] + 1
+			}
+			y := x - k
+			for x < N && y < M && A[x] == B[y] {
+				x++
+				y++
+			}
+			V[MAX+k] = x
+			if x >= N && y >= M {
+				Vs = append(Vs, append(make([]int, 0, len(V)), V...))
+				break dLoop
+			}
+		}
+		Vs = append(Vs, append(make([]int, 0, len(V)), V...))
+	}
+	if D == 0 {
+		return nil
+	}
+	chunks := make([]Chunk, D+1)
+
+	x, y := N, M
+	for d := D; d > 0; d-- {
+		V := Vs[d]
+		k := x - y
+		insert := k == -d || (k != d && V[MAX+k-1] < V[MAX+k+1])
+
+		x1 := V[MAX+k]
+		var x0, xM, kk int
+		if insert {
+			kk = k + 1
+			x0 = V[MAX+kk]
+			xM = x0
+		} else {
+			kk = k - 1
+			x0 = V[MAX+kk]
+			xM = x0 + 1
+		}
+		y0 := x0 - kk
+
+		var c Chunk
+		if insert {
+			c.Added = B[y0:][:1]
+		} else {
+			c.Deleted = A[x0:][:1]
+		}
+		if xM < x1 {
+			c.Equal = A[xM:][:x1-xM]
+		}
+
+		x, y = x0, y0
+		chunks[d] = c
+	}
+	if x > 0 {
+		chunks[0].Equal = A[:x]
+	}
+	return chunks
+}
+
+type Chunk struct {
+	Added   []string
+	Deleted []string
+	Equal   []string
+}

--- a/diff/lines_test.go
+++ b/diff/lines_test.go
@@ -1,0 +1,53 @@
+package diff
+
+import (
+	"reflect"
+	"testing"
+)
+
+func testLineDiff(t *testing.T, a, b []string, expected []Difference) {
+	diffs, err := DiffLines(a, b, "lines")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expected, diffs) {
+		t.Errorf("expected:\n%#v\ngot:\n%#v", expected, diffs)
+	}
+}
+
+func TestEmptyLineDiff(t *testing.T) {
+	testLineDiff(t, nil, nil, nil)
+	testLineDiff(t, nil, []string{}, nil)
+	testLineDiff(t, []string{}, nil, nil)
+}
+
+func TestSomeVsNoneLinesDiff(t *testing.T) {
+	expected := []Difference{
+		Added{"added", "lines[0]"},
+	}
+	testLineDiff(t, nil, []string{"added"}, expected)
+	testLineDiff(t, []string{}, []string{"added"}, expected)
+}
+
+func TestSingleLineAdd(t *testing.T) {
+	a := []string{"foo", "bar", "baz"}
+	b := []string{"foo", "bar", "boom"}
+	expected := []Difference{
+		Removed{"baz", "lines[2]"},
+		Added{"boom", "lines[2]"},
+	}
+	testLineDiff(t, a, b, expected)
+}
+
+func TestMultipleLineDiff(t *testing.T) {
+	a := []string{"one", "two", "three", "four", "five"}
+	b := []string{"one", "2", "three", "4", "five"}
+	expected := []Difference{
+		Removed{"two", "lines[1]"},
+		Added{"2", "lines[1]"},
+		Removed{"four", "lines[3]"},
+		Added{"4", "lines[3]"},
+	}
+	testLineDiff(t, a, b, expected)
+}

--- a/diff/lines_test.go
+++ b/diff/lines_test.go
@@ -24,7 +24,7 @@ func TestEmptyLineDiff(t *testing.T) {
 
 func TestSomeVsNoneLinesDiff(t *testing.T) {
 	expected := []Difference{
-		Added{"added", "lines[0]"},
+		Added("added", "lines[0]"),
 	}
 	testLineDiff(t, nil, []string{"added"}, expected)
 	testLineDiff(t, []string{}, []string{"added"}, expected)
@@ -34,8 +34,7 @@ func TestSingleLineAdd(t *testing.T) {
 	a := []string{"foo", "bar", "baz"}
 	b := []string{"foo", "bar", "boom"}
 	expected := []Difference{
-		Removed{"baz", "lines[2]"},
-		Added{"boom", "lines[2]"},
+		Changed("baz", "boom", "lines[2]"),
 	}
 	testLineDiff(t, a, b, expected)
 }
@@ -44,10 +43,8 @@ func TestMultipleLineDiff(t *testing.T) {
 	a := []string{"one", "two", "three", "four", "five"}
 	b := []string{"one", "2", "three", "4", "five"}
 	expected := []Difference{
-		Removed{"two", "lines[1]"},
-		Added{"2", "lines[1]"},
-		Removed{"four", "lines[3]"},
-		Added{"4", "lines[3]"},
+		Changed("two", "2", "lines[1]"),
+		Changed("four", "4", "lines[3]"),
 	}
 	testLineDiff(t, a, b, expected)
 }

--- a/diff/summarise.go
+++ b/diff/summarise.go
@@ -1,0 +1,47 @@
+package diff
+
+import (
+	"fmt"
+	"io"
+)
+
+func (d Changed) Summarise(out io.Writer) {
+	fmt.Fprintf(out, "* %s: %v != %v\n", d.Path, d.A, d.B)
+}
+
+func (d Added) Summarise(out io.Writer) {
+	fmt.Fprintf(out, "+ %s: %+v\n", d.Path, d.Value)
+}
+
+func (d Removed) Summarise(out io.Writer) {
+	fmt.Fprintf(out, "- %s: %+v\n", d.Path, d.Value)
+}
+
+func (d OpaqueChanged) Summarise(out io.Writer) {
+	fmt.Fprintf(out, "* %s: data has changed\n", d.Path)
+}
+
+func (d ObjectSetDiff) Summarise(out io.Writer) {
+	if len(d.OnlyA) > 0 {
+		fmt.Fprintf(out, "Only in %s:\n", d.A.Source)
+		for _, obj := range d.OnlyA {
+			id := obj.ID()
+			fmt.Fprintf(out, "%s %s/%s (%s)\n", id.Kind, id.Namespace, id.Name, obj.Source())
+		}
+	}
+	if len(d.OnlyB) > 0 {
+		fmt.Fprintf(out, "Only in %s:\n", d.B.Source)
+		for _, obj := range d.OnlyB {
+			id := obj.ID()
+			fmt.Fprintf(out, "%s %s/%s (%s)\n", id.Kind, id.Namespace, id.Name, obj.Source())
+		}
+	}
+	if len(d.Different) > 0 {
+		for id, diffs := range d.Different {
+			fmt.Fprintf(out, "\n%s %s/%s is different:\n", id.Kind, id.Namespace, id.Name)
+			for _, diff := range diffs {
+				diff.Summarise(out)
+			}
+		}
+	}
+}

--- a/diff/summarise.go
+++ b/diff/summarise.go
@@ -5,18 +5,16 @@ import (
 	"io"
 )
 
-func (d Changed) Summarise(out io.Writer) {
-	fmt.Fprintf(out, "* %s: %v != %v\n", d.Path, d.A, d.B)
+func (d Chunk) Summarise(out io.Writer) {
+	fmt.Fprintf(out, "%s:\n", d.Path)
+	for _, del := range d.Deleted {
+		fmt.Fprintf(out, "- %#v\n", del)
+	}
+	for _, add := range d.Added {
+		fmt.Fprintf(out, "+ %#v\n", add)
+	}
 }
 
-func (d Added) Summarise(out io.Writer) {
-	fmt.Fprintf(out, "+ %s: %+v\n", d.Path, d.Value)
-}
-
-func (d Removed) Summarise(out io.Writer) {
-	fmt.Fprintf(out, "- %s: %+v\n", d.Path, d.Value)
-}
-
-func (d OpaqueChanged) Summarise(out io.Writer) {
-	fmt.Fprintf(out, "* %s: data has changed\n", d.Path)
+func (d OpaqueChunk) Summarise(out io.Writer) {
+	fmt.Fprintf(out, "%s: value has changed\n", d.Path)
 }

--- a/diff/summarise.go
+++ b/diff/summarise.go
@@ -20,28 +20,3 @@ func (d Removed) Summarise(out io.Writer) {
 func (d OpaqueChanged) Summarise(out io.Writer) {
 	fmt.Fprintf(out, "* %s: data has changed\n", d.Path)
 }
-
-func (d ObjectSetDiff) Summarise(out io.Writer) {
-	if len(d.OnlyA) > 0 {
-		fmt.Fprintf(out, "Only in %s:\n", d.A.Source)
-		for _, obj := range d.OnlyA {
-			id := obj.ID()
-			fmt.Fprintf(out, "%s %s/%s (%s)\n", id.Kind, id.Namespace, id.Name, obj.Source())
-		}
-	}
-	if len(d.OnlyB) > 0 {
-		fmt.Fprintf(out, "Only in %s:\n", d.B.Source)
-		for _, obj := range d.OnlyB {
-			id := obj.ID()
-			fmt.Fprintf(out, "%s %s/%s (%s)\n", id.Kind, id.Namespace, id.Name, obj.Source())
-		}
-	}
-	if len(d.Different) > 0 {
-		for id, diffs := range d.Different {
-			fmt.Fprintf(out, "\n%s %s/%s is different:\n", id.Kind, id.Namespace, id.Name)
-			for _, diff := range diffs {
-				diff.Summarise(out)
-			}
-		}
-	}
-}

--- a/platform/kubernetes/files_test.go
+++ b/platform/kubernetes/files_test.go
@@ -21,6 +21,6 @@ func TestDefinedServices(t *testing.T) {
 	}
 
 	if !reflect.DeepEqual(testdata.ServiceMap(dir), services) {
-		t.Errorf("Got unexpected result: %#v", services)
+		t.Errorf("Expected:\n%#v\ngot:\n%#v\n", testdata.ServiceMap(dir), services)
 	}
 }

--- a/platform/kubernetes/resource/configmap.go
+++ b/platform/kubernetes/resource/configmap.go
@@ -1,0 +1,6 @@
+package resource
+
+type ConfigMap struct {
+	baseObject
+	Data map[string]string
+}

--- a/platform/kubernetes/resource/daemonset.go
+++ b/platform/kubernetes/resource/daemonset.go
@@ -1,0 +1,11 @@
+package resource
+
+type DaemonSet struct {
+	baseObject
+	Spec DaemonSetSpec
+}
+
+type DaemonSetSpec struct {
+	Selector map[string]string
+	Template PodTemplate
+}

--- a/platform/kubernetes/resource/deployment.go
+++ b/platform/kubernetes/resource/deployment.go
@@ -1,0 +1,11 @@
+package resource
+
+type Deployment struct {
+	baseObject
+	Spec DeploymentSpec
+}
+
+type DeploymentSpec struct {
+	Replicas int
+	Template PodTemplate
+}

--- a/platform/kubernetes/resource/doc.go
+++ b/platform/kubernetes/resource/doc.go
@@ -1,0 +1,6 @@
+// Types and procedures for representing Kubernetes objects.
+//
+// These types are mainly for the purpose of generating diffs, and
+// ignore much of the detail in "real" Kubernetes objects.
+
+package resource

--- a/platform/kubernetes/resource/load.go
+++ b/platform/kubernetes/resource/load.go
@@ -1,0 +1,98 @@
+package resource
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/weaveworks/flux/diff"
+)
+
+// Load takes a path to a directory or file, and creates an object set
+// based on the file(s) therein. Resources are named according to the
+// file content, rather than the file name of directory structure.
+func Load(root string) (*diff.ObjectSet, error) {
+	objs := diff.MakeObjectSet(root)
+	var err error
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf(`walking %q for yamels: %s`, path, err.Error())
+		}
+		if !info.IsDir() && filepath.Ext(path) == ".yaml" || filepath.Ext(path) == ".yml" {
+			bytes, err := ioutil.ReadFile(path)
+			if err != nil {
+				return fmt.Errorf(`reading file at "%s": %s`, path, err.Error())
+			}
+			docsInFile, err := ParseMultidoc(bytes, path)
+			if err != nil {
+				return fmt.Errorf(`parsing file at "%s": %s`, path, err.Error())
+			}
+			for id, obj := range docsInFile.Objects {
+
+				objs.Objects[id] = obj
+			}
+		}
+		return nil
+	})
+	return objs, err
+}
+
+// ParseManifests takes a dump of config (a multidoc YAML) and
+// constructs an object set from the resources represented therein.
+func ParseMultidoc(multidoc []byte, source string) (*diff.ObjectSet, error) {
+	objs := diff.MakeObjectSet(source)
+	chunks := bufio.NewScanner(bytes.NewReader(multidoc))
+	chunks.Split(splitYAMLDocument)
+
+	for chunks.Scan() {
+		if obj, err := unmarshalObject(source, chunks.Bytes()); err != nil {
+			return nil, fmt.Errorf(`parsing YAML doc from "%s": %s`, source, err.Error())
+		} else {
+			objs.Objects[obj.ID()] = obj
+		}
+	}
+	if err := chunks.Err(); err != nil {
+		return objs, fmt.Errorf(`scanning multidoc from "%s": %s`, source, err.Error())
+	}
+	return objs, nil
+}
+
+// ---
+// Taken directly from https://github.com/kubernetes/apimachinery/blob/master/pkg/util/yaml/decoder.go.
+
+const yamlSeparator = "\n---"
+
+// splitYAMLDocument is a bufio.SplitFunc for splitting YAML streams into individual documents.
+func splitYAMLDocument(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+	sep := len([]byte(yamlSeparator))
+	if i := bytes.Index(data, []byte(yamlSeparator)); i >= 0 {
+		// We have a potential document terminator
+		i += sep
+		after := data[i:]
+		if len(after) == 0 {
+			// we can't read any more characters
+			if atEOF {
+				return len(data), data[:len(data)-sep], nil
+			}
+			return 0, nil, nil
+		}
+		if j := bytes.IndexByte(after, '\n'); j >= 0 {
+			return i + j + 1, data[0 : i-sep], nil
+		}
+		return 0, nil, nil
+	}
+	// If we're at EOF, we have a final, non-terminated line. Return it.
+	if atEOF {
+		return len(data), data, nil
+	}
+	// Request more data.
+	return 0, nil, nil
+}
+
+// ---

--- a/platform/kubernetes/resource/load_test.go
+++ b/platform/kubernetes/resource/load_test.go
@@ -1,0 +1,76 @@
+package resource
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/flux/diff"
+	"github.com/weaveworks/flux/platform/kubernetes/testdata"
+)
+
+// for convenience
+func base(source, kind, namespace, name string) baseObject {
+	b := baseObject{source: source, Kind: kind}
+	b.Meta.Namespace = namespace
+	b.Meta.Name = name
+	return b
+}
+
+func TestParseEmpty(t *testing.T) {
+	doc := ``
+
+	objs, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Error(err)
+	}
+	if len(objs.Objects) != 0 {
+		t.Errorf("expected empty set; got %#v", objs)
+	}
+}
+
+func TestParseSome(t *testing.T) {
+	docs := `---
+kind: Service
+metadata:
+  name: b-service
+  namespace: b-namespace
+---
+kind: Deployment
+metadata:
+  name: a-deployment
+`
+	objs, err := ParseMultidoc([]byte(docs), "test")
+	if err != nil {
+		t.Error(err)
+	}
+
+	objA := base("test", "Deployment", "", "a-deployment")
+	objB := base("test", "Service", "b-namespace", "b-service")
+	expected := diff.MakeObjectSet("fake-path")
+	expected.Objects = map[diff.ObjectID]diff.Object{
+		objA.ID(): &Deployment{baseObject: objA},
+		objB.ID(): &Service{baseObject: objB},
+	}
+
+	for id, obj := range expected.Objects {
+		if !reflect.DeepEqual(obj, objs.Objects[id]) {
+			t.Errorf("At %+v expected:\n%#v\ngot:\n%#v", id, obj, objs.Objects[id])
+		}
+	}
+}
+
+func TestLoadSome(t *testing.T) {
+	dir, cleanup := testdata.TempDir(t)
+	defer cleanup()
+	if err := testdata.WriteTestFiles(dir); err != nil {
+		t.Fatal(err)
+	}
+	objs, err := Load(dir)
+	if err != nil {
+		t.Error(err)
+	}
+	// assume it's one per file for the minute
+	if len(objs.Objects) != len(testdata.Files) {
+		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testdata.Files), len(testdata.Files), objs)
+	}
+}

--- a/platform/kubernetes/resource/namespace.go
+++ b/platform/kubernetes/resource/namespace.go
@@ -1,0 +1,17 @@
+package resource
+
+import (
+	"github.com/weaveworks/flux/diff"
+)
+
+type Namespace struct {
+	baseObject
+}
+
+func (ns *Namespace) ID() diff.ObjectID {
+	return diff.ObjectID{
+		Kind:      ns.Kind,
+		Name:      ns.Meta.Name,
+		Namespace: "",
+	}
+}

--- a/platform/kubernetes/resource/node.go
+++ b/platform/kubernetes/resource/node.go
@@ -1,0 +1,18 @@
+package resource
+
+import (
+	"github.com/weaveworks/flux/diff"
+)
+
+type Node struct {
+	baseObject
+	Metadata ObjectMeta
+}
+
+func (ns *Node) ID() diff.ObjectID {
+	return diff.ObjectID{
+		Kind:      ns.Kind,
+		Name:      ns.Meta.Name,
+		Namespace: "",
+	}
+}

--- a/platform/kubernetes/resource/replication_controller.go
+++ b/platform/kubernetes/resource/replication_controller.go
@@ -1,0 +1,11 @@
+package resource
+
+type ReplicationController struct {
+	baseObject
+	Spec ReplicationControllerSpec
+}
+
+type ReplicationControllerSpec struct {
+	Replicas int
+	Template PodTemplate
+}

--- a/platform/kubernetes/resource/resource.go
+++ b/platform/kubernetes/resource/resource.go
@@ -1,0 +1,95 @@
+package resource
+
+import (
+	"errors"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/weaveworks/flux/diff"
+)
+
+// -- unmarshaling code and diffing code for specific object and field
+// types
+
+// struct to embed in objects, to provide default implementation
+type baseObject struct {
+	source string
+	Kind   string `yaml:"kind"`
+	Meta   struct {
+		Namespace string `yaml:"namespace"`
+		Name      string `yaml:"name"`
+	} `yaml:"metadata"`
+}
+
+func (o baseObject) ID() diff.ObjectID {
+	ns := o.Meta.Namespace
+	if ns == "" {
+		ns = "default"
+	}
+	return diff.ObjectID{
+		Kind:      o.Kind,
+		Namespace: ns,
+		Name:      o.Meta.Name,
+	}
+}
+
+func (o baseObject) Source() string {
+	return o.source
+}
+
+func unmarshalObject(source string, bytes []byte) (diff.Object, error) {
+	var base = baseObject{source: source}
+	if err := yaml.Unmarshal(bytes, &base); err != nil {
+		return nil, err
+	}
+
+	switch base.Kind {
+	case "Deployment":
+		var dep = Deployment{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &dep); err != nil {
+			return nil, err
+		}
+		return &dep, nil
+	case "Service":
+		var svc = Service{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &svc); err != nil {
+			return nil, err
+		}
+		return &svc, nil
+	case "Secret":
+		var secret = Secret{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &secret); err != nil {
+			return nil, err
+		}
+		return &secret, nil
+	case "ConfigMap":
+		var config = ConfigMap{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &config); err != nil {
+			return nil, err
+		}
+		return &config, nil
+	case "Namespace":
+		var ns = Namespace{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &ns); err != nil {
+			return nil, err
+		}
+		return &ns, nil
+	case "DaemonSet":
+		var ds = DaemonSet{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &ds); err != nil {
+			return nil, err
+		}
+		return &ds, nil
+	case "Node":
+		var n = Node{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &n); err != nil {
+			return nil, err
+		}
+		return &n, nil
+	}
+
+	return nil, errors.New("unknown object type " + base.Kind)
+}
+
+// For reference, the Kubernetes v1 types are in:
+// https://github.com/kubernetes/client-go/blob/master/pkg/api/v1/types.go

--- a/platform/kubernetes/resource/resource_test.go
+++ b/platform/kubernetes/resource/resource_test.go
@@ -1,0 +1,61 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/weaveworks/flux/diff"
+)
+
+var serviceA = `---
+kind: Service
+meta:
+  name: ServiceA
+  namespace: NamespaceA
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+  selector:
+    name: appA
+`
+
+var serviceB = `---
+kind: Service
+meta:
+  name: ServiceA
+  namespace: NamespaceA
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 443
+  selector:
+    label: foo
+    name: appB
+`
+
+func TestServiceDiff(t *testing.T) {
+	a, err := ParseMultidoc([]byte(serviceA), "A")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := ParseMultidoc([]byte(serviceB), "B")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	diff, err := diff.DiffSet(a, b)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(diff.OnlyA) > 0 {
+		t.Errorf("expected no items just in A, got:\n%#v", diff.OnlyA)
+	}
+	if len(diff.OnlyB) > 0 {
+		t.Errorf("expected no items just in B, got:\n%#v", diff.OnlyB)
+	}
+	if len(diff.Different) == 0 {
+		t.Errorf("expected A and B different, got:\n%#v", diff.Different)
+	}
+}

--- a/platform/kubernetes/resource/secret.go
+++ b/platform/kubernetes/resource/secret.go
@@ -17,7 +17,7 @@ func (s SecretData) Diff(d diff.Differ, path string) ([]diff.Difference, error) 
 		if s1 == s {
 			return nil, nil
 		}
-		return []diff.Difference{diff.OpaqueChanged{path}}, nil
+		return []diff.Difference{diff.OpaqueChunk{Path: path}}, nil
 	}
 	return nil, diff.ErrNotDiffable
 }

--- a/platform/kubernetes/resource/secret.go
+++ b/platform/kubernetes/resource/secret.go
@@ -1,0 +1,23 @@
+package resource
+
+import (
+	"github.com/weaveworks/flux/diff"
+)
+
+type Secret struct {
+	baseObject
+	Data map[string]SecretData
+	Type string
+}
+
+type SecretData string
+
+func (s SecretData) Diff(d diff.Differ, path string) ([]diff.Difference, error) {
+	if s1, ok := d.(SecretData); ok {
+		if s1 == s {
+			return nil, nil
+		}
+		return []diff.Difference{diff.OpaqueChanged{path}}, nil
+	}
+	return nil, diff.ErrNotDiffable
+}

--- a/platform/kubernetes/resource/service.go
+++ b/platform/kubernetes/resource/service.go
@@ -1,0 +1,23 @@
+package resource
+
+// For reference:
+// https://github.com/kubernetes/client-go/blob/master/pkg/api/v1/types.go#L2641
+
+type Service struct {
+	baseObject
+	Spec ServiceSpec `yaml:"spec"`
+}
+
+type ServiceSpec struct {
+	Type     string            `yaml:"type"`
+	Ports    []ServicePort     `yaml:"ports"`
+	Selector map[string]string `yaml:"selector"`
+}
+
+type ServicePort struct {
+	Name       string `yaml:"name"`
+	Protocol   string `yaml:"protocol"`
+	Port       int32  `yaml:"port"`
+	TargetPort string `yaml:"targetPort"`
+	NodePort   int32  `yaml:"nodePort"`
+}

--- a/platform/kubernetes/resource/spec.go
+++ b/platform/kubernetes/resource/spec.go
@@ -89,15 +89,15 @@ func (a Env) Diff(d diff.Differ, path string) ([]diff.Difference, error) {
 		for keyA, entryA := range as {
 			if entryB, ok := bs[keyA]; ok {
 				if entryB.Value != entryA.Value {
-					diffs = append(diffs, diff.Changed{entryA.Value, entryB.Value, fmt.Sprintf("%s[%s]", path, entryA.Name)})
+					diffs = append(diffs, diff.Changed(entryA.Value, entryB.Value, fmt.Sprintf("%s[%s]", path, entryA.Name)))
 				}
 			} else {
-				diffs = append(diffs, diff.Removed{entryA.Value, fmt.Sprintf("%s[%s]", path, entryA.Name)})
+				diffs = append(diffs, diff.Removed(entryA.Value, fmt.Sprintf("%s[%s]", path, entryA.Name)))
 			}
 		}
 		for keyB, entryB := range bs {
 			if _, ok := as[keyB]; !ok {
-				diffs = append(diffs, diff.Added{entryB.Value, fmt.Sprintf("%s[%s]", path, entryB.Name)})
+				diffs = append(diffs, diff.Added(entryB.Value, fmt.Sprintf("%s[%s]", path, entryB.Name)))
 			}
 		}
 		return diffs, nil

--- a/platform/kubernetes/resource/spec.go
+++ b/platform/kubernetes/resource/spec.go
@@ -1,0 +1,106 @@
+package resource
+
+import (
+	"fmt"
+
+	"github.com/weaveworks/flux/diff"
+)
+
+// Types that daemonsets, deployments, and other things have in
+// common.
+
+type ObjectMeta struct {
+	Labels      map[string]string
+	Annotations map[string]string
+}
+
+type PodTemplate struct {
+	Metadata ObjectMeta
+	Spec     PodSpec
+}
+
+type PodSpec struct {
+	ImagePullSecrets []struct{ Name string }
+	Volumes          []Volume
+	Containers       []ContainerSpec
+}
+
+type Volume struct {
+	Name   string
+	Secret struct {
+		SecretName string
+	}
+}
+
+type ContainerSpec struct {
+	Name  string
+	Image string
+	Args  Args
+	Ports []ContainerPort
+	Env   Env
+}
+
+type Args []string
+
+func (a Args) Diff(d diff.Differ, path string) ([]diff.Difference, error) {
+	if b, ok := d.(Args); ok {
+		return diff.DiffLines([]string(a), []string(b), path)
+	}
+	return nil, diff.ErrNotDiffable
+}
+
+type ContainerPort struct {
+	ContainerPort int
+	Name          string
+}
+
+type VolumeMount struct {
+	Name      string
+	MountPath string
+	ReadOnly  bool
+}
+
+// Env is a bag of Name, Value pairs that are treated somewhat like a
+// map.
+type Env []EnvEntry
+
+type EnvEntry struct {
+	Name, Value string
+}
+
+func (a Env) Diff(d diff.Differ, path string) ([]diff.Difference, error) {
+	if b, ok := d.(Env); ok {
+		var diffs []diff.Difference
+
+		type entry struct {
+			EnvEntry
+			index int
+		}
+
+		as := map[string]entry{}
+		bs := map[string]entry{}
+		for i, e := range a {
+			as[e.Name] = entry{e, i}
+		}
+		for i, e := range b {
+			bs[e.Name] = entry{e, i}
+		}
+
+		for keyA, entryA := range as {
+			if entryB, ok := bs[keyA]; ok {
+				if entryB.Value != entryA.Value {
+					diffs = append(diffs, diff.Changed{entryA.Value, entryB.Value, fmt.Sprintf("%s[%s]", path, entryA.Name)})
+				}
+			} else {
+				diffs = append(diffs, diff.Removed{entryA.Value, fmt.Sprintf("%s[%s]", path, entryA.Name)})
+			}
+		}
+		for keyB, entryB := range bs {
+			if _, ok := as[keyB]; !ok {
+				diffs = append(diffs, diff.Added{entryB.Value, fmt.Sprintf("%s[%s]", path, entryB.Name)})
+			}
+		}
+		return diffs, nil
+	}
+	return nil, diff.ErrNotDiffable
+}


### PR DESCRIPTION
This adds some machinery for diffing generic objects, then specialises that to the Kubernetes objects that we typically deal with, then use that to implement a `fluxctl diff` command.

The package `diff` provides generic representations of diffs, and some algorithms for diffing values of various kinds. There is a specialisation hook: implementing the interface `Differ` for a type means that will get used instead of the generic diff algorithm.

The package `platform/kubernetes/diff` contains some of the types used in Kubeternetes config, and some procedures for loading them from a file or directory, and some specialisations via `Differ` (e.g., for secrets). 

The idea here is to build the types out of the fields that matter when applying -- then it can be used to see if, for example, a commit contains a "meaningful" change, and therefore whether to apply it to the cluster. I have probably not captured all such fields; it may take a bit of trial and error to figure out what we care about.

Lastly, this adds a `fluxctl diff` command, which just checks one file (or directory) against another. This is mainly just to prove the use of the packages, but may eventually be useful in itself.
