### PR TITLE
Update fluxsvc test with release cause struct change

### DIFF
--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -215,9 +215,11 @@ func TestFluxsvc_Release(t *testing.T) {
 
 	// Test PostRelease
 	r, err := apiClient.PostRelease("", jobs.ReleaseJobParams{
-		ImageSpec:    "alpine:latest",
-		Kind:         "execute",
-		ServiceSpecs: []flux.ServiceSpec{helloWorldSvc},
+		ReleaseSpec: flux.ReleaseSpec{
+			ImageSpec:    "alpine:latest",
+			Kind:         "execute",
+			ServiceSpecs: []flux.ServiceSpec{helloWorldSvc},
+		},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
The merge of #495 collided with the earlier merge of #450, such that tests on master don't pass. This reconciles them.