### PR TITLE
Add user and message to history and slack notification

### DIFF
--- a/event.go
+++ b/event.go
@@ -86,10 +86,20 @@ func (e Event) String() string {
 		if len(strServiceIDs) == 0 {
 			strServiceIDs = []string{"no services"}
 		}
+		var user string
+		if metadata.Release.Cause.User != "" {
+			user = fmt.Sprintf(", by %s", metadata.Release.Cause.User)
+		}
+		var msg string
+		if metadata.Release.Cause.Message != "" {
+			msg = fmt.Sprintf(", with message %q", metadata.Release.Cause.Message)
+		}
 		return fmt.Sprintf(
-			"Released: %s to %s",
+			"Released: %s to %s%s%s",
 			strings.Join(strImageIDs, ", "),
 			strings.Join(strServiceIDs, ", "),
+			user,
+			msg,
 		)
 	case EventAutomate:
 		return fmt.Sprintf("Automated: %s", strings.Join(strServiceIDs, ", "))

--- a/notifications/slack.go
+++ b/notifications/slack.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	defaultReleaseTemplate = `Release {{with .Cause}}{{if .User}}({{.User}}){{end}}{{end}} {{trim (print .Spec.ImageSpec) "<>"}} to {{with .Spec.ServiceSpecs}}{{range $index, $spec := .}}{{if not (eq $index 0)}}, {{if last $index $.Spec.ServiceSpecs}}and {{end}}{{end}}{{trim (print .) "<>"}}{{end}}{{end}}. {{with .Error}}{{.}}. failed{{else}}done{{end}}`
+	defaultReleaseTemplate = `Release {{with .Cause}}({{if .User}}{{.User}}{{else}}unknown{{end}}{{if .Message}}: {{.Message}}{{end}}){{end}} {{trim (print .Spec.ImageSpec) "<>"}} to {{with .Spec.ServiceSpecs}}{{range $index, $spec := .}}{{if not (eq $index 0)}}, {{if last $index $.Spec.ServiceSpecs}}and {{end}}{{end}}{{trim (print .) "<>"}}{{end}}{{end}}. {{with .Error}}{{.}}. failed{{else}}done{{end}}`
 )
 
 var (

--- a/notifications/slack_test.go
+++ b/notifications/slack_test.go
@@ -44,7 +44,7 @@ func TestSlackNotifier(t *testing.T) {
 	}
 	for k, expectedV := range map[string]string{
 		"username": "user1",
-		"text":     "Release (test-user) all latest to default/helloworld. test-error. failed",
+		"text":     "Release (test-user: this was to test notifications) all latest to default/helloworld. test-error. failed",
 	} {
 		if v, ok := body[k]; !ok || v != expectedV {
 			t.Errorf("Expected %s to have been set to %q, but got: %q", k, expectedV, v)


### PR DESCRIPTION
This adds the release user and message metadata (that was already there) to the history message and the slack notification.

Fixes #274