### PR TITLE
Record a cause for each release

### DIFF
--- a/automator/automator.go
+++ b/automator/automator.go
@@ -177,9 +177,15 @@ func (a *Automator) handleAutomatedInstanceJob(logger log.Logger, job *jobs.Job,
 			Method:   jobs.ReleaseJob,
 			Priority: jobs.PriorityBackground,
 			Params: jobs.ReleaseJobParams{
-				ServiceSpecs: services,
-				ImageSpec:    flux.ImageSpecFromID(imageID),
-				Kind:         flux.ReleaseKindExecute,
+				ReleaseSpec: flux.ReleaseSpec{
+					ServiceSpecs: services,
+					ImageSpec:    flux.ImageSpecFromID(imageID),
+					Kind:         flux.ReleaseKindExecute,
+				},
+				Cause: flux.ReleaseCause{
+					User:    flux.UserAutomated,
+					Message: fmt.Sprintf("due to new image %s", imageID.String()),
+				},
 			},
 		})
 	}

--- a/cmd/fluxctl/check_release_cmd_test.go
+++ b/cmd/fluxctl/check_release_cmd_test.go
@@ -1,6 +1,8 @@
 package main //+integration
 import (
 	"github.com/gorilla/mux"
+
+	"github.com/weaveworks/flux"
 	transport "github.com/weaveworks/flux/http"
 	"github.com/weaveworks/flux/jobs"
 	"testing"
@@ -52,7 +54,9 @@ func testCheckReleaseArgs(t *testing.T, args []string, shouldErr bool, errMsg st
 				Done: true,
 				ID:   "1",
 				Params: jobs.ReleaseJobParams{
-					Kind: "test",
+					ReleaseSpec: flux.ReleaseSpec{
+						Kind: "test",
+					},
 				},
 				Method: jobs.ReleaseJob,
 			},

--- a/cmd/fluxctl/release_cmd_test.go
+++ b/cmd/fluxctl/release_cmd_test.go
@@ -103,7 +103,9 @@ func newMockService() *genericMockRoundTripper {
 				Done: true,
 				ID:   "1",
 				Params: jobs.ReleaseJobParams{
-					Kind: "test",
+					ReleaseSpec: flux.ReleaseSpec{
+						Kind: "test",
+					},
 				},
 				Method: jobs.ReleaseJob,
 			},

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -45,12 +45,19 @@ func (c *client) ListImages(_ flux.InstanceID, s flux.ServiceSpec) ([]flux.Image
 }
 
 func (c *client) PostRelease(_ flux.InstanceID, s jobs.ReleaseJobParams) (jobs.JobID, error) {
-	args := []string{"image", string(s.ImageSpec), "kind", string(s.Kind)}
+	args := []string{
+		"image", string(s.ImageSpec),
+		"kind", string(s.Kind),
+		"user", s.Cause.User,
+	}
 	for _, spec := range s.ServiceSpecs {
 		args = append(args, "service", string(spec))
 	}
 	for _, ex := range s.Excludes {
 		args = append(args, "exclude", string(ex))
+	}
+	if s.Cause.Message != "" {
+		args = append(args, "message", s.Cause.Message)
 	}
 
 	var resp transport.PostReleaseResponse

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -134,10 +134,16 @@ func (s HTTPService) PostRelease(w http.ResponseWriter, r *http.Request) {
 	}
 
 	id, err := s.service.PostRelease(inst, jobs.ReleaseJobParams{
-		ServiceSpecs: serviceSpecs,
-		ImageSpec:    imageSpec,
-		Kind:         releaseKind,
-		Excludes:     excludes,
+		ReleaseSpec: flux.ReleaseSpec{
+			ServiceSpecs: serviceSpecs,
+			ImageSpec:    imageSpec,
+			Kind:         releaseKind,
+			Excludes:     excludes,
+		},
+		Cause: flux.ReleaseCause{
+			User:    r.FormValue("user"),
+			Message: r.FormValue("message"),
+		},
 	})
 	if err != nil {
 		errorResponse(w, r, err)

--- a/jobs/job.go
+++ b/jobs/job.go
@@ -136,10 +136,13 @@ func (j *Job) UnmarshalJSON(data []byte) error {
 }
 
 // ReleaseJobParams are the params for a release job
-type ReleaseJobParams flux.ReleaseSpec
+type ReleaseJobParams struct {
+	flux.ReleaseSpec
+	Cause flux.ReleaseCause
+}
 
 func (params ReleaseJobParams) Spec() flux.ReleaseSpec {
-	return flux.ReleaseSpec(params)
+	return params.ReleaseSpec
 }
 
 // AutomatedInstanceJobParams are the params for an automated_instance job

--- a/jobs/job_test.go
+++ b/jobs/job_test.go
@@ -77,9 +77,11 @@ func TestJobEncodingDecoding(t *testing.T) {
 		Queue:    DefaultQueue,
 		Method:   ReleaseJob,
 		Params: ReleaseJobParams{
-			ServiceSpecs: []flux.ServiceSpec{flux.ServiceSpecAll},
-			ImageSpec:    flux.ImageSpecLatest,
-			Kind:         flux.ReleaseKindExecute,
+			ReleaseSpec: flux.ReleaseSpec{
+				ServiceSpecs: []flux.ServiceSpec{flux.ServiceSpecAll},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+			},
 		},
 		ScheduledAt: now,
 		Priority:    PriorityInteractive,

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -44,6 +44,10 @@ func exampleRelease(t *testing.T) flux.Release {
 				},
 			},
 		},
+		Cause: flux.ReleaseCause{
+			User:    "test-user",
+			Message: "this was to test notifications",
+		},
 	}
 }
 

