### PR TITLE
Change git package to use a shallow git clone

### DIFF
--- a/git/operations.go
+++ b/git/operations.go
@@ -14,6 +14,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// Do a shallow clone of the repo. We only need the files, and not the
+// history. A shallow clone is marginally quicker, and takes less
+// space, than a full clone.
 func clone(workingDir, keyData, repoURL, repoBranch string) (path string, err error) {
 	keyPath, err := writeKey(keyData)
 	if err != nil {
@@ -21,7 +24,8 @@ func clone(workingDir, keyData, repoURL, repoBranch string) (path string, err er
 	}
 	defer os.Remove(keyPath)
 	repoPath := filepath.Join(workingDir, "repo")
-	args := []string{"clone"}
+	// --single-branch is also useful, but is implied by --depth=1
+	args := []string{"clone", "--depth=1"}
 	if repoBranch != "" {
 		args = append(args, "--branch", repoBranch)
 	}


### PR DESCRIPTION
We only need the files from the git repo, and not the history. There are savings to using a shallow clone in this circumstance, in network traffic and disk space (and therefore in speed). The savings will depend on the repo, of course.
