### PR TITLE
Report 200 `{"connected": false}` when fluxd is not connected

### DIFF
--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -486,7 +486,7 @@ func TestFluxsvc_Ping(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)
@@ -511,7 +511,7 @@ func TestFluxsvc_Register(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusNoContent {
+	if resp.StatusCode != http.StatusOK {
 		body, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
 			t.Fatal(err)

--- a/platform/standalone.go
+++ b/platform/standalone.go
@@ -87,7 +87,15 @@ func (s *StandaloneMessageBus) Ping(inst flux.InstanceID) error {
 	if ok {
 		return p.Ping()
 	}
-	return errNotSubscribed
+	return flux.Missing{
+		BaseError: &flux.BaseError{
+			Err: errNotSubscribed,
+			Help: `Flux daemon is not connected
+
+Please check that you have started fluxd in your cluster and that
+the FLUX_URL or FLUX_SERVICE_TOKEN is configured correctly.`,
+		},
+	}
 }
 
 // Version returns the fluxd version for the connected instance if the


### PR DESCRIPTION
Altered `/v4/ping` endpoint to check for specific errors that occur when fluxd isn't connected.
Added check for standalone.
Added check for nats.

Fixes #440