--- a/notifications/slack.go
+++ b/notifications/slack.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultReleaseTemplate = `Release {{trim (print .Spec.ImageSpec) "<>"}} to {{with .Spec.ServiceSpecs}}{{range $index, $spec := .}}{{if not (eq $index 0)}}, {{if last $index $.Spec.ServiceSpecs}}and {{end}}{{end}}{{trim (print .) "<>"}}{{end}}{{end}}. {{with .Error}}{{.}}. failed{{else}}done{{end}}`
+	defaultReleaseTemplate = `Release {{with .Cause}}{{if .User}}({{.User}}){{end}}{{end}} {{trim (print .Spec.ImageSpec) "<>"}} to {{with .Spec.ServiceSpecs}}{{range $index, $spec := .}}{{if not (eq $index 0)}}, {{if last $index $.Spec.ServiceSpecs}}and {{end}}{{end}}{{trim (print .) "<>"}}{{end}}{{end}}. {{with .Error}}{{.}}. failed{{else}}done{{end}}`
 )
 
 var (

--- a/notifications/slack_test.go
+++ b/notifications/slack_test.go
@@ -44,7 +44,7 @@ func TestSlackNotifier(t *testing.T) {
 	}
 	for k, expectedV := range map[string]string{
 		"username": "user1",
-		"text":     "Release all latest to default/helloworld. test-error. failed",
+		"text":     "Release (test-user) all latest to default/helloworld. test-error. failed",
 	} {
 		if v, ok := body[k]; !ok || v != expectedV {
 			t.Errorf("Expected %s to have been set to %q, but got: %q", k, expectedV, v)

--- a/release.go
+++ b/release.go
@@ -43,6 +43,14 @@ func NewReleaseID() ReleaseID {
 	return ReleaseID(guid.New())
 }
 
+// How did this release get triggered?
+type ReleaseCause struct {
+	Message string
+	User    string
+}
+
+const UserAutomated = "<automated>"
+
 // Release describes a release
 type Release struct {
 	ID        ReleaseID            `json:"id"`
@@ -54,6 +62,7 @@ type Release struct {
 	Status    ServiceReleaseStatus `json:"status"`
 	Log       []string             `json:"log"`
 
+	Cause  ReleaseCause  `json:"cause"`
 	Spec   ReleaseSpec   `json:"spec"`
 	Result ReleaseResult `json:"result"`
 }

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -170,11 +170,13 @@ func (r *Releaser) release(instanceID flux.InstanceID, job *jobs.Job, logStatus 
 		Status:   status,
 		Log:      job.Log,
 
+		Cause:  job.Params.(jobs.ReleaseJobParams).Cause,
 		Spec:   job.Params.(jobs.ReleaseJobParams).Spec(),
 		Result: results,
 	}
 
 	// Report on success or failure of the application above.
+	logStatus("Sending notifications.")
 	timer = NewStageTimer("send_notifications")
 	notifyErr := sendNotifications(rc.Instance, applyErr, release)
 	timer.ObserveDuration()

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -49,9 +49,11 @@ func TestMissingFromPlatform(t *testing.T) {
 	}
 
 	spec := jobs.ReleaseJobParams{
-		ServiceSpec: flux.ServiceSpecAll,
-		ImageSpec:   flux.ImageSpecLatest,
-		Kind:        flux.ReleaseKindPlan,
+		ReleaseSpec: flux.ReleaseSpec{
+			ServiceSpec: flux.ServiceSpecAll,
+			ImageSpec:   flux.ImageSpecLatest,
+			Kind:        flux.ReleaseKindPlan,
+		},
 	}
 
 	results := flux.ReleaseResult{}
@@ -82,9 +84,11 @@ func TestMissingFromPlatform(t *testing.T) {
 	}
 
 	spec = jobs.ReleaseJobParams{
-		ServiceSpec: flux.ServiceSpec("default/helloworld"),
-		ImageSpec:   flux.ImageSpecLatest,
-		Kind:        flux.ReleaseKindPlan,
+		ReleaseSpec: flux.ReleaseSpec{
+			ServiceSpec: flux.ServiceSpec("default/helloworld"),
+			ImageSpec:   flux.ImageSpecLatest,
+			Kind:        flux.ReleaseKindPlan,
+		},
 	}
 	results = flux.ReleaseResult{}
 	moreJobs, err = releaser.release(flux.InstanceID("unimportant"),
@@ -152,9 +156,11 @@ func TestUpdateOne(t *testing.T) {
 	defer cleanup()
 
 	spec := jobs.ReleaseJobParams{
-		ServiceSpec: flux.ServiceSpec("default/helloworld"),
-		ImageSpec:   flux.ImageSpecLatest,
-		Kind:        flux.ReleaseKindExecute,
+		ReleaseSpec: flux.ReleaseSpec{
+			ServiceSpec: flux.ServiceSpec("default/helloworld"),
+			ImageSpec:   flux.ImageSpecLatest,
+			Kind:        flux.ReleaseKindExecute,
+		},
 	}
 
 	results := flux.ReleaseResult{}


### PR DESCRIPTION
This is just a username (possibly "<automated>") and a message (possibly supplied by the user, possibly empty).

The cause is not displayed in any output, barring "raw" output such as check-release can give. It _could_ go in:
 * notifications
 * history
and web UI.

Since the arguments are strictly optional, I've not updated the API version. Also, existing records of jobs should deserialise into the new struct (though I should test that).