### PR TITLE
Implement PATCH config

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,6 +19,7 @@ type ClientService interface {
 	History(flux.InstanceID, flux.ServiceSpec) ([]flux.HistoryEntry, error)
 	GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
+	PatchConfig(flux.InstanceID, flux.ConfigPatch) error
 	GenerateDeployKey(flux.InstanceID) error
 	Export(inst flux.InstanceID) ([]byte, error)
 }

--- a/config.go
+++ b/config.go
@@ -101,3 +101,66 @@ func (g GitConfig) HideKey() GitConfig {
 	g.Key = string(ssh.MarshalAuthorizedKey(pubKey))
 	return g
 }
+
+type untypedConfig map[string]interface{}
+
+func (uc untypedConfig) toUnsafeInstanceConfig() (UnsafeInstanceConfig, error) {
+	bytes, err := json.Marshal(uc)
+	if err != nil {
+		return UnsafeInstanceConfig{}, err
+	}
+	var uic UnsafeInstanceConfig
+	if err := json.Unmarshal(bytes, &uic); err != nil {
+		return UnsafeInstanceConfig{}, err
+	}
+	return uic, nil
+}
+
+func (uic UnsafeInstanceConfig) toUntypedConfig() (untypedConfig, error) {
+	bytes, err := json.Marshal(uic)
+	if err != nil {
+		return nil, err
+	}
+	var uc untypedConfig
+	if err := json.Unmarshal(bytes, &uc); err != nil {
+		return nil, err
+	}
+	return uc, nil
+}
+
+type ConfigPatch map[string]interface{}
+
+func (uic UnsafeInstanceConfig) Patch(cp ConfigPatch) (UnsafeInstanceConfig, error) {
+	// Convert the strongly-typed config into an untyped form that's easier to patch
+	uc, err := uic.toUntypedConfig()
+	if err != nil {
+		return UnsafeInstanceConfig{}, err
+	}
+
+	applyPatch(uc, cp)
+
+	// If the modifications detailed by the patch have resulted in JSON which
+	// doesn't meet the config schema it will be caught here
+	return uc.toUnsafeInstanceConfig()
+}
+
+func applyPatch(uc untypedConfig, cp ConfigPatch) {
+	for key, value := range cp {
+		switch value := value.(type) {
+		case nil:
+			delete(uc, key)
+		case map[string]interface{}:
+			if uc[key] == nil {
+				uc[key] = make(map[string]interface{})
+			}
+			if uc, ok := uc[key].(map[string]interface{}); ok {
+				applyPatch(uc, value)
+			}
+		default:
+			// Remaining types; []interface{}, bool, float64 & string
+			// Note that we only support replacing arrays in their entirety
+			// as there is no way to address subelements for removal or update
+			uc[key] = value
+		}
+	}
+}

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,54 @@
+package flux
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestConfig_Patch(t *testing.T) {
+
+	uic := UnsafeInstanceConfig{
+		Git: GitConfig{
+			Key: "existingkey",
+		},
+		Registry: RegistryConfig{
+			Auths: map[string]Auth{
+				"https://index.docker.io/v1/": {
+					Auth: "existingauth",
+				},
+			},
+		},
+	}
+
+	patchBytes := []byte(`{
+		"git": {
+			"key": "newkey"
+		},
+		"registry": { 
+			"auths": { 
+				"https://index.docker.io/v1/": null,
+				"quay.io": {
+					"Auth": "some auth config"
+				}
+			}
+		}
+	}`)
+
+	var cf ConfigPatch
+	if err := json.Unmarshal(patchBytes, &cf); err != nil {
+		t.Fatal(err)
+	}
+
+	puic, err := uic.Patch(cf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if puic.Git.Key != "newkey" {
+		t.Fatalf("git key not patched: %v", puic.Git.Key)
+	}
+
+	if len(puic.Registry.Auths) != 1 || puic.Registry.Auths["quay.io"].Auth != "some auth config" {
+		t.Fatal("auth config not patched")
+	}
+}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -103,6 +103,10 @@ func (c *client) SetConfig(_ flux.InstanceID, config flux.UnsafeInstanceConfig) 
 	return c.postWithBody("SetConfig", config)
 }
 
+func (c *client) PatchConfig(_ flux.InstanceID, config flux.ConfigPatch) error {
+	return errors.New("not implemented")
+}
+
 func (c *client) GenerateDeployKey(_ flux.InstanceID) error {
 	return c.post("GenerateDeployKeys")
 }

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -61,7 +61,7 @@ func (c *client) PostRelease(_ flux.InstanceID, s jobs.ReleaseJobParams) (jobs.J
 	}
 
 	var resp transport.PostReleaseResponse
