### PR TITLE
Omit change-cause annotation when saving resources

### DIFF
--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -98,6 +98,7 @@ func (opts *saveOpts) RunE(cmd *cobra.Command, args []string) error {
 func filterObject(object saveObject) {
 	delete(object.Metadata.Annotations, "deployment.kubernetes.io/revision")
 	delete(object.Metadata.Annotations, "kubectl.kubernetes.io/last-applied-configuration")
+	delete(object.Metadata.Annotations, "kubernetes.io/change-cause")
 	deleteNested(object.Spec, "template", "metadata", "creationTimestamp")
 	deleteEmptyMapValues(object.Spec)
 }


### PR DESCRIPTION
Don't version control `kubernetes.io/change-cause`