### PR TITLE
add before, limit, and simple=1 query params to history api

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"time"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/jobs"
 	"github.com/weaveworks/flux/platform"
@@ -16,7 +18,7 @@ type ClientService interface {
 	Deautomate(flux.InstanceID, flux.ServiceID) error
 	Lock(flux.InstanceID, flux.ServiceID) error
 	Unlock(flux.InstanceID, flux.ServiceID) error
-	History(flux.InstanceID, flux.ServiceSpec) ([]flux.HistoryEntry, error)
+	History(flux.InstanceID, flux.ServiceSpec, time.Time, int64) ([]flux.HistoryEntry, error)
 	GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
 	GenerateDeployKey(flux.InstanceID) error

--- a/cmd/fluxctl/history_cmd.go
+++ b/cmd/fluxctl/history_cmd.go
@@ -40,7 +40,7 @@ func (opts *serviceHistoryOpts) RunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	events, err := opts.API.History(noInstanceID, service, time.Now().UTC(), -1)
+	events, err := opts.API.History(noInstanceID, service, time.Time{}, -1)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/history_cmd.go
+++ b/cmd/fluxctl/history_cmd.go
@@ -40,7 +40,7 @@ func (opts *serviceHistoryOpts) RunE(_ *cobra.Command, args []string) error {
 		return err
 	}
 
-	events, err := opts.API.History(noInstanceID, service)
+	events, err := opts.API.History(noInstanceID, service, time.Now().UTC(), -1)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -375,7 +375,7 @@ func TestFluxsvc_History(t *testing.T) {
 	apiClient.Lock("", helloWorldSvc)
 
 	// Test History
-	hist, err := apiClient.History("", helloWorldSvc)
+	hist, err := apiClient.History("", helloWorldSvc, time.Now().UTC(), -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/history/history.go
+++ b/history/history.go
@@ -2,6 +2,7 @@ package history
 
 import (
 	"io"
+	"time"
 
 	"github.com/weaveworks/flux"
 )
@@ -19,11 +20,11 @@ type EventWriter interface {
 type EventReader interface {
 	// AllEvents returns a history for every service. Events must be
 	// returned in descending timestamp order.
-	AllEvents() ([]flux.Event, error)
+	AllEvents(time.Time, int64) ([]flux.Event, error)
 
 	// EventsForService returns the history for a particular
 	// service. Events must be returned in descending timestamp order.
-	EventsForService(flux.ServiceID) ([]flux.Event, error)
+	EventsForService(flux.ServiceID, time.Time, int64) ([]flux.Event, error)
 
 	// GetEvent finds a single event, by ID.
 	GetEvent(flux.EventID) (flux.Event, error)
@@ -31,8 +32,8 @@ type EventReader interface {
 
 type DB interface {
 	LogEvent(flux.InstanceID, flux.Event) error
-	AllEvents(flux.InstanceID) ([]flux.Event, error)
-	EventsForService(flux.InstanceID, flux.ServiceID) ([]flux.Event, error)
+	AllEvents(flux.InstanceID, time.Time, int64) ([]flux.Event, error)
+	EventsForService(flux.InstanceID, flux.ServiceID, time.Time, int64) ([]flux.Event, error)
 	GetEvent(flux.EventID) (flux.Event, error)
 	io.Closer
 }

--- a/history/metrics.go
+++ b/history/metrics.go
@@ -43,24 +43,24 @@ func (i *instrumentedDB) LogEvent(inst flux.InstanceID, e flux.Event) (err error
 	return i.db.LogEvent(inst, e)
 }
 
-func (i *instrumentedDB) AllEvents(inst flux.InstanceID) (e []flux.Event, err error) {
+func (i *instrumentedDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64) (e []flux.Event, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			LabelMethod, "AllEvents",
 			LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.db.AllEvents(inst)
+	return i.db.AllEvents(inst, before, limit)
 }
 
-func (i *instrumentedDB) EventsForService(inst flux.InstanceID, s flux.ServiceID) (e []flux.Event, err error) {
+func (i *instrumentedDB) EventsForService(inst flux.InstanceID, s flux.ServiceID, before time.Time, limit int64) (e []flux.Event, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			LabelMethod, "EventsForService",
 			LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.db.EventsForService(inst, s)
+	return i.db.EventsForService(inst, s, before, limit)
 }
 
 func (i *instrumentedDB) GetEvent(id flux.EventID) (e flux.Event, err error) {

--- a/history/mock.go
+++ b/history/mock.go
@@ -1,6 +1,8 @@
 package history
 
 import (
+	"time"
+
 	"github.com/weaveworks/flux"
 )
 
@@ -13,11 +15,11 @@ func NewMock() interface {
 	return mock{}
 }
 
-func (m mock) AllEvents() ([]flux.Event, error) {
+func (m mock) AllEvents(_ time.Time, _ int64) ([]flux.Event, error) {
 	return nil, nil
 }
 
-func (m mock) EventsForService(_ flux.ServiceID) ([]flux.Event, error) {
+func (m mock) EventsForService(_ flux.ServiceID, _ time.Time, _ int64) ([]flux.Event, error) {
 	return nil, nil
 }
 

--- a/history/sql/sql.go
+++ b/history/sql/sql.go
@@ -1,6 +1,9 @@
 package sql
 
 import (
+	"database/sql"
+
+	"github.com/Masterminds/squirrel"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/weaveworks/flux/history"
@@ -9,6 +12,7 @@ import (
 // A history DB that uses a SQL database
 type DB struct {
 	driver *sqlx.DB
+	squirrel.StatementBuilderType
 }
 
 func NewSQL(driver, datasource string) (history.DB, error) {
@@ -16,7 +20,10 @@ func NewSQL(driver, datasource string) (history.DB, error) {
 	if err != nil {
 		return nil, err
 	}
-	historyDB := &DB{driver: db}
+	historyDB := &DB{
+		driver:               db,
+		StatementBuilderType: statementBuilder(db),
+	}
 	switch driver {
 	case "ql", "ql-mem":
 		q := &qlDB{historyDB}
@@ -25,6 +32,12 @@ func NewSQL(driver, datasource string) (history.DB, error) {
 		p := &pgDB{historyDB}
 		return p, p.sanityCheck()
 	}
+}
+
+var statementBuilder = squirrel.StatementBuilder.PlaceholderFormat(squirrel.Dollar).RunWith
+
+func (db *DB) Query(query string, args ...interface{}) (*sql.Rows, error) {
+	return db.driver.Query(query, args...)
 }
 
 func (db *DB) Close() error {

--- a/history/sql/sql_test.go
+++ b/history/sql/sql_test.go
@@ -72,7 +72,7 @@ func TestHistoryLog(t *testing.T) {
 		Message:    "event 2",
 	}))
 
-	es, err := db.EventsForService(instance, flux.ServiceID("namespace/service"))
+	es, err := db.EventsForService(instance, flux.ServiceID("namespace/service"), time.Now().UTC(), -1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestHistoryLog(t *testing.T) {
 	}
 	checkInDescOrder(t, es)
 
-	es, err = db.AllEvents(instance)
+	es, err = db.AllEvents(instance, time.Now().UTC(), -1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -3,9 +3,11 @@ package client
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
@@ -87,9 +89,9 @@ func (c *client) Unlock(_ flux.InstanceID, id flux.ServiceID) error {
 	return c.post("Unlock", "service", string(id))
 }
 
-func (c *client) History(_ flux.InstanceID, s flux.ServiceSpec) ([]flux.HistoryEntry, error) {
+func (c *client) History(_ flux.InstanceID, s flux.ServiceSpec, before time.Time, limit int64) ([]flux.HistoryEntry, error) {
 	var res []flux.HistoryEntry
-	err := c.get(&res, "History", "service", string(s))
+	err := c.get(&res, "History", "service", string(s), "before", before.Format(time.RFC3339Nano), "limit", fmt.Sprint(limit))
 	return res, err
 }
 

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -90,8 +90,15 @@ func (c *client) Unlock(_ flux.InstanceID, id flux.ServiceID) error {
 }
 
 func (c *client) History(_ flux.InstanceID, s flux.ServiceSpec, before time.Time, limit int64) ([]flux.HistoryEntry, error) {
+	params := []string{"service", string(s)}
+	if !before.IsZero() {
+		params = append(params, "before", before.Format(time.RFC3339Nano))
+	}
+	if limit >= 0 {
+		params = append(params, "limit", fmt.Sprint(limit))
+	}
 	var res []flux.HistoryEntry
-	err := c.get(&res, "History", "service", string(s), "before", before.Format(time.RFC3339Nano), "limit", fmt.Sprint(limit))
+	err := c.get(&res, "History", params...)
 	return res, err
 }
 

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -268,7 +268,7 @@ func (s HTTPService) History(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if r.FormValue("simple") == "1" {
+	if r.FormValue("simple") == "true" {
 		// Remove all the individual event data, just return the timestamps and messages
 		for i := range h {
 			h[i].Event = nil

--- a/instance/events.go
+++ b/instance/events.go
@@ -1,6 +1,8 @@
 package instance
 
 import (
+	"time"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/history"
 )
@@ -14,12 +16,12 @@ func (rw EventReadWriter) LogEvent(e flux.Event) error {
 	return rw.db.LogEvent(rw.inst, e)
 }
 
-func (rw EventReadWriter) AllEvents() ([]flux.Event, error) {
-	return rw.db.AllEvents(rw.inst)
+func (rw EventReadWriter) AllEvents(before time.Time, limit int64) ([]flux.Event, error) {
+	return rw.db.AllEvents(rw.inst, before, limit)
 }
 
-func (rw EventReadWriter) EventsForService(service flux.ServiceID) ([]flux.Event, error) {
-	return rw.db.EventsForService(rw.inst, service)
+func (rw EventReadWriter) EventsForService(service flux.ServiceID, before time.Time, limit int64) ([]flux.Event, error) {
+	return rw.db.EventsForService(rw.inst, service, before, limit)
 }
 
 func (rw EventReadWriter) GetEvent(id flux.EventID) (flux.Event, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -180,7 +180,7 @@ func containersWithAvailable(service platform.Service, images instance.ImageMap)
 	return res
 }
 
-func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec) (res []flux.HistoryEntry, err error) {
+func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec, before time.Time, limit int64) (res []flux.HistoryEntry, err error) {
 	helper, err := s.instancer.Get(inst)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance")
@@ -188,7 +188,7 @@ func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec) (res []flu
 
 	var events []flux.Event
 	if spec == flux.ServiceSpecAll {
-		events, err = helper.AllEvents()
+		events, err = helper.AllEvents(before, limit)
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching all history events")
 		}
@@ -198,7 +198,7 @@ func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec) (res []flu
 			return nil, errors.Wrapf(err, "parsing service ID from spec %s", spec)
 		}
 
-		events, err = helper.EventsForService(id)
+		events, err = helper.EventsForService(id, before, limit)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching history events for %s", id)
 		}
@@ -210,7 +210,7 @@ func (s *Server) History(inst flux.InstanceID, spec flux.ServiceSpec) (res []flu
 			Stamp: &events[i].StartedAt,
 			Type:  "v0",
 			Data:  event.String(),
-			Event: event,
+			Event: &events[i],
 		}
 	}
 

--- a/service.go
+++ b/service.go
@@ -254,7 +254,7 @@ type HistoryEntry struct {
 	Stamp *time.Time `json:",omitempty"`
 	Type  string
 	Data  string
-	Event Event
+	Event *Event `json:",omitempty"`
 }
 
 // TODO: How similar should this be to the `get-config` result?

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -28,6 +28,14 @@
 			"notests": true
 		},
 		{
+			"importpath": "github.com/Masterminds/squirrel",
+			"repository": "https://github.com/Masterminds/squirrel",
+			"vcs": "git",
+			"revision": "20f192218cf52a73397fa2df45bdda720f3e47c8",
+			"branch": "v1",
+			"notests": true
+		},
+		{
 			"importpath": "github.com/PuerkitoBio/goquery",
 			"repository": "https://github.com/PuerkitoBio/goquery",
 			"vcs": "git",
@@ -532,6 +540,22 @@
 			"repository": "https://github.com/kr/logfmt",
 			"vcs": "git",
 			"revision": "b84e30acd515aadc4b783ad4ff83aff3299bdfe0",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/lann/builder",
+			"repository": "https://github.com/lann/builder",
+			"vcs": "git",
+			"revision": "f22ce00fd9394014049dad11c244859432bd6820",
+			"branch": "master",
+			"notests": true
+		},
+		{
+			"importpath": "github.com/lann/ps",
+			"repository": "https://github.com/lann/ps",
+			"vcs": "git",
+			"revision": "62de8c46ede02a7675c4c79c84883eb164cb71e3",
 			"branch": "master",
 			"notests": true
 		},


### PR DESCRIPTION
Fixes #503 

Called e.g. `http://192.168.99.100:30081/api/app/local-test/api/flux/v3/history?service=%3Call%3E&simple=1&before=2017-04-05T14:48:44.88041415Z&limit=10`

New flags are:
```
simple=1                             # Do not include event data in the items.
before=2017-04-05T14:48:44.000000Z   # Only include events older than X
limit=10                             # Only return 10 events at a time
```

So to paginate you'd first do a request with `?limit=10`, then find the earliest "before" value of the messages, then do a request with `?limit=10&before=<earliest-before-value>`, and repeat for subsequent pages.

The reason to not just do `page=5&perPage=10`, is that new events might accumulate in between requests, which would cause the page-alignment of events to change. `before` does not have this issue.

@davkal does this work for you?