### PR TITLE
Avoid using 500s for application-level errors from the daemon

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -9,6 +9,13 @@ type HelpfulError interface {
 	Base() *BaseError
 }
 
+func UnderlyingError(err error) error {
+	if helpful, ok := err.(HelpfulError); ok {
+		return helpful.Base().Err
+	}
+	return err
+}
+
 // Representation of errors in the API. These are divided into a small
 // number of categories, essentially distinguished by whose fault the
 // error is; i.e., is this error:

--- a/platform/errors.go
+++ b/platform/errors.go
@@ -35,7 +35,7 @@ If you are still stuck, please log an issue:
 }
 
 func UpgradeNeededError(err error) error {
-	return &flux.BaseError{
+	return flux.UserConfigProblem{&flux.BaseError{
 		Help: `Your fluxd needs to be upgraded
 
 To service this request, we need to ask the agent running in your
@@ -46,5 +46,33 @@ Please install the latest version of fluxd and try again.
 
 `,
 		Err: err,
-	}
+	}}
+}
+
+func ClusterError(err error) error {
+	return flux.UserConfigProblem{&flux.BaseError{
+		Help: `Error from Flux daemon
+
+The Flux daemon (fluxd) reported this error:
+
+    ` + err.Error() + `
+
+which indicates that it is running, but cannot complete the request.
+
+Thus may be because the request wasn't valid; e.g., you asked for
+something in a namespace that doesn't exist.
+
+Otherwise, it is likely to be an ongoing problem until fluxd is
+updated and/or redeployed. For help, please consult the installation
+instructions:
+
+    https://github.com/weaveworks/flux/blob/master/site/installing.md
+
+If you are still stuck, please log an issue:
+
+    https://github.com/weaveworks/flux/issues
+
+`,
+		Err: err,
+	}}
 }

--- a/platform/kubernetes/kubernetes.go
+++ b/platform/kubernetes/kubernetes.go
@@ -172,13 +172,17 @@ func (c *Cluster) AllServices(namespace string, ignore flux.ServiceIDSet) (res [
 			namespaces = append(namespaces, ns.Name)
 		}
 	} else {
+		_, err := c.client.Namespaces().Get(namespace)
+		if err != nil {
+			return nil, errors.Wrap(err, "checking supplied namespace")
+		}
 		namespaces = []string{namespace}
 	}
 
 	for _, ns := range namespaces {
 		controllers, err := c.podControllersInNamespace(ns)
 		if err != nil {
-			return nil, errors.Wrapf(err, "getting pod controllers for namespace %s", ns)
+			return nil, errors.Wrapf(err, "getting controllers for namespace %s", ns)
 		}
 
 		list, err := c.client.Services(ns).List(api.ListOptions{})

--- a/platform/mock.go
+++ b/platform/mock.go
@@ -207,7 +207,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	}
 	mock.ApplyError = applyErrors
 	err = client.Apply(expectedDefs)
-	if !reflect.DeepEqual(err, applyErrors) {
+	if !reflect.DeepEqual(flux.UnderlyingError(err), applyErrors) {
 		t.Errorf("expected ApplyError, got %#v", err)
 	}
 
@@ -221,7 +221,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	}
 	mock.SyncError = syncErrors
 	err = client.Sync(expectedSyncDef)
-	if !reflect.DeepEqual(err, syncErrors) {
-		t.Errorf("expected SyncError, got %+v", err)
+	if !reflect.DeepEqual(flux.UnderlyingError(err), syncErrors) {
+		t.Errorf("expected SyncError, got %#v", err)
 	}
 }

--- a/platform/rpc/errors.go
+++ b/platform/rpc/errors.go
@@ -1,0 +1,24 @@
+package rpc
+
+import (
+	"net/rpc"
+
+	"github.com/weaveworks/flux/platform"
+)
+
+// CategoriseError turns any old error from an RPC call into a
+// FatalError or a (non-fatal) ClusterError; or nil, if it happens to
+// be nil to start off with.
+func CategoriseRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
+	// An rpc.ServerError is what the net/rpc package returns if the
+	// remote method call returned an error; anything else indicates a
+	// problem with the PRC _mechanism_, which we regard as a
+	// connection-terminating error.
+	if _, ok := err.(rpc.ServerError); !ok {
+		return platform.FatalError{err}
+	}
+	return platform.ClusterError(err)
+}

--- a/platform/rpc/nats/bus.go
+++ b/platform/rpc/nats/bus.go
@@ -2,7 +2,6 @@ package nats
 
 import (
 	"errors"
-	"net/rpc"
 	"strings"
 	"time"
 
@@ -152,7 +151,7 @@ func extractError(resp ErrorResponse) error {
 		if resp.Fatal {
 			return platform.FatalError{errors.New(resp.Error)}
 		}
-		return rpc.ServerError(resp.Error)
+		return platform.ClusterError(errors.New(resp.Error))
 	}
 	return nil
 }


### PR DESCRIPTION
We distinguish between "fatal" errors from the daemon, which indicate
that it is most likely not responsive (and therefore, please
disconnect it) and errors which simply indicate that the daemon could
not carry out the request.

However, both are returned up to the HTTP server as unadorned errors,
rather than wrapped in an `HelpfulError` from flux/errors.go; and as a
result, the server will send a HTTP 500 Internal Server Error status
to the client, which is misleading, and also a false alarm for monitoring.

This commit wraps non-fatal errors in a UserConfigProblem so that it
gets translated into a 422 Precondition Failed (which is the closest
we have to "application error").

It also makes the "upgrade needed" error (used by deprecated daemon
methods) a `UserConfigProblem`, for a similar reason.

It _also_ makes asking for a namespace that doesn't exist (in `fluxctl
list-services`) an error, rather than returning nothing.