### PR TITLE
Protocol for syncing changes to the cluster

### DIFF
--- a/cmd/fluxsvc/kubeservice
+++ b/cmd/fluxsvc/kubeservice
@@ -2,7 +2,6 @@
 
 import yaml, sys, os, os.path, string, subprocess, optparse, json
 
-
 class Kubeimage(Exception):
   pass
 

--- a/platform/kubernetes/kubernetes_test.go
+++ b/platform/kubernetes/kubernetes_test.go
@@ -1,0 +1,131 @@
+package kubernetes
+
+// Test that the implementation of platform wrt Kubernetes is
+// adequate. Starting with Sync.
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	"k8s.io/client-go/1.5/rest"
+
+	"github.com/weaveworks/flux/platform"
+)
+
+type command struct {
+	action string
+	def    string
+}
+
+type mockApplier struct {
+	commands  []command
+	applyErr  error
+	createErr error
+	deleteErr error
+}
+
+func (m *mockApplier) Create(logger log.Logger, def []byte) error {
+	m.commands = append(m.commands, command{"create", string(def)})
+	return m.createErr
+}
+
+func (m *mockApplier) Apply(logger log.Logger, def []byte) error {
+	m.commands = append(m.commands, command{"apply", string(def)})
+	return m.applyErr
+}
+
+func (m *mockApplier) Delete(logger log.Logger, def []byte) error {
+	m.commands = append(m.commands, command{"delete", string(def)})
+	return m.deleteErr
+}
+
+// ---
+
+func setup(t *testing.T) (platform.Platform, *mockApplier) {
+	restClientConfig := &rest.Config{}
+	applier := &mockApplier{}
+	kube, err := NewCluster(restClientConfig, applier, "test-version", log.NewNopLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return kube, applier
+}
+
+func TestSyncNop(t *testing.T) {
+	kube, mock := setup(t)
+	if err := kube.Sync(platform.SyncDef{}); err != nil {
+		t.Error(err)
+	}
+	if len(mock.commands) > 0 {
+		t.Errorf("expected no commands run, but got %#v", mock.commands)
+	}
+}
+
+func TestSyncOrder(t *testing.T) {
+	kube, mock := setup(t)
+	if err := kube.Sync(platform.SyncDef{
+		Actions: []platform.SyncAction{
+			platform.SyncAction{
+				ResourceID: "foobar",
+				Delete:     []byte("delete first"),
+				Create:     []byte("create second"),
+				Apply:      []byte("apply last"),
+			},
+		},
+	}); err != nil {
+		t.Error(err)
+	}
+
+	expected := []command{
+		command{"delete", "delete first"},
+		command{"create", "create second"},
+		command{"apply", "apply last"},
+	}
+	if !reflect.DeepEqual(expected, mock.commands) {
+		t.Errorf("expected commands:\n%#v\ngot:\n%#v", expected, mock.commands)
+	}
+}
+
+// Test that getting an error in the middle of an action records the
+// error, and skips to the next action.
+func TestSkipOnError(t *testing.T) {
+	kube, mock := setup(t)
+	mock.createErr = errors.New("create failed")
+
+	def := platform.SyncDef{
+		Actions: []platform.SyncAction{
+			platform.SyncAction{
+				ResourceID: "fail in middle",
+				Delete:     []byte("succeeds"),
+				Create:     []byte("should fail"),
+				Apply:      []byte("skipped"),
+			},
+			platform.SyncAction{
+				ResourceID: "proceed",
+				Apply:      []byte("apply works"),
+			},
+		},
+	}
+
+	err := kube.Sync(def)
+	switch err := err.(type) {
+	case platform.SyncError:
+		if _, ok := err["fail in middle"]; !ok {
+			t.Errorf("expected error for failing resource %q, but got %#v", "fail in middle", err)
+		}
+	default:
+		t.Errorf("expected sync error, got %#v", err)
+	}
+
+	expected := []command{
+		command{"delete", "succeeds"},
+		command{"create", "should fail"},
+		// skip to next resource after failure
+		command{"apply", "apply works"},
+	}
+	if !reflect.DeepEqual(expected, mock.commands) {
+		t.Errorf("expected commands:\n%#v\ngot:\n%#v", expected, mock.commands)
+	}
+}

--- a/platform/metrics.go
+++ b/platform/metrics.go
@@ -90,6 +90,16 @@ func (i *instrumentedPlatform) Export() (config []byte, err error) {
 	return i.p.Export()
 }
 
+func (i *instrumentedPlatform) Sync(spec SyncDef) (err error) {
+	defer func(begin time.Time) {
+		requestDuration.With(
+			fluxmetrics.LabelMethod, "Sync",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
+		).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	return i.p.Sync(spec)
+}
+
 // BusMetrics has metrics for messages buses.
 type BusMetrics struct {
 	KickCount metrics.Counter

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -125,7 +125,6 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 			SyncAction{
 				ResourceID: "service/foo/bar",
 				Apply:      []byte("apply this"),
-				Create:     []byte("create this"),
 			},
 		},
 	}

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -23,6 +23,8 @@ type MockPlatform struct {
 
 	ExportAnswer []byte
 	ExportError  error
+
+	SyncError error
 }
 
 func (p *MockPlatform) AllServices(ns string, ss flux.ServiceIDSet) ([]Service, error) {
@@ -62,4 +64,8 @@ func (p *MockPlatform) Version() (string, error) {
 
 func (p *MockPlatform) Export() ([]byte, error) {
 	return p.ExportAnswer, p.ExportError
+}
+
+func (p *MockPlatform) Sync(SyncDef) error {
+	return p.SyncError
 }

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -117,13 +117,15 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	}
 
 	expectedSyncDef := SyncDef{
-		Actions: map[ResourceID]SyncAction{
-			ResourceID("deployment/foo/bar"): SyncAction{
-				Delete: []byte("delete this"),
+		Actions: []SyncAction{
+			SyncAction{
+				ResourceID: "deployment/foo/bar",
+				Delete:     []byte("delete this"),
 			},
-			ResourceID("service/foo/bar"): SyncAction{
-				Apply:  []byte("apply this"),
-				Create: []byte("create this"),
+			SyncAction{
+				ResourceID: "service/foo/bar",
+				Apply:      []byte("apply this"),
+				Create:     []byte("create this"),
 			},
 		},
 	}
@@ -216,7 +218,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	}
 
 	syncErrors := SyncError{
-		ResourceID("deployment/foo/bar"): errors.New("delete failed for this"),
+		"deployment/foo/bar": errors.New("delete failed for this"),
 	}
 	mock.SyncError = syncErrors
 	err = client.Sync(expectedSyncDef)

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -1,6 +1,11 @@
 package platform
 
 import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
 	"github.com/weaveworks/flux"
 )
 
@@ -24,7 +29,8 @@ type MockPlatform struct {
 	ExportAnswer []byte
 	ExportError  error
 
-	SyncError error
+	SyncArgTest func(SyncDef) error
+	SyncError   error
 }
 
 func (p *MockPlatform) AllServices(ns string, ss flux.ServiceIDSet) ([]Service, error) {
@@ -66,6 +72,155 @@ func (p *MockPlatform) Export() ([]byte, error) {
 	return p.ExportAnswer, p.ExportError
 }
 
-func (p *MockPlatform) Sync(SyncDef) error {
+func (p *MockPlatform) Sync(def SyncDef) error {
+	if p.SyncArgTest != nil {
+		if err := p.SyncArgTest(def); err != nil {
+			return err
+		}
+	}
 	return p.SyncError
+}
+
+// -- battery of tests for a platform mechanism
+
+func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
+	// set up
+	namespace := "space-of-names"
+	serviceID := flux.ServiceID(namespace + "/service")
+	serviceList := []flux.ServiceID{serviceID}
+	services := flux.ServiceIDSet{}
+	services.Add(serviceList)
+
+	expectedDefs := []ServiceDefinition{
+		{
+			ServiceID:     serviceID,
+			NewDefinition: []byte("imagine a definition here"),
+		},
+	}
+
+	serviceAnswer := []Service{
+		Service{
+			ID:       flux.ServiceID("foobar/hello"),
+			IP:       "10.32.1.45",
+			Metadata: map[string]string{},
+			Status:   "ok",
+			Containers: ContainersOrExcuse{
+				Containers: []Container{
+					Container{
+						Name:  "frobnicator",
+						Image: "quay.io/example.com/frob:v0.4.5",
+					},
+				},
+			},
+		},
+		Service{},
+	}
+
+	expectedSyncDef := SyncDef{
+		Actions: map[ResourceID]SyncAction{
+			ResourceID("deployment/foo/bar"): SyncAction{
+				Delete: []byte("delete this"),
+			},
+			ResourceID("service/foo/bar"): SyncAction{
+				Apply:  []byte("apply this"),
+				Create: []byte("create this"),
+			},
+		},
+	}
+
+	mock := &MockPlatform{
+		AllServicesArgTest: func(ns string, ss flux.ServiceIDSet) error {
+			if !(ns == namespace &&
+				ss.Contains(serviceID)) {
+				return fmt.Errorf("did not get expected args, got %q, %+v", ns, ss)
+			}
+			return nil
+		},
+		AllServicesAnswer: serviceAnswer,
+
+		SomeServicesArgTest: func(ss []flux.ServiceID) error {
+			if !reflect.DeepEqual(ss, serviceList) {
+				return fmt.Errorf("did not get expected args, got %+v", ss)
+			}
+			return nil
+		},
+		SomeServicesAnswer: serviceAnswer,
+
+		ApplyArgTest: func(defs []ServiceDefinition) error {
+			if !reflect.DeepEqual(expectedDefs, defs) {
+				return fmt.Errorf("did not get expected args, got %+v", defs)
+			}
+			return nil
+		},
+		ApplyError: nil,
+
+		SyncArgTest: func(def SyncDef) error {
+			if !reflect.DeepEqual(expectedSyncDef, def) {
+				return fmt.Errorf("did not get expected sync def, got %+v", def)
+			}
+			return nil
+		},
+		SyncError: nil,
+	}
+
+	// OK, here we go
+	client := wrap(mock)
+
+	if err := client.Ping(); err != nil {
+		t.Fatal(err)
+	}
+
+	ss, err := client.AllServices(namespace, services)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(ss, mock.AllServicesAnswer) {
+		t.Error(fmt.Errorf("expected %d result(s), got %+v", len(mock.AllServicesAnswer), ss))
+	}
+	mock.AllServicesError = fmt.Errorf("all services query failure")
+	ss, err = client.AllServices(namespace, services)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+
+	ss, err = client.SomeServices(serviceList)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(ss, mock.SomeServicesAnswer) {
+		t.Error(fmt.Errorf("expected %d result(s), got %+v", len(mock.SomeServicesAnswer), ss))
+	}
+	mock.SomeServicesError = fmt.Errorf("fail for some reason")
+	ss, err = client.SomeServices(serviceList)
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+
+	err = client.Apply(expectedDefs)
+	if err != nil {
+		t.Error(err)
+	}
+
+	applyErrors := ApplyError{
+		serviceID: fmt.Errorf("it just failed"),
+	}
+	mock.ApplyError = applyErrors
+	err = client.Apply(expectedDefs)
+	if !reflect.DeepEqual(err, applyErrors) {
+		t.Errorf("expected ApplyError, got %#v", err)
+	}
+
+	err = client.Sync(expectedSyncDef)
+	if err != nil {
+		t.Error(err)
+	}
+
+	syncErrors := SyncError{
+		ResourceID("deployment/foo/bar"): errors.New("delete failed for this"),
+	}
+	mock.SyncError = syncErrors
+	err = client.Sync(expectedSyncDef)
+	if !reflect.DeepEqual(err, syncErrors) {
+		t.Errorf("expected SyncError, got %+v", err)
+	}
 }

--- a/platform/platform.go
+++ b/platform/platform.go
@@ -24,6 +24,7 @@ type PlatformV5 interface {
 	PlatformV4
 	// Additional methods accumulate here as we develop V5
 	Export() ([]byte, error)
+	Sync(SyncDef) error
 }
 
 // Platform is the interface various platforms fulfill, e.g.

--- a/platform/platform_test.go
+++ b/platform/platform_test.go
@@ -7,14 +7,17 @@ import (
 	"github.com/weaveworks/flux"
 )
 
+// Just tests that the mock does its job.
 func TestPlatformMock(t *testing.T) {
-	var p Platform = &MockPlatform{
+	var p = &MockPlatform{
 		AllServicesAnswer: []Service{Service{}},
 		SomeServicesArgTest: func([]flux.ServiceID) error {
 			return errors.New("arg fail")
 		},
-		ApplyError: errors.New("fail"),
+		ApplyError: errors.New("fail apply"),
+		SyncError:  errors.New("fail sync"),
 	}
+	var _ Platform = p
 
 	// Just token tests so we're attempting _something_ here
 	ss, err := p.AllServices("", flux.ServiceIDSet{})
@@ -33,5 +36,25 @@ func TestPlatformMock(t *testing.T) {
 	err = p.Apply([]ServiceDefinition{})
 	if err == nil {
 		t.Error("expected error, got nil")
+	}
+
+	p.ApplyError = nil
+	p.ApplyArgTest = func([]ServiceDefinition) error {
+		return errors.New("apply args fail")
+	}
+	if err = p.Apply([]ServiceDefinition{}); err == nil {
+		t.Error("expected error from apply, got nil")
+	}
+
+	if err = p.Sync(SyncDef{}); err == nil {
+		t.Error("expected error from sync, got nil")
+	}
+
+	p.SyncError = nil
+	p.SyncArgTest = func(SyncDef) error {
+		return errors.New("sync args fail")
+	}
+	if err = p.Sync(SyncDef{}); err == nil {
+		t.Error("expected error from sync, got nil")
 	}
 }

--- a/platform/rpc/baseclient.go
+++ b/platform/rpc/baseclient.go
@@ -9,7 +9,7 @@ import (
 
 type baseClient struct{}
 
-var _ platform.Platform = &baseClient{}
+var _ platform.Platform = baseClient{}
 
 func (bc baseClient) AllServices(string, flux.ServiceIDSet) ([]platform.Service, error) {
 	return nil, platform.UpgradeNeededError(errors.New("AllServices method not implemented"))
@@ -31,12 +31,10 @@ func (bc baseClient) Version() (string, error) {
 	return "", platform.UpgradeNeededError(errors.New("Version method not implemented"))
 }
 
-// Export is used to get service configuration in platform-specific format
 func (bc baseClient) Export() ([]byte, error) {
 	return nil, platform.UpgradeNeededError(errors.New("Export method not implemented"))
 }
 
-// Export is used to get service configuration in platform-specific format
 func (bc baseClient) Sync(platform.SyncDef) error {
 	return platform.UpgradeNeededError(errors.New("Sync method not implemented"))
 }

--- a/platform/rpc/baseclient.go
+++ b/platform/rpc/baseclient.go
@@ -32,6 +32,11 @@ func (bc baseClient) Version() (string, error) {
 }
 
 // Export is used to get service configuration in platform-specific format
-func (p baseClient) Export() ([]byte, error) {
+func (bc baseClient) Export() ([]byte, error) {
 	return nil, platform.UpgradeNeededError(errors.New("Export method not implemented"))
+}
+
+// Export is used to get service configuration in platform-specific format
+func (bc baseClient) Sync(platform.SyncDef) error {
+	return platform.UpgradeNeededError(errors.New("Sync method not implemented"))
 }

--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -33,6 +33,7 @@ const (
 	methodSomeServices = ".Platform.SomeServices"
 	methodApply        = ".Platform.Apply"
 	methodExport       = ".Platform.Export"
+	methodSync         = ".Platform.Sync"
 )
 
 type NATS struct {
@@ -135,6 +136,11 @@ type export struct{}
 
 type ExportResponse struct {
 	Config []byte
+	ErrorResponse
+}
+
+type SyncResponse struct {
+	Result fluxrpc.SyncResult
 	ErrorResponse
 }
 
@@ -246,6 +252,29 @@ func (r *natsPlatform) Export() ([]byte, error) {
 	}
 	return response.Config, extractError(response.ErrorResponse)
 }
+
+func (r *natsPlatform) Sync(spec platform.SyncDef) error {
+	var response SyncResponse
+	// I use the applyTimeout here to be conservative; just applying
+	// things should take much less time (though it'll still be in the
+	// seconds)
+	if err := r.conn.Request(r.instance+methodSync, spec, &response, applyTimeout); err != nil {
+		if err == nats.ErrTimeout {
+			err = platform.UnavailableError(err)
+		}
+		return err
+	}
+	if len(response.Result) > 0 {
+		errs := platform.SyncError{}
+		for s, e := range response.Result {
+			errs[s] = errors.New(e)
+		}
+		return errs
+	}
+	return extractError(response.ErrorResponse)
+}
+
+// --- end Platform implementation
 
 // Connect returns a platform.Platform implementation that can be used
 // to talk to a particular instance.

--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -18,13 +18,13 @@ const (
 	// We give subscriptions an age limit, because if we have very
 	// long-lived connections we don't get fine-enough-grained usage
 	// metrics
-	maxAge  = 2 * time.Hour
-	timeout = 5 * time.Second
+	maxAge         = 2 * time.Hour
+	defaultTimeout = 5 * time.Second
 	// Apply can take minutes, simply because some deployments take a
 	// while to roll out for whatever reason
-	applyTimeout = 20 * time.Minute
-	presenceTick = 50 * time.Millisecond
-	encoderType  = nats.JSON_ENCODER
+	defaultApplyTimeout = 20 * time.Minute
+	presenceTick        = 50 * time.Millisecond
+	encoderType         = nats.JSON_ENCODER
 
 	methodKick         = ".Platform.Kick"
 	methodPing         = ".Platform.Ping"
@@ -35,6 +35,9 @@ const (
 	methodExport       = ".Platform.Export"
 	methodSync         = ".Platform.Sync"
 )
+
+var applyTimeout = defaultApplyTimeout
+var timeout = defaultTimeout
 
 type NATS struct {
 	url string
@@ -381,6 +384,24 @@ func (n *NATS) Subscribe(instID flux.InstanceID, remote platform.Platform, done 
 				bytes, err = remote.Export()
 			}
 			n.enc.Publish(request.Reply, ExportResponse{bytes, makeErrorResponse(err)})
+		case strings.HasSuffix(request.Subject, methodSync):
+			var def platform.SyncDef
+			err = encoder.Decode(request.Subject, request.Data, &def)
+			if err == nil {
+				err = remote.Sync(def)
+			}
+			response := SyncResponse{}
+			switch syncErr := err.(type) {
+			case platform.SyncError:
+				result := fluxrpc.SyncResult{}
+				for s, e := range syncErr {
+					result[s] = e.Error()
+				}
+				response.Result = result
+			default:
+				response.ErrorResponse = makeErrorResponse(err)
+			}
+			n.enc.Publish(request.Reply, response)
 		default:
 			err = errors.New("unknown message: " + request.Subject)
 		}

--- a/platform/rpc/rpc_test.go
+++ b/platform/rpc/rpc_test.go
@@ -2,12 +2,10 @@ package rpc
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"reflect"
 	"testing"
 
-	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/platform"
 )
 
@@ -23,116 +21,18 @@ func pipes() (io.ReadWriteCloser, io.ReadWriteCloser) {
 }
 
 func TestRPC(t *testing.T) {
-	namespace := "space-of-names"
-	serviceID := flux.ServiceID(namespace + "/service")
-	serviceList := []flux.ServiceID{serviceID}
-	services := flux.ServiceIDSet{}
-	services.Add(serviceList)
 
-	expectedDefs := []platform.ServiceDefinition{
-		{
-			ServiceID:     serviceID,
-			NewDefinition: []byte("imagine a definition here"),
-		},
-	}
+	wrap := func(mock platform.Platform) platform.Platform {
+		clientConn, serverConn := pipes()
 
-	serviceAnswer := []platform.Service{
-		platform.Service{
-			ID:       flux.ServiceID("foobar/hello"),
-			IP:       "10.32.1.45",
-			Metadata: map[string]string{},
-			Status:   "ok",
-			Containers: platform.ContainersOrExcuse{
-				Containers: []platform.Container{
-					platform.Container{
-						Name:  "frobnicator",
-						Image: "quay.io/example.com/frob:v0.4.5",
-					},
-				},
-			},
-		},
-		platform.Service{},
+		server, err := NewServer(mock)
+		if err != nil {
+			t.Fatal(err)
+		}
+		go server.ServeConn(serverConn)
+		return NewClientV5(clientConn)
 	}
-
-	mock := &platform.MockPlatform{
-		AllServicesArgTest: func(ns string, ss flux.ServiceIDSet) error {
-			if !(ns == namespace &&
-				ss.Contains(serviceID)) {
-				return fmt.Errorf("did not get expected args, got %q, %+v", ns, ss)
-			}
-			return nil
-		},
-		AllServicesAnswer: serviceAnswer,
-
-		SomeServicesArgTest: func(ss []flux.ServiceID) error {
-			if !reflect.DeepEqual(ss, serviceList) {
-				return fmt.Errorf("did not get expected args, got %+v", ss)
-			}
-			return nil
-		},
-		SomeServicesAnswer: serviceAnswer,
-
-		ApplyArgTest: func(defs []platform.ServiceDefinition) error {
-			if !reflect.DeepEqual(expectedDefs, defs) {
-				return fmt.Errorf("did not get expected args, got %+v", defs)
-			}
-			return nil
-		},
-		ApplyError: nil,
-	}
-
-	clientConn, serverConn := pipes()
-
-	server, err := NewServer(mock)
-	if err != nil {
-		t.Fatal(err)
-	}
-	go server.ServeConn(serverConn)
-
-	client := NewClientV5(clientConn)
-	if err := client.Ping(); err != nil {
-		t.Fatal(err)
-	}
-
-	ss, err := client.AllServices(namespace, services)
-	if err != nil {
-		t.Error(err)
-	}
-	if !reflect.DeepEqual(ss, mock.AllServicesAnswer) {
-		t.Error(fmt.Errorf("expected %d result(s), got %+v", len(mock.AllServicesAnswer), ss))
-	}
-	mock.AllServicesError = fmt.Errorf("all services query failure")
-	ss, err = client.AllServices(namespace, services)
-	if err == nil {
-		t.Error("expected error, got nil")
-	}
-
-	ss, err = client.SomeServices(serviceList)
-	if err != nil {
-		t.Error(err)
-	}
-	if !reflect.DeepEqual(ss, mock.SomeServicesAnswer) {
-		t.Error(fmt.Errorf("expected %d result(s), got %+v", len(mock.SomeServicesAnswer), ss))
-	}
-	mock.SomeServicesError = fmt.Errorf("fail for some reason")
-	ss, err = client.SomeServices(serviceList)
-	if err == nil {
-		t.Error("expected error, got nil")
-	}
-
-	err = client.Apply(expectedDefs)
-	if err != nil {
-		t.Error(err)
-	}
-
-	applyErrors := platform.ApplyError{
-		serviceID: fmt.Errorf("it just failed"),
-	}
-	mock.ApplyError = applyErrors
-	err = client.Apply(expectedDefs)
-	if !reflect.DeepEqual(err, applyErrors) {
-		t.Errorf("expected ApplyError, got %#v", err)
-	}
+	platform.PlatformTestBattery(t, wrap)
 }
 
 // ---

--- a/platform/rpc/server.go
+++ b/platform/rpc/server.go
@@ -14,7 +14,7 @@ import (
 type ApplyResult map[flux.ServiceID]string
 
 // Likewise with SyncResult
-type SyncResult map[platform.ResourceID]string
+type SyncResult map[string]string
 
 // Server takes a platform and makes it available over RPC.
 type Server struct {

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -177,6 +177,18 @@ func (p *removeablePlatform) Export() (config []byte, err error) {
 	return p.remote.Export()
 }
 
+func (p *removeablePlatform) Sync(spec SyncDef) (err error) {
+	defer func() {
+		if _, ok := err.(FatalError); ok {
+			p.closeWithError(err)
+		}
+	}()
+	return p.remote.Sync(spec)
+}
+
+// disconnectedPlatform is a stub implementation used when the
+// platform is known to be missing.
+
 type disconnectedPlatform struct{}
 
 func (p disconnectedPlatform) AllServices(string, flux.ServiceIDSet) ([]Service, error) {
@@ -201,4 +213,8 @@ func (p disconnectedPlatform) Version() (string, error) {
 
 func (p disconnectedPlatform) Export() ([]byte, error) {
 	return nil, errNotSubscribed
+}
+
+func (p disconnectedPlatform) Sync(_ SyncDef) error {
+	return errNotSubscribed
 }

--- a/platform/sync.go
+++ b/platform/sync.go
@@ -1,0 +1,47 @@
+package platform
+
+import (
+	"strings"
+)
+
+// Definitions for use in synchronising a platform with a git repo.
+
+// This is really just to have a handle for reporting back; when,
+// e.g., deleting a resource, it's the definition that matters. (The
+// definition should certainly match the ID though, otherwise chaos or
+// at least confusion will ensue)
+type ResourceID string
+
+func (id ResourceID) String() string {
+	return string(id)
+}
+
+// Yep, resources are defined by opaque bytes. It's up to the platform
+// at the other end to do the right thing.
+type ResourceDef []byte
+
+// The action(s) to take on a particular resource.
+// This should just be done in order, i.e.,:
+//  1. delete if something in Delete
+//  2. create if something in Create
+//  3. apply if something in Apply
+type SyncAction struct {
+	Delete ResourceDef
+	Create ResourceDef
+	Apply  ResourceDef
+}
+
+type SyncDef struct {
+	// The actions to undertake
+	Actions map[ResourceID]SyncAction
+}
+
+type SyncError map[ResourceID]error
+
+func (err SyncError) Error() string {
+	var errs []string
+	for id, e := range err {
+		errs = append(errs, id.String()+": "+e.Error())
+	}
+	return strings.Join(errs, "; ")
+}

--- a/platform/sync.go
+++ b/platform/sync.go
@@ -6,16 +6,6 @@ import (
 
 // Definitions for use in synchronising a platform with a git repo.
 
-// This is really just to have a handle for reporting back; when,
-// e.g., deleting a resource, it's the definition that matters. (The
-// definition should certainly match the ID though, otherwise chaos or
-// at least confusion will ensue)
-type ResourceID string
-
-func (id ResourceID) String() string {
-	return string(id)
-}
-
 // Yep, resources are defined by opaque bytes. It's up to the platform
 // at the other end to do the right thing.
 type ResourceDef []byte
@@ -26,22 +16,25 @@ type ResourceDef []byte
 //  2. create if something in Create
 //  3. apply if something in Apply
 type SyncAction struct {
-	Delete ResourceDef
-	Create ResourceDef
-	Apply  ResourceDef
+	// The ID is just a handle for labeling any error. No other
+	// meaning is attached to it.
+	ResourceID string
+	Delete     ResourceDef
+	Create     ResourceDef
+	Apply      ResourceDef
 }
 
 type SyncDef struct {
 	// The actions to undertake
-	Actions map[ResourceID]SyncAction
+	Actions []SyncAction
 }
 
-type SyncError map[ResourceID]error
+type SyncError map[string]error
 
 func (err SyncError) Error() string {
 	var errs []string
 	for id, e := range err {
-		errs = append(errs, id.String()+": "+e.Error())
+		errs = append(errs, id+": "+e.Error())
 	}
 	return strings.Join(errs, "; ")
 }

--- a/platform/sync.go
+++ b/platform/sync.go
@@ -13,14 +13,12 @@ type ResourceDef []byte
 // The action(s) to take on a particular resource.
 // This should just be done in order, i.e.,:
 //  1. delete if something in Delete
-//  2. create if something in Create
-//  3. apply if something in Apply
+//  2. apply if something in Apply
 type SyncAction struct {
 	// The ID is just a handle for labeling any error. No other
 	// meaning is attached to it.
 	ResourceID string
 	Delete     ResourceDef
-	Create     ResourceDef
 	Apply      ResourceDef
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -499,3 +499,12 @@ func (p *loggingPlatform) Export() (config []byte, err error) {
 	}()
 	return p.platform.Export()
 }
+
+func (p *loggingPlatform) Sync(def platform.SyncDef) (err error) {
+	defer func() {
+		if err != nil {
+			p.logger.Log("method", "Sync", "error", err)
+		}
+	}()
+	return p.platform.Sync(def)
+}


### PR DESCRIPTION
Adds a new method to platform, `Sync`, which is designed to be used for synchronising the cluster with git. Reimplements Apply in terms of Sync (vice-versa is not in general possible).

This has the side-effect of making all releases asynchronous, i.e., they succeed as soon as `kubectl apply` returns. If this is not actually what we want (I'm undecided), synchronisation can be restored by going back to the previous definition of Apply, or by using (async) Apply then asking the platform for the services in question until they match the versions required. Or something.

This PR dodges the question of what to do when applying replication controllers and daemonsets (they do not automatically start new pods, unlike deployments). They get `kubectl apply`d, which means the definition will be updated but the pods left alone. While sync is only used to implement releases, this won't matter, since they only affect deployments (assuming replication controllers are deprecated). But we should be careful to emit warnings, errors, or implement something sensible if we want to use sync in a more general way.