### PR TITLE
WIP: Added HTTP API to return the value of a single configuration key

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -18,6 +18,7 @@ type ClientService interface {
 	Unlock(flux.InstanceID, flux.ServiceID) error
 	History(flux.InstanceID, flux.ServiceSpec) ([]flux.HistoryEntry, error)
 	GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error)
+	GetConfigSingle(flux.InstanceID, string, string) (string, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
 	GenerateDeployKey(flux.InstanceID) error
 	Export(inst flux.InstanceID) ([]byte, error)

--- a/api/api.go
+++ b/api/api.go
@@ -20,6 +20,8 @@ type ClientService interface {
 	GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error)
 	GetConfigSingle(flux.InstanceID, string, string) (string, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
+	SetConfigSingle(flux.InstanceID, flux.SingleConfigParams, string) error
+	DeleteConfigSingle(flux.InstanceID, flux.SingleConfigParams) error
 	GenerateDeployKey(flux.InstanceID) error
 	Export(inst flux.InstanceID) ([]byte, error)
 }

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -485,6 +485,64 @@ func TestFluxsvc_GetConfigSingleSecret(t *testing.T) {
 	}
 }
 
+func TestFluxsvc_SetConfigSingle(t *testing.T) {
+	setup()
+	defer teardown()
+
+	err := apiClient.SetConfigSingle("", flux.SingleConfigParams{
+		Key:    "git.branch",
+		Syntax: "yaml",
+	}, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resp, err := apiClient.GetConfigSingle("", "git.branch", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != "test" {
+		t.Fatal("Should have set config but got", resp)
+	}
+}
+
+func TestFluxsvc_DeleteConfigSingle(t *testing.T) {
+	setup()
+	defer teardown()
+
+	err := apiClient.SetConfig("", flux.UnsafeInstanceConfig{
+		Git: flux.GitConfig{
+			Branch: "dummy",
+			Key:    "exampleKey",
+		},
+		Registry: flux.RegistryConfig{
+			Auths: map[string]flux.Auth{
+				"https://index.docker.io/v1/": flux.Auth{
+					Auth: "dXNlcjpwYXNzd29yZA==",
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = apiClient.DeleteConfigSingle("", flux.SingleConfigParams{
+		Key:    "git.branch",
+		Syntax: "yaml",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := apiClient.GetConfigSingle("", "git.branch", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp != "" {
+		t.Fatal("Config should be blank (deleted)")
+	}
+}
+
 func TestFluxsvc_DeployKeys(t *testing.T) {
 	setup()
 	defer teardown()

--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	"errors"
 	"golang.org/x/crypto/ssh"
 	"reflect"
 	"regexp"
@@ -14,8 +15,10 @@ import (
 const secretReplacement = "******"
 
 var (
-	settingCleaner  = regexp.MustCompile(`[']`)
-	settingSplitter = regexp.MustCompile(`('.+'|[^.]+)`)
+	settingCleaner   = regexp.MustCompile(`[']`)
+	settingSplitter  = regexp.MustCompile(`('.+'|[^.]+)`)
+	settingDelimiter = "."
+	mapKeyWrapper    = byte('\'')
 )
 
 // Instance configuration, mutated via `fluxctl config`. It can be
@@ -51,6 +54,13 @@ type InstanceConfig struct {
 	Git      GitConfig      `json:"git" yaml:"git"`
 	Slack    NotifierConfig `json:"slack" yaml:"slack"`
 	Registry RegistryConfig `json:"registry" yaml:"registry"`
+}
+
+type ConfigSyntax string
+
+type SingleConfigParams struct {
+	Key    string
+	Syntax ConfigSyntax
 }
 
 // As a safeguard, we make the default behaviour to hide secrets when
@@ -109,13 +119,74 @@ func (g GitConfig) HideKey() GitConfig {
 	return g
 }
 
+// WriteSetting will set a value in an InstanceConfig struct for a given key.
+// The reference to the config must be a pointer so it can update values in place.
+func (c *InstanceConfig) WriteSetting(setting SingleConfigParams, value string) error {
+	if setting.Syntax == "" {
+		setting.Syntax = "yaml" // Default to yaml, to match `fluxctl get-config`
+	}
+
+	// Get value for the configuration path
+	w := configWalker{
+		string(setting.Syntax),
+	}
+
+	path := setting.Key
+	v := reflect.ValueOf(c)
+	splitPaths := settingSplitter.FindAllString(path, -1)
+	// Only walk up to the first map. Then have custom code to write to specific maps
+	// Really hacky way of doing it, but I've no better idea right now.
+	lastIndex := 0
+	for ; lastIndex < len(splitPaths); lastIndex++ {
+		v = w.walk(v, splitPaths[lastIndex])
+		if v.Kind() == reflect.Map {
+			break
+		}
+	}
+
+	if !v.CanSet() {
+		return Missing{
+			BaseError: &BaseError{
+				Help: "The requested configuration parameter does not exist. Please ensure your request matches the configuration from `fluxctl get-config`",
+				Err:  errors.New("Configuration parameter does not exist"),
+			},
+		}
+	}
+
+	// Special set for maps
+	switch v.Kind() {
+	case reflect.Map:
+		m := v.Interface()
+		match := settingCleaner.ReplaceAllString(splitPaths[lastIndex+1], "")
+		switch m.(type) {
+		case map[string]Auth:
+			castMap := v.Interface().(map[string]Auth)
+			newMap := make(map[string]Auth, len(castMap))
+			for k, v := range castMap {
+				if k == match {
+					newMap[k] = Auth{value}
+				} else {
+					newMap[k] = v
+				}
+			}
+			v.Set(reflect.ValueOf(newMap))
+		default:
+			panic("Setting map of type " + v.Kind().String() + " is not implemented")
+		}
+		break
+	default:
+		v.SetString(value)
+	}
+	return nil
+}
+
 // FindSetting returns a reflect.Value representing the found setting.
 // If the Value is invalid, the setting wasn't found.
 // Only allow from SafeInstanceConfig to attempt to prevent leaking
 // secure variables.
 func (c SafeInstanceConfig) FindSetting(path, syntax string) reflect.Value {
 	if syntax == "" {
-		syntax = "yaml" // Default to yaml, to match `fluxctl get-config`
+		syntax = "yaml" // Default to yaml, to key `fluxctl get-config`
 	}
 	// Split path into configuration keys
 	confKeys := settingSplitter.FindAllString(path, -1)
@@ -124,7 +195,22 @@ func (c SafeInstanceConfig) FindSetting(path, syntax string) reflect.Value {
 	w := configWalker{
 		syntax,
 	}
-	return w.walk(reflect.ValueOf(c), confKeys...)
+	v := w.walk(reflect.ValueOf(c), confKeys...)
+
+	// Special get for maps
+	if v.Kind() == reflect.Map {
+		m := v.Interface()
+		paths := settingSplitter.FindAllString(path, -1)
+		key := settingCleaner.ReplaceAllString(paths[len(paths)-1], "")
+		switch m.(type) {
+		case map[string]Auth:
+			castMap := v.Interface().(map[string]Auth)
+			v = reflect.ValueOf(castMap[key].Auth)
+		default:
+			panic("Getting map of type " + v.Kind().String() + " is not implemented")
+		}
+	}
+	return v
 }
 
 type configWalker struct {
@@ -136,34 +222,56 @@ type configWalker struct {
 // E.g. git.url will first look for a top level
 // field with a json tag called git, reflect into that struct and then
 // find and return a field that has the json tag url.
-func (w configWalker) walk(topValue reflect.Value, paths ...string) reflect.Value {
-	// Clean path of any invalid character
-	paths[0] = settingCleaner.ReplaceAllString(paths[0], "")
-
-	var nextValue reflect.Value
-	switch topValue.Kind() {
+func (w configWalker) walk(v reflect.Value, paths ...string) reflect.Value {
+	nextPath := paths[0]
+	paths = paths[1:]
+	nextValue := reflect.Value{}
+	switch unwrap(v).Kind() {
 	case reflect.Struct:
-		nextValue = w.valueFromStruct(topValue, paths[0])
+		for i := 0; i < unwrap(v).NumField(); i++ {
+			vt := unwrap(v).Type().Field(i)
+			tag := vt.Tag.Get(w.Syntax)
+			if tag == nextPath {
+				nextValue = unwrap(v).Field(i)
+				break
+			}
+		}
 		break
 	case reflect.Map:
-		nextValue = w.valueFromMap(topValue, paths[0])
+		m := v.Interface()
+		key := settingCleaner.ReplaceAllString(nextPath, "")
+		switch m.(type) {
+		case map[string]Auth:
+			castMap := v.Interface().(map[string]Auth)
+			nextValue = reflect.ValueOf(castMap[key])
+		default:
+			panic("Getting map of type " + v.Kind().String() + " is not implemented")
+		}
 		break
 	}
-	// If we continue to have valid values and there are more paths to search
-	if nextValue.IsValid() && len(paths[1:]) > 0 {
-		return w.walk(nextValue, paths[1:]...)
+	if len(paths) > 0 {
+		return w.walk(nextValue, paths...)
 	}
-	// Final value
 	return nextValue
+}
+
+// unwrap is a helper to dereference values if they need to be.
+// To write values, values must be a pointer to a variable. But to read
+// from them they need to be dereferenced.
+func unwrap(v reflect.Value) reflect.Value {
+	if v.IsValid() && !v.CanAddr() && v.Kind() != reflect.Struct && v.Kind() != reflect.Map {
+		return v.Elem()
+	}
+	return v
 }
 
 // Search fields for json tags
 func (w configWalker) valueFromStruct(v reflect.Value, match string) reflect.Value {
-	for i := 0; i < v.NumField(); i++ {
-		vt := v.Type().Field(i)
-		jsonTag := vt.Tag.Get(w.Syntax)
-		if jsonTag == match {
-			return v.Field(i)
+	for i := 0; i < unwrap(v).NumField(); i++ {
+		vt := unwrap(v).Type().Field(i)
+		tag := vt.Tag.Get(w.Syntax)
+		if tag == match {
+			return unwrap(v).Field(i)
 		}
 	}
 	return reflect.Value{}

--- a/config.go
+++ b/config.go
@@ -7,9 +7,16 @@ import (
 	"strings"
 
 	"golang.org/x/crypto/ssh"
+	"reflect"
+	"regexp"
 )
 
 const secretReplacement = "******"
+
+var (
+	settingCleaner  = regexp.MustCompile(`[']`)
+	settingSplitter = regexp.MustCompile(`('.+'|[^.]+)`)
+)
 
 // Instance configuration, mutated via `fluxctl config`. It can be
 // supplied as YAML (hence YAML annotations) and is transported as
@@ -100,4 +107,79 @@ func (g GitConfig) HideKey() GitConfig {
 
 	g.Key = string(ssh.MarshalAuthorizedKey(pubKey))
 	return g
+}
+
+// FindSetting returns a reflect.Value representing the found setting.
+// If the Value is invalid, the setting wasn't found.
+// Only allow from SafeInstanceConfig to attempt to prevent leaking
+// secure variables.
+func (c SafeInstanceConfig) FindSetting(path, syntax string) reflect.Value {
+	if syntax == "" {
+		syntax = "yaml" // Default to yaml, to match `fluxctl get-config`
+	}
+	// Split path into configuration keys
+	confKeys := settingSplitter.FindAllString(path, -1)
+
+	// Get value for the configuration path
+	w := configWalker{
+		syntax,
+	}
+	return w.walk(reflect.ValueOf(c), confKeys...)
+}
+
+type configWalker struct {
+	Syntax string
+}
+
+// walk recursively walks through a struct to find an element
+// with the same json tag.
+// E.g. git.url will first look for a top level
+// field with a json tag called git, reflect into that struct and then
+// find and return a field that has the json tag url.
+func (w configWalker) walk(topValue reflect.Value, paths ...string) reflect.Value {
+	// Clean path of any invalid character
+	paths[0] = settingCleaner.ReplaceAllString(paths[0], "")
+
+	var nextValue reflect.Value
+	switch topValue.Kind() {
+	case reflect.Struct:
+		nextValue = w.valueFromStruct(topValue, paths[0])
+		break
+	case reflect.Map:
+		nextValue = w.valueFromMap(topValue, paths[0])
+		break
+	}
+	// If we continue to have valid values and there are more paths to search
+	if nextValue.IsValid() && len(paths[1:]) > 0 {
+		return w.walk(nextValue, paths[1:]...)
+	}
+	// Final value
+	return nextValue
+}
+
+// Search fields for json tags
+func (w configWalker) valueFromStruct(v reflect.Value, match string) reflect.Value {
+	for i := 0; i < v.NumField(); i++ {
+		vt := v.Type().Field(i)
+		jsonTag := vt.Tag.Get(w.Syntax)
+		if jsonTag == match {
+			return v.Field(i)
+		}
+	}
+	return reflect.Value{}
+}
+
+// Search for key in map
+func (w configWalker) valueFromMap(v reflect.Value, match string) reflect.Value {
+	m := v.Interface()
+	switch m.(type) {
+	case map[string]Auth:
+		castMap := v.Interface().(map[string]Auth)
+		for k, v := range castMap {
+			if k == match {
+				return reflect.ValueOf(v.Auth)
+			}
+		}
+	}
+	return reflect.Value{}
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,45 @@
+package flux
+
+import (
+	"testing"
+)
+
+func TestConfig_ParseSettingsPath(t *testing.T) {
+	// We're using SafeInstanceConfig here, but it isn't actually safe
+	// because we haven't done InstanceConfig.HideSecrets()
+	cfg := SafeInstanceConfig{
+		Git: GitConfig{
+			Branch: "exampleBranch",
+		},
+		Registry: RegistryConfig{
+			Auths: map[string]Auth{
+				"https://index.docker.io/v1/": {
+					Auth: "dXNlcjpwYXNzd29yZA==",
+				},
+			},
+		},
+	}
+
+	for _, v := range []struct {
+		Key    string
+		Value  string
+		Valid  bool
+		Syntax string
+	}{
+		{"git.branch", "exampleBranch", true, ""},                                          // Get a set parameter and empty syntax
+		{"slack.hookURL", "", true, ""},                                                    // Get an unset parameter
+		{"does.not.exist", "", false, ""},                                                  // Get a parameter that doesn't exist
+		{"registry.auths.'https://index.docker.io/v1/'", "dXNlcjpwYXNzd29yZA==", true, ""}, // Get a map value
+		{"git.branch", "exampleBranch", true, "json"},                                      // Test that json syntax works
+		{"git.branch", "exampleBranch", true, "yaml"},                                      // Test that yaml syntax works
+		{"git.branch", "", false, "invalid"},                                               // Test that invalid syntax doesn't work
+	} {
+		resp := cfg.FindSetting(v.Key, v.Syntax)
+		if resp.IsValid() != v.Valid {
+			t.Fatal(v.Key, "IsValid =", resp.IsValid())
+		}
+		if resp.IsValid() && resp.String() != v.Value {
+			t.Fatalf("%s: Expected %q but got %q", v.Key, v.Value, resp.String())
+		}
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,6 +1,7 @@
 package flux
 
 import (
+	"encoding/base64"
 	"testing"
 )
 
@@ -26,13 +27,13 @@ func TestConfig_ParseSettingsPath(t *testing.T) {
 		Valid  bool
 		Syntax string
 	}{
-		{"git.branch", "exampleBranch", true, ""},                                          // Get a set parameter and empty syntax
-		{"slack.hookURL", "", true, ""},                                                    // Get an unset parameter
-		{"does.not.exist", "", false, ""},                                                  // Get a parameter that doesn't exist
-		{"registry.auths.'https://index.docker.io/v1/'", "dXNlcjpwYXNzd29yZA==", true, ""}, // Get a map value
-		{"git.branch", "exampleBranch", true, "json"},                                      // Test that json syntax works
-		{"git.branch", "exampleBranch", true, "yaml"},                                      // Test that yaml syntax works
-		{"git.branch", "", false, "invalid"},                                               // Test that invalid syntax doesn't work
+		{"git.branch", "exampleBranch", true, ""},                                               // Get a set parameter and empty syntax
+		{"slack.hookURL", "", true, ""},                                                         // Get an unset parameter
+		{"does.not.exist", "", false, ""},                                                       // Get a parameter that doesn't exist
+		{"registry.auths.'https://index.docker.io/v1/'.auth", "dXNlcjpwYXNzd29yZA==", true, ""}, // Get a map value
+		{"git.branch", "exampleBranch", true, "json"},                                           // Test that json syntax works
+		{"git.branch", "exampleBranch", true, "yaml"},                                           // Test that yaml syntax works
+		{"git.branch", "", false, "invalid"},                                                    // Test that invalid syntax doesn't work
 	} {
 		resp := cfg.FindSetting(v.Key, v.Syntax)
 		if resp.IsValid() != v.Valid {
@@ -42,4 +43,49 @@ func TestConfig_ParseSettingsPath(t *testing.T) {
 			t.Fatalf("%s: Expected %q but got %q", v.Key, v.Value, resp.String())
 		}
 	}
+}
+
+func TestConfig_WriteSetting(t *testing.T) {
+	// We're using SafeInstanceConfig here, but it isn't actually safe
+	// because we haven't done InstanceConfig.HideSecrets()
+	cfg := InstanceConfig{
+		Git: GitConfig{
+			Branch: "exampleBranch",
+		},
+		Registry: RegistryConfig{
+			Auths: map[string]Auth{
+				"aaaa": {
+					Auth: base64.StdEncoding.EncodeToString([]byte(`user:password`)),
+				},
+				"https://index.docker.io/v1/": {
+					Auth: base64.StdEncoding.EncodeToString([]byte(`user:password`)),
+				},
+			},
+		},
+	}
+
+	for _, v := range []struct {
+		Key    string
+		Value  string
+		Result string
+		IsErr  bool
+		Syntax string
+	}{
+		{"git.branch", "newBranch", "newBranch", false, ""}, // Set a previously set value
+		{"git.URL", "newUrl", "newUrl", false, ""},          // Set on an empty value
+		{"git.abc", "", "", true, ""},                       // Set a param that doesn't exist
+		{"registry.auths.'https://index.docker.io/v1/'.auth", base64.StdEncoding.EncodeToString([]byte(`new:pass`)), "new:******", false, ""}, // Set a map value
+	} {
+		err := cfg.WriteSetting(SingleConfigParams{v.Key, ConfigSyntax(v.Syntax)}, v.Value)
+		if (err != nil) != v.IsErr {
+			t.Fatalf("%q: Expected error = %v, but got %v.", v.Key, v.IsErr, err != nil)
+		}
+		if !v.IsErr {
+			s := cfg.HideSecrets().FindSetting(v.Key, "").String()
+			if s != v.Result {
+				t.Fatalf("Setting has not changed for key %q. Expected %q but still %q\n", v.Key, v.Value, s)
+			}
+		}
+	}
+
 }

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -99,6 +99,11 @@ func (c *client) GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error) {
 	return res, err
 }
 
+func (c *client) GetConfigSingle(_ flux.InstanceID, settingPath, syntax string) (res string, err error) {
+	err = c.get(&res, "GetConfigSingle", "key", settingPath, "syntax", syntax)
+	return
+}
+
 func (c *client) SetConfig(_ flux.InstanceID, config flux.UnsafeInstanceConfig) error {
 	return c.postWithBody("SetConfig", config)
 }

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -44,6 +44,8 @@ func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger) http.Handle
 		"GetConfig":              handle.GetConfig,
 		"GetConfigSingle":        handle.GetConfigSingle,
 		"SetConfig":              handle.SetConfig,
+		"SetConfigSingle":        handle.SetConfigSingle,
+		"DeleteConfigSingle":     handle.DeleteConfigSingle,
 		"GenerateDeployKeys":     handle.GenerateKeys,
 		"PostIntegrationsGithub": handle.PostIntegrationsGithub,
 		"RegisterDaemonV4":       handle.RegisterV4,
@@ -297,6 +299,43 @@ func (s HTTPService) SetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.WriteHeader(http.StatusOK)
+}
+
+func (s HTTPService) SetConfigSingle(w http.ResponseWriter, r *http.Request) {
+	inst := getInstanceID(r)
+
+	settingPath := r.URL.Query().Get("key")
+	syntax := r.URL.Query().Get("syntax")
+	var value string
+	if err := json.NewDecoder(r.Body).Decode(&value); err != nil {
+		transport.WriteError(w, r, http.StatusBadRequest, err)
+		return
+	}
+	if err := s.service.SetConfigSingle(inst, flux.SingleConfigParams{
+		Key:    settingPath,
+		Syntax: flux.ConfigSyntax(syntax),
+	}, value); err != nil {
+		errorResponse(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s HTTPService) DeleteConfigSingle(w http.ResponseWriter, r *http.Request) {
+	inst := getInstanceID(r)
+
+	settingPath := r.URL.Query().Get("key")
+	syntax := r.URL.Query().Get("syntax")
+	if err := s.service.DeleteConfigSingle(inst, flux.SingleConfigParams{
+		Key:    settingPath,
+		Syntax: flux.ConfigSyntax(syntax),
+	}); err != nil {
+		errorResponse(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusResetContent)
 }
 
 func (s HTTPService) GenerateKeys(w http.ResponseWriter, r *http.Request) {

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -42,6 +42,7 @@ func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger) http.Handle
 		"History":                handle.History,
 		"Status":                 handle.Status,
 		"GetConfig":              handle.GetConfig,
+		"GetConfigSingle":        handle.GetConfigSingle,
 		"SetConfig":              handle.SetConfig,
 		"GenerateDeployKeys":     handle.GenerateKeys,
 		"PostIntegrationsGithub": handle.PostIntegrationsGithub,
@@ -264,6 +265,21 @@ func (s HTTPService) GetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	jsonResponse(w, r, config)
+}
+
+func (s HTTPService) GetConfigSingle(w http.ResponseWriter, r *http.Request) {
+	inst := getInstanceID(r)
+	settingPath := r.URL.Query().Get("key")
+	syntax := r.URL.Query().Get("syntax")
+	if syntax == "" {
+		syntax = "yaml"
+	}
+	value, err := s.service.GetConfigSingle(inst, settingPath, syntax)
+	if err != nil {
+		errorResponse(w, r, err)
+		return
+	}
+	jsonResponse(w, r, value)
 }
 
 func (s HTTPService) SetConfig(w http.ResponseWriter, r *http.Request) {

--- a/http/transport.go
+++ b/http/transport.go
@@ -36,6 +36,7 @@ func NewRouter() *mux.Router {
 	r.NewRoute().Name("History").Methods("GET").Path("/v3/history").Queries("service", "{service}")
 	r.NewRoute().Name("Status").Methods("GET").Path("/v3/status")
 	r.NewRoute().Name("GetConfig").Methods("GET").Path("/v4/config")
+	r.NewRoute().Name("GetConfigSingle").Methods("GET").Path("/v5/config").Queries("key", "{key}", "syntax", "{syntax}")
 	r.NewRoute().Name("SetConfig").Methods("POST").Path("/v4/config")
 	r.NewRoute().Name("GenerateDeployKeys").Methods("POST").Path("/v5/config/deploy-keys")
 	r.NewRoute().Name("PostIntegrationsGithub").Methods("POST").Path("/v5/integrations/github").Queries("owner", "{owner}", "repository", "{repository}")

--- a/http/transport.go
+++ b/http/transport.go
@@ -37,6 +37,8 @@ func NewRouter() *mux.Router {
 	r.NewRoute().Name("Status").Methods("GET").Path("/v3/status")
 	r.NewRoute().Name("GetConfig").Methods("GET").Path("/v4/config")
 	r.NewRoute().Name("GetConfigSingle").Methods("GET").Path("/v5/config").Queries("key", "{key}", "syntax", "{syntax}")
+	r.NewRoute().Name("SetConfigSingle").Methods("PUT").Path("/v5/config").Queries("key", "{key}", "syntax", "{syntax}")
+	r.NewRoute().Name("DeleteConfigSingle").Methods("DELETE").Path("/v5/config").Queries("key", "{key}", "syntax", "{syntax}")
 	r.NewRoute().Name("SetConfig").Methods("POST").Path("/v4/config")
 	r.NewRoute().Name("GenerateDeployKeys").Methods("POST").Path("/v5/config/deploy-keys")
 	r.NewRoute().Name("PostIntegrationsGithub").Methods("POST").Path("/v5/integrations/github").Queries("owner", "{owner}", "repository", "{repository}")

--- a/server/server.go
+++ b/server/server.go
@@ -385,6 +385,31 @@ func (s *Server) SetConfig(instID flux.InstanceID, updates flux.UnsafeInstanceCo
 	return s.config.UpdateConfig(instID, applyConfigUpdates(updates))
 }
 
+func (s *Server) SetConfigSingle(instID flux.InstanceID, params flux.SingleConfigParams, data string) error {
+	config, err := s.GetConfig(instID)
+	if err != nil {
+		return flux.ServerException{
+			BaseError: &flux.BaseError{
+				Help: "Cannot get config. Does `fluxctl get-config` work?",
+				Err:  err,
+			},
+		}
+	}
+	if err = config.WriteSetting(params, data); err != nil {
+		return flux.ServerException{
+			BaseError: &flux.BaseError{
+				Help: "Cannot write config. Does `fluxctl set-config` work?",
+				Err:  err,
+			},
+		}
+	}
+	return s.SetConfig(instID, flux.UnsafeInstanceConfig(config))
+}
+
+func (s *Server) DeleteConfigSingle(instID flux.InstanceID, params flux.SingleConfigParams) error {
+	return s.SetConfigSingle(instID, params, "")
+}
+
 func applyConfigUpdates(updates flux.UnsafeInstanceConfig) instance.UpdateFunc {
 	return func(config instance.Config) (instance.Config, error) {
 		config.Settings = updates


### PR DESCRIPTION
The new API is called GetSingleConfig can be found at GET /v5/config?key={key}&syntax=[yaml|json].
Much of the new logic is located in the config.go file. The goal is to reflectively iterate and compare every configuration key to that of a requested configuration path format (e.g. git.key). The key can follow the yaml keys or the json keys using the syntax parameter. The default is yaml. (Currently both syntaxes are the same).
The options that have periods must be quoted in single quotes.
The options use the yaml tag in the configuration struct to match the get-config names.