### PR TITLE
Bring the bus implementation of Ping up-to-date

### DIFF
--- a/platform/mock.go
+++ b/platform/mock.go
@@ -208,7 +208,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	mock.ApplyError = applyErrors
 	err = client.Apply(expectedDefs)
 	if !reflect.DeepEqual(flux.UnderlyingError(err), applyErrors) {
-		t.Errorf("expected ApplyError, got %#v", err)
+		t.Errorf("expected ApplyError, got %+v: %s", err, err.Error())
 	}
 
 	err = client.Sync(expectedSyncDef)
@@ -222,6 +222,6 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	mock.SyncError = syncErrors
 	err = client.Sync(expectedSyncDef)
 	if !reflect.DeepEqual(flux.UnderlyingError(err), syncErrors) {
-		t.Errorf("expected SyncError, got %#v", err)
+		t.Errorf("expected SyncError, got %+v: %s", err, err.Error())
 	}
 }


### PR DESCRIPTION
The various platform.Platform implementations of Ping return a
platform.UnavailableError if the call fails to return (including if
the NATS request times out). However, the method actually used by the
server is MessageBus.Ping -- the platform.Platform implementation is
side-stepped.

This commit makes the error handling for NATS.Ping behave the same as
for natsPlatform.Ping.