-	err := c.postWithResp(&resp, "PostRelease", nil, args...)
+	err := c.methodWithResp("POST", &resp, "PostRelease", nil, args...)
 	return resp.ReleaseID, err
 }
 
@@ -103,8 +103,8 @@ func (c *client) SetConfig(_ flux.InstanceID, config flux.UnsafeInstanceConfig) 
 	return c.postWithBody("SetConfig", config)
 }
 
-func (c *client) PatchConfig(_ flux.InstanceID, config flux.ConfigPatch) error {
-	return errors.New("not implemented")
+func (c *client) PatchConfig(_ flux.InstanceID, patch flux.ConfigPatch) error {
+	return c.patchWithBody("PatchConfig", patch)
 }
 
 func (c *client) GenerateDeployKey(_ flux.InstanceID) error {
@@ -131,13 +131,17 @@ func (c *client) post(route string, queryParams ...string) error {
 // postWithBody is a more complex post request, which includes a json-ified body.
 // If body is not nil, it is encoded to json before sending
 func (c *client) postWithBody(route string, body interface{}, queryParams ...string) error {
-	return c.postWithResp(nil, route, body, queryParams...)
+	return c.methodWithResp("POST", nil, route, body, queryParams...)
 }
 
-// postWithResp is the full enchilada, it handles body and query-param
+func (c *client) patchWithBody(route string, body interface{}, queryParams ...string) error {
+	return c.methodWithResp("PATCH", nil, route, body, queryParams...)
+}
+
+// methodWithResp is the full enchilada, it handles body and query-param
 // encoding, as well as decoding the response into the provided destination.
 // Note, the response will only be decoded into the dest if the len is > 0.
-func (c *client) postWithResp(dest interface{}, route string, body interface{}, queryParams ...string) error {
+func (c *client) methodWithResp(method string, dest interface{}, route string, body interface{}, queryParams ...string) error {
 	u, err := transport.MakeURL(c.endpoint, c.router, route, queryParams...)
 	if err != nil {
 		return errors.Wrap(err, "constructing URL")
@@ -151,7 +155,7 @@ func (c *client) postWithResp(dest interface{}, route string, body interface{}, 
 		}
 	}
 
-	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(bodyBytes))
+	req, err := http.NewRequest(method, u.String(), bytes.NewReader(bodyBytes))
 	if err != nil {
 		return errors.Wrapf(err, "constructing request %s", u)
 	}

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -43,6 +43,7 @@ func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger) http.Handle
 		"Status":                 handle.Status,
 		"GetConfig":              handle.GetConfig,
 		"SetConfig":              handle.SetConfig,
+		"PatchConfig":            handle.PatchConfig,
 		"GenerateDeployKeys":     handle.GenerateKeys,
 		"PostIntegrationsGithub": handle.PostIntegrationsGithub,
 		"RegisterDaemonV4":       handle.RegisterV4,
@@ -276,6 +277,23 @@ func (s HTTPService) SetConfig(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := s.service.SetConfig(inst, config); err != nil {
+		errorResponse(w, r, err)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (s HTTPService) PatchConfig(w http.ResponseWriter, r *http.Request) {
+	inst := getInstanceID(r)
+
+	var patch flux.ConfigPatch
+	if err := json.NewDecoder(r.Body).Decode(&patch); err != nil {
+		transport.WriteError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	if err := s.service.PatchConfig(inst, patch); err != nil {
 		errorResponse(w, r, err)
 		return
 	}

--- a/http/transport.go
+++ b/http/transport.go
@@ -37,6 +37,7 @@ func NewRouter() *mux.Router {
 	r.NewRoute().Name("Status").Methods("GET").Path("/v3/status")
 	r.NewRoute().Name("GetConfig").Methods("GET").Path("/v4/config")
 	r.NewRoute().Name("SetConfig").Methods("POST").Path("/v4/config")
+	r.NewRoute().Name("PatchConfig").Methods("PATCH").Path("/v4/config")
 	r.NewRoute().Name("GenerateDeployKeys").Methods("POST").Path("/v5/config/deploy-keys")
 	r.NewRoute().Name("PostIntegrationsGithub").Methods("POST").Path("/v5/integrations/github").Queries("owner", "{owner}", "repository", "{repository}")
 	r.NewRoute().Name("RegisterDaemonV4").Methods("GET").Path("/v4/daemon")


### PR DESCRIPTION
Fixes #441. Note that this does not extend `fluxctl set-config` with the ability to do partial updates, it's just the API for the web UI.