### PR TITLE
Deprecate updating ReplicationControllers

### DIFF
--- a/platform/kubernetes/errors.go
+++ b/platform/kubernetes/errors.go
@@ -1,0 +1,43 @@
+package kubernetes
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/weaveworks/flux"
+)
+
+var ErrReplicationControllersDeprecated = flux.UserConfigProblem{
+	&flux.BaseError{
+		Err: errors.New("updating replication controllers is deprecated"),
+		Help: `Using Flux to update replication controllers is deprecated.
+
+ReplicationController resources are difficult to update, and it is
+almost certainly better to use a Deployment resource instead. Please
+see
+
+    https://kubernetes.io/docs/user-guide/replication-controller/#deployment-recommended
+
+If replacing with a Deployment is not possible, you can still update a
+ReplicationController manually (e.g., with kubectl rolling-update).
+`,
+	},
+}
+
+func UpdateNotSupportedError(kind string) error {
+	return flux.UserConfigProblem{
+		&flux.BaseError{
+			Err: fmt.Errorf("updating resource kind %q not supported", kind),
+			Help: `Flux does not support updating ` + kind + ` resources.
+
+This may be because those resources do not use images, or because it
+is a new kind of resource in Kubernetes, and Flux does not support it
+yet.
+
+If you can use a Deployment instead, Flux can work with
+those. Otherwise, you may have to update the resource manually (e.g.,
+using kubectl).
+`,
+		},
+	}
+}

--- a/platform/kubernetes/update.go
+++ b/platform/kubernetes/update.go
@@ -19,8 +19,22 @@ import (
 // This function has many additional requirements that are likely in flux. Read
 // the source to learn about them.
 func UpdatePodController(def []byte, newImageID flux.ImageID, trace io.Writer) ([]byte, error) {
+	// Sanity check
+	obj, err := definitionObj(def)
+	if err != nil {
+		return nil, err
+	}
+	switch obj.Kind {
+	case "ReplicationController":
+		return nil, ErrReplicationControllersDeprecated
+	case "Deployment":
+		break
+	default:
+		return nil, UpdateNotSupportedError(obj.Kind)
+	}
+
 	var buf bytes.Buffer
-	err := tryUpdate(string(def), newImageID, trace, &buf)
+	err = tryUpdate(string(def), newImageID, trace, &buf)
 	return buf.Bytes(), err
 }
 

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -359,6 +359,7 @@ func calculateImageUpdates(inst *instance.Instance, candidates []*ServiceUpdate,
 
 			update.ManifestBytes, err = kubernetes.UpdatePodController(update.ManifestBytes, latestImage.ID, ioutil.Discard)
 			if err != nil {
+				logStatus("Failed on service %s: %s", update.ServiceID, err.Error())
 				return nil, err
 			}
 


### PR DESCRIPTION
There are a few places where we can detect replication controllers and
return an error:

 * when listing the services or images
 * when updating a manifest
 * when applying an updated manifest

In the first case, I thought it would be strange to remove information
from the UI by supplying an error instead of container information. So
that stays as it is.

The second case is the best point, since it occurs just before a
lasting change (git commit) is made. The third case, failing to apply
the change, is really a backstop -- a change has been committed by
this point, which shouldn't have happened -- but it means we can
remove a bunch of code dealing with `kubectl rolling-upgrade`.

There is a choice between failing to update _just this service_, and
failing a release altogether. I have opted for the latter, because it
means we can put a big help message in front of the user.

(A more subtle (but maybe confusing?) approach is to fail just the
service, if it's one of many, or fail the whole thing if the release
is specifically for this service.)