### PR TITLE
Encode test invocation into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 .DEFAULT: all
-.PHONY: all release-bins clean realclean
+.PHONY: all release-bins clean realclean test
 
 DOCKER?=docker
+TEST_FLAGS?=
+
 include docker/kubectl.version
 
 # NB because this outputs absolute file names, you have to be careful
@@ -18,7 +20,6 @@ MIGRATIONS:=$(shell find db/migrations -type f)
 
 all: $(GOPATH)/bin/fluxctl $(GOPATH)/bin/fluxd $(GOPATH)/bin/fluxsvc build/.fluxd.done build/.fluxsvc.done
 
-.PHONY: release-bins
 release-bins:
 	for arch in amd64; do \
 		for os in linux darwin; do \
@@ -32,6 +33,10 @@ clean:
 
 realclean: clean
 	rm -rf ./cache
+
+test:
+	export PATH="$$PATH:$$PWD/cmd/fluxsvc"; \
+	go test -v ${TEST_FLAGS} $(shell find . -path './vendor' -prune -o -name '*.go' -printf '%h\n' | sort -u)
 
 build/migrations.tar: $(MIGRATIONS)
 	tar cf $@ db/migrations

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,6 @@ dependencies:
     - "~/flux/vendor/golang.org"
     - "~/download"
   override:
-    - go get github.com/Masterminds/glide
     - go get github.com/FiloSottile/gvt
     - go get github.com/nats-io/gnatsd
     - go get github.com/weaveworks/github-release
@@ -41,9 +40,7 @@ test:
   override:
     - gnatsd:
         background: true
-    - go build -v $(glide novendor)
-    - go test -v -race $(glide novendor)
-    - go test -v -race -tags integration -timeout 30s $(glide novendor)
+    - make test TEST_FLAGS="-race -tags integration -timeout 30s"
   post:
     - |
         cd ${GOPATH}/src/github.com/weaveworks/flux


### PR DESCRIPTION
This moves the invocation of `go test` into the Makefile, for
convenience of users and the CircleCI script; and removes the need for
`glide` to be installed.

NB drops the `go build ...` step from the CircleCI test stage -- it's
not doing anything that `go test` and `make all` won't do, and it adds
significantly to the build time.
