### PR TITLE
Do fingerprinting and secret masking server-side so we can use it via the UI

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,7 @@ type ClientService interface {
 	Lock(flux.InstanceID, flux.ServiceID) error
 	Unlock(flux.InstanceID, flux.ServiceID) error
 	History(flux.InstanceID, flux.ServiceSpec, time.Time, int64) ([]flux.HistoryEntry, error)
-	GetConfig(_ flux.InstanceID, secrets bool, fingerprint string) (flux.InstanceConfig, error)
+	GetConfig(_ flux.InstanceID, fingerprint string) (flux.InstanceConfig, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
 	PatchConfig(flux.InstanceID, flux.ConfigPatch) error
 	GenerateDeployKey(flux.InstanceID) error

--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,7 @@ type ClientService interface {
 	Lock(flux.InstanceID, flux.ServiceID) error
 	Unlock(flux.InstanceID, flux.ServiceID) error
 	History(flux.InstanceID, flux.ServiceSpec, time.Time, int64) ([]flux.HistoryEntry, error)
-	GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error)
+	GetConfig(_ flux.InstanceID, secrets bool, fingerprint string) (flux.InstanceConfig, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
 	PatchConfig(flux.InstanceID, flux.ConfigPatch) error
 	GenerateDeployKey(flux.InstanceID) error

--- a/cmd/fluxctl/get_config_cmd.go
+++ b/cmd/fluxctl/get_config_cmd.go
@@ -52,7 +52,7 @@ func (opts *getConfigOpts) RunE(_ *cobra.Command, args []string) error {
 		return errors.New("unknown output format " + opts.output)
 	}
 
-	config, err := opts.API.GetConfig(noInstanceID, false, opts.fingerprint)
+	config, err := opts.API.GetConfig(noInstanceID, opts.fingerprint)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/get_config_cmd.go
+++ b/cmd/fluxctl/get_config_cmd.go
@@ -1,17 +1,11 @@
 package main
 
 import (
-	"crypto/md5"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
-	"fmt"
 	"os"
-	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"golang.org/x/crypto/ssh"
 	"gopkg.in/yaml.v2"
 
 	"github.com/weaveworks/flux"
@@ -58,33 +52,9 @@ func (opts *getConfigOpts) RunE(_ *cobra.Command, args []string) error {
 		return errors.New("unknown output format " + opts.output)
 	}
 
-	config, err := opts.API.GetConfig(noInstanceID)
-
+	config, err := opts.API.GetConfig(noInstanceID, false, opts.fingerprint)
 	if err != nil {
 		return err
-	}
-
-	if opts.fingerprint != "" && config.Git.Key != "" {
-		pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(config.Git.Key))
-		if err != nil {
-			config.Git.Key = "unable to parse public key"
-		} else {
-			switch opts.fingerprint {
-			case "md5":
-				hash := md5.Sum(pk.Marshal())
-				fingerprint := ""
-				for i, b := range hash {
-					fingerprint = fmt.Sprintf("%s%0.2x", fingerprint, b)
-					if i < len(hash)-1 {
-						fingerprint = fingerprint + ":"
-					}
-				}
-				config.Git.Key = fingerprint
-			case "sha256":
-				hash := sha256.Sum256(pk.Marshal())
-				config.Git.Key = strings.TrimRight(base64.StdEncoding.EncodeToString(hash[:]), "=")
-			}
-		}
 	}
 
 	// Since we always want to output whatever we got, use UnsafeInstanceConfig

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -433,7 +433,7 @@ func TestFluxsvc_Config(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conf, err := apiClient.GetConfig("")
+	conf, err := apiClient.GetConfig("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -466,7 +466,7 @@ func TestFluxsvc_DeployKeys(t *testing.T) {
 	}
 
 	// Get new key
-	conf, err := apiClient.GetConfig("")
+	conf, err := apiClient.GetConfig("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/config.go
+++ b/config.go
@@ -57,6 +57,7 @@ func (c InstanceConfig) MarshalJSON() ([]byte, error) {
 }
 
 func (c InstanceConfig) HideSecrets() SafeInstanceConfig {
+	c.Git = c.Git.HideKey()
 	for host, auth := range c.Registry.Auths {
 		c.Registry.Auths[host] = auth.HidePassword()
 	}

--- a/config.go
+++ b/config.go
@@ -57,7 +57,6 @@ func (c InstanceConfig) MarshalJSON() ([]byte, error) {
 }
 
 func (c InstanceConfig) HideSecrets() SafeInstanceConfig {
-	c.Git = c.Git.HideKey()
 	for host, auth := range c.Registry.Auths {
 		c.Registry.Auths[host] = auth.HidePassword()
 	}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -102,9 +102,13 @@ func (c *client) History(_ flux.InstanceID, s flux.ServiceSpec, before time.Time
 	return res, err
 }
 
-func (c *client) GetConfig(_ flux.InstanceID) (flux.InstanceConfig, error) {
+func (c *client) GetConfig(_ flux.InstanceID, secrets bool, fingerprint string) (flux.InstanceConfig, error) {
+	params := []string{"secrets", fmt.Sprint(secrets)}
+	if fingerprint != "" {
+		params = append(params, "fingerprint", fingerprint)
+	}
 	var res flux.InstanceConfig
-	err := c.get(&res, "GetConfig")
+	err := c.get(&res, "GetConfig", params...)
 	return res, err
 }
 

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -102,8 +102,8 @@ func (c *client) History(_ flux.InstanceID, s flux.ServiceSpec, before time.Time
 	return res, err
 }
 
-func (c *client) GetConfig(_ flux.InstanceID, secrets bool, fingerprint string) (flux.InstanceConfig, error) {
-	params := []string{"secrets", fmt.Sprint(secrets)}
+func (c *client) GetConfig(_ flux.InstanceID, fingerprint string) (flux.InstanceConfig, error) {
+	var params []string
 	if fingerprint != "" {
 		params = append(params, "fingerprint", fingerprint)
 	}

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -292,6 +292,8 @@ func (s HTTPService) GetConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// This replaces the private key with the public one, so we can fingerprint
+	// it if needed
 	safeConfig := config.HideSecrets()
 	if fingerprint != "" && config.Git.Key != "" {
 		pk, _, _, _, err := ssh.ParseAuthorizedKey([]byte(safeConfig.Git.Key))

--- a/server/server.go
+++ b/server/server.go
@@ -340,13 +340,14 @@ func (s *Server) GetRelease(inst flux.InstanceID, id jobs.JobID) (jobs.Job, erro
 	return j, err
 }
 
-func (s *Server) GetConfig(instID flux.InstanceID) (flux.InstanceConfig, error) {
+func (s *Server) GetConfig(instID flux.InstanceID, secrets bool, fingerprint string) (flux.InstanceConfig, error) {
 	fullConfig, err := s.config.GetConfig(instID)
 	if err != nil {
 		return flux.InstanceConfig{}, err
 	}
 
 	config := flux.InstanceConfig(fullConfig.Settings)
+
 	return config, nil
 }
 
@@ -389,7 +390,7 @@ func (s *Server) GenerateDeployKey(instID flux.InstanceID) error {
 	}
 
 	// Get current config
-	cfg, err := s.GetConfig(instID)
+	cfg, err := s.GetConfig(instID, true, "")
 	if err != nil {
 		return err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -340,7 +340,7 @@ func (s *Server) GetRelease(inst flux.InstanceID, id jobs.JobID) (jobs.Job, erro
 	return j, err
 }
 
-func (s *Server) GetConfig(instID flux.InstanceID, secrets bool, fingerprint string) (flux.InstanceConfig, error) {
+func (s *Server) GetConfig(instID flux.InstanceID, fingerprint string) (flux.InstanceConfig, error) {
 	fullConfig, err := s.config.GetConfig(instID)
 	if err != nil {
 		return flux.InstanceConfig{}, err
@@ -390,7 +390,7 @@ func (s *Server) GenerateDeployKey(instID flux.InstanceID) error {
 	}
 
 	// Get current config
-	cfg, err := s.GetConfig(instID, true, "")
+	cfg, err := s.GetConfig(instID, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes #510 

Code is super messy. I'm really unhappy with how it turned out. Suggestions for improvement welcome.

The http server seems like the right place to be doing the masking, as it is a formatting decision, but this makes the Safe/UnsafeInstanceConfig distinction not really used anymore, and a bit awkward.