### PR TITLE
If service specifically requested and not in repo, add skipped "not in repo"

### DIFF
--- a/release/context.go
+++ b/release/context.go
@@ -18,6 +18,7 @@ const (
 	Excluded       = "excluded"
 	DifferentImage = "a different image"
 	NotInCluster   = "not running in cluster"
+	NotInRepo      = "not found in repository"
 	ImageNotFound  = "cannot find one or more images"
 	ImageUpToDate  = "image(s) up to date"
 )

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -112,6 +112,24 @@ func (r *Releaser) release(instanceID flux.InstanceID, job *jobs.Job, logStatus 
 		return nil, err
 	}
 	logStatus("Found %d services.", len(updates))
+
+	// If the request was for a specific service and the service was
+	// not in the cluster, then add a result with a skipped status
+	for _, v := range spec.ServiceSpecs {
+		if v == flux.ServiceSpecAll {
+			continue
+		}
+		id, err := v.AsID()
+		if err != nil {
+			continue
+		}
+		if _, ok := results[id]; !ok {
+			results[id] = flux.ServiceResult{
+				Status: flux.ReleaseStatusSkipped,
+				Error:  NotInRepo,
+			}
+		}
+	}
 	report(results)
 
 	// Look up images, and calculate updates, if we've been asked to

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -132,6 +132,7 @@ func Test_FilterLogic(t *testing.T) {
 		Error: nil,
 	}
 
+	notInRepoSpec, _ := flux.ParseServiceSpec("default/notInRepo")
 	for _, tst := range []struct {
 		Name     string
 		Spec     flux.ReleaseSpec
@@ -280,6 +281,33 @@ func Test_FilterLogic(t *testing.T) {
 				flux.ServiceID("default/test-service"): flux.ServiceResult{
 					Status: flux.ReleaseStatusSkipped,
 					Error:  NotInCluster,
+				},
+			},
+		},
+		{
+			Name: "service not in repo",
+			Spec: flux.ReleaseSpec{
+				ServiceSpecs: []flux.ServiceSpec{notInRepoSpec},
+				ImageSpec:    flux.ImageSpecLatest,
+				Kind:         flux.ReleaseKindExecute,
+				Excludes:     []flux.ServiceID{},
+			},
+			Expected: flux.ReleaseResult{
+				flux.ServiceID("default/helloworld"): flux.ServiceResult{
+					Status: flux.ReleaseStatusIgnored,
+					Error:  NotIncluded,
+				},
+				flux.ServiceID("default/locked-service"): flux.ServiceResult{
+					Status: flux.ReleaseStatusIgnored,
+					Error:  NotIncluded,
+				},
+				flux.ServiceID("default/test-service"): flux.ServiceResult{
+					Status: flux.ReleaseStatusIgnored,
+					Error:  NotIncluded,
+				},
+				flux.ServiceID(notInRepoSpec.String()): flux.ServiceResult{
+					Status: flux.ReleaseStatusSkipped,
+					Error:  NotInRepo,
 				},
 			},
 		},


### PR DESCRIPTION
Added test.
Added logic to test if all specified `ServiceSpec`'s are found. If not, manually add a result entry.

Fixes #473