### PR TITLE
Increase registry timeout to 300s to allow for large numbers of tags

### DIFF
--- a/registry/registry.go
+++ b/registry/registry.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	requestTimeout = 10 * time.Second
+	requestTimeout = 300 * time.Second
 	maxConcurrency = 10 // Chosen arbitrarily
 )
 


### PR DESCRIPTION
Fixes #533

(Partially, there still might be an issue with authfe timeouts, but we shall see when this gets deployed).