### PR TITLE
Implemented `ServiceFilter` to filter defined or running services.

### DIFF
--- a/automator/automator.go
+++ b/automator/automator.go
@@ -118,7 +118,8 @@ func (a *Automator) handleAutomatedInstanceJob(logger log.Logger, job *jobs.Job,
 	}
 
 	// Get the list of services that are automated, in the repo, and in the running service.
-	updates, err := rc.SelectServices(automatedServiceIDs, flux.ServiceIDSet{}, flux.ServiceIDSet{}, results, logInJob)
+	incFilt := &release.IncludeFilter{automatedServiceIDs}
+	updates, err := rc.SelectServices(results, logInJob, incFilt)
 	if err != nil {
 		logInJob("error finding services: %s", err)
 		return followUps, err

--- a/automator/automator.go
+++ b/automator/automator.go
@@ -118,8 +118,13 @@ func (a *Automator) handleAutomatedInstanceJob(logger log.Logger, job *jobs.Job,
 	}
 
 	// Get the list of services that are automated, in the repo, and in the running service.
-	incFilt := &release.IncludeFilter{automatedServiceIDs}
-	updates, err := rc.SelectServices(results, logInJob, incFilt)
+	updates, err := rc.SelectServices(
+		results,
+		logInJob,
+		&release.IncludeFilter{
+			IDs: automatedServiceIDs,
+		},
+	)
 	if err != nil {
 		logInJob("error finding services: %s", err)
 		return followUps, err

--- a/platform/kubernetes/testdata/data.go
+++ b/platform/kubernetes/testdata/data.go
@@ -47,7 +47,9 @@ func WriteTestFiles(dir string) error {
 // given in the test data.
 func ServiceMap(dir string) map[flux.ServiceID][]string {
 	return map[flux.ServiceID][]string{
-		flux.ServiceID("default/helloworld"): []string{filepath.Join(dir, "helloworld-deploy.yaml")},
+		flux.ServiceID("default/helloworld"):     []string{filepath.Join(dir, "helloworld-deploy.yaml")},
+		flux.ServiceID("default/locked-service"): []string{filepath.Join(dir, "locked-service-deploy.yaml")},
+		flux.ServiceID("default/test-service"):   []string{filepath.Join(dir, "test-service-deploy.yaml")},
 	}
 }
 
@@ -87,5 +89,65 @@ spec:
     - port: 80
   selector:
     name: helloworld
+`,
+	"locked-service-deploy.yaml": `apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: locked-service
+spec:
+  minReadySeconds: 1
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: locked-service
+    spec:
+      containers:
+      - name: locked-service
+        image: quay.io/weaveworks/locked-service:1
+        args:
+        - -msg=Ahoy
+        ports:
+        - containerPort: 80
+`,
+	"locked-service-svc.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  name: locked-service
+spec:
+  ports:
+    - port: 80
+  selector:
+    name: locked-service
+`,
+	"test-service-deploy.yaml": `apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: test-service
+spec:
+  minReadySeconds: 1
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: test-service
+    spec:
+      containers:
+      - name: test-service
+        image: quay.io/weaveworks/test-service:1
+        args:
+        - -msg=Ahoy
+        ports:
+        - containerPort: 80
+`,
+	"test-service-svc.yaml": `apiVersion: v1
+kind: Service
+metadata:
+  name: test-service
+spec:
+  ports:
+    - port: 80
+  selector:
+    name: test-service
 `,
 }

--- a/release.go
+++ b/release.go
@@ -4,6 +4,7 @@ import (
 	"sort"
 	"time"
 
+	"fmt"
 	"github.com/weaveworks/flux/guid"
 )
 
@@ -74,10 +75,6 @@ type ReleaseSpec struct {
 	ImageSpec    ImageSpec
 	Kind         ReleaseKind
 	Excludes     []ServiceID
-
-	// Backwards Compatibility, remove once no more jobs
-	// TODO: Remove this once there are no more jobs with ServiceSpec, only ServiceSpecs
-	ServiceSpec ServiceSpec
 }
 
 // ReleaseType gives a one-word description of the release, mainly
@@ -134,6 +131,10 @@ type ServiceResult struct {
 	Status       ServiceReleaseStatus // summary of what happened, e.g., "incomplete", "ignored", "success"
 	Error        string               `json:",omitempty"` // error if there was one finding the service (e.g., it doesn't exist in repo)
 	PerContainer []ContainerUpdate    // what happened with each container
+}
+
+func (fr ServiceResult) Msg(id ServiceID) string {
+	return fmt.Sprintf("%s service %s as it is %s", fr.Status, fr.Error)
 }
 
 type ContainerUpdate struct {

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -286,6 +286,7 @@ func filters(spec *flux.ReleaseSpec, rc *ReleaseContext) ([]ServiceFilter, error
 	ids := []flux.ServiceID{}
 	for _, s := range spec.ServiceSpecs {
 		if s == flux.ServiceSpecAll {
+			ids = []flux.ServiceID{} // "<all>" Overrides any other filters
 			break
 		}
 		id, err := flux.ParseServiceID(string(s))

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -253,6 +253,35 @@ func Test_FilterLogic(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "all overrides spec",
+			Spec: flux.ReleaseSpec{
+				ServiceSpecs: []flux.ServiceSpec{hwSvcSpec, flux.ServiceSpecAll},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
+			},
+			Expected: flux.ReleaseResult{
+				flux.ServiceID("default/helloworld"): flux.ServiceResult{
+					Status: flux.ReleaseStatusSuccess,
+					PerContainer: []flux.ContainerUpdate{
+						flux.ContainerUpdate{
+							Container: "helloworld",
+							Current:   oldImageID,
+							Target:    newImageID,
+						},
+					},
+				},
+				flux.ServiceID("default/locked-service"): flux.ServiceResult{
+					Status: flux.ReleaseStatusSkipped,
+					Error:  Locked,
+				},
+				flux.ServiceID("default/test-service"): flux.ServiceResult{
+					Status: flux.ReleaseStatusSkipped,
+					Error:  NotInCluster,
+				},
+			},
+		},
 	} {
 		releaser, cleanup := setup(t, instance.Instance{
 			Platform: mockPlatform,

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -140,10 +140,10 @@ func Test_FilterLogic(t *testing.T) {
 		{
 			Name: "not included",
 			Spec: flux.ReleaseSpec{
-				ServiceSpec: hwSvcSpec,
-				ImageSpec:   flux.ImageSpecLatest,
-				Kind:        flux.ReleaseKindExecute,
-				Excludes:    []flux.ServiceID{},
+				ServiceSpecs: []flux.ServiceSpec{hwSvcSpec},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
 			},
 			Expected: flux.ReleaseResult{
 				flux.ServiceID("default/helloworld"): flux.ServiceResult{
@@ -168,10 +168,10 @@ func Test_FilterLogic(t *testing.T) {
 		}, {
 			Name: "excluded",
 			Spec: flux.ReleaseSpec{
-				ServiceSpec: flux.ServiceSpecAll,
-				ImageSpec:   flux.ImageSpecLatest,
-				Kind:        flux.ReleaseKindExecute,
-				Excludes:    []flux.ServiceID{lockedSvcID},
+				ServiceSpecs: []flux.ServiceSpec{flux.ServiceSpecAll},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{lockedSvcID},
 			},
 			Expected: flux.ReleaseResult{
 				flux.ServiceID("default/helloworld"): flux.ServiceResult{
@@ -196,10 +196,10 @@ func Test_FilterLogic(t *testing.T) {
 		}, {
 			Name: "not image",
 			Spec: flux.ReleaseSpec{
-				ServiceSpec: flux.ServiceSpecAll,
-				ImageSpec:   flux.ImageSpecFromID(newImageID),
-				Kind:        flux.ReleaseKindExecute,
-				Excludes:    []flux.ServiceID{},
+				ServiceSpecs: []flux.ServiceSpec{flux.ServiceSpecAll},
+				ImageSpec:    flux.ImageSpecFromID(newImageID),
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
 			},
 			Expected: flux.ReleaseResult{
 				flux.ServiceID("default/helloworld"): flux.ServiceResult{
@@ -227,10 +227,10 @@ func Test_FilterLogic(t *testing.T) {
 		{
 			Name: "skipped & service is pending",
 			Spec: flux.ReleaseSpec{
-				ServiceSpec: flux.ServiceSpecAll,
-				ImageSpec:   flux.ImageSpecLatest,
-				Kind:        flux.ReleaseKindExecute,
-				Excludes:    []flux.ServiceID{},
+				ServiceSpecs: []flux.ServiceSpec{flux.ServiceSpecAll},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
 			},
 			Expected: flux.ReleaseResult{
 				flux.ServiceID("default/helloworld"): flux.ServiceResult{
@@ -307,10 +307,10 @@ func Test_ImageStatus(t *testing.T) {
 		{
 			Name: "image not found",
 			Spec: flux.ReleaseSpec{
-				ServiceSpec: testSvcSpec,
-				ImageSpec:   flux.ImageSpecLatest,
-				Kind:        flux.ReleaseKindExecute,
-				Excludes:    []flux.ServiceID{},
+				ServiceSpecs: []flux.ServiceSpec{testSvcSpec},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
 			},
 			Expected: flux.ReleaseResult{
 				flux.ServiceID("default/helloworld"): flux.ServiceResult{
@@ -329,10 +329,10 @@ func Test_ImageStatus(t *testing.T) {
 		}, {
 			Name: "image up to date",
 			Spec: flux.ReleaseSpec{
-				ServiceSpec: hwSvcSpec,
-				ImageSpec:   flux.ImageSpecLatest,
-				Kind:        flux.ReleaseKindExecute,
-				Excludes:    []flux.ServiceID{},
+				ServiceSpecs: []flux.ServiceSpec{hwSvcSpec},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
 			},
 			Expected: flux.ReleaseResult{
 				flux.ServiceID("default/helloworld"): flux.ServiceResult{

--- a/service.go
+++ b/service.go
@@ -117,6 +117,16 @@ func (s ServiceIDSet) Intersection(others ServiceIDSet) ServiceIDSet {
 	return result
 }
 
+func (s ServiceIDSet) ToSlice() ServiceIDs {
+	i := 0
+	keys := make(ServiceIDs, len(s))
+	for k := range s {
+		keys[i] = k
+		i++
+	}
+	return keys
+}
+
 type ServiceIDs []ServiceID
 
 func (p ServiceIDs) Len() int           { return len(p) }


### PR DESCRIPTION
The service is ignored if: excluded OR not included OR not correct image.
The service is skipped if: not ignored AND (locked or not found in cluster)
Else the service is pending.
The filters must be run across both the services to update and the services that are not running in the cluster. This is because the services not running in the cluster might have been ignored anyway.

Fixes #492