### PR TITLE
Fix and document a bunch of bugs in the image updating regexes.

### DIFF
--- a/cluster/kubernetes/files_test.go
+++ b/cluster/kubernetes/files_test.go
@@ -15,12 +15,12 @@ func TestDefinedServices(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	services, err := FindDefinedServices(dir)
+	services, err := (&Cluster{}).FindDefinedServices(dir)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(testfiles.ServiceMap(dir), services) {
-		t.Errorf("Expected:\n%#v\ngot:\n%#v\n", testdata.ServiceMap(dir), services)
+		t.Errorf("Expected:\n%#v\ngot:\n%#v\n", testfiles.ServiceMap(dir), services)
 	}
 }

--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -47,10 +47,10 @@ metadata:
 
 // ---
 
-func setup(t *testing.T) (platform.Platform, *mockApplier) {
+func setup(t *testing.T) (*Cluster, *mockApplier) {
 	restClientConfig := &rest.Config{}
 	applier := &mockApplier{}
-	kube, err := NewCluster(restClientConfig, applier, "test-version", log.NewNopLogger())
+	kube, err := NewCluster(restClientConfig, applier, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster/kubernetes/policies_test.go
+++ b/cluster/kubernetes/policies_test.go
@@ -99,7 +99,7 @@ func TestUpdatePolicies(t *testing.T) {
 	} {
 		caseIn := templToString(t, annotationsTemplate, c.in)
 		caseOut := templToString(t, annotationsTemplate, c.out)
-		out, err := UpdatePolicies([]byte(caseIn), c.update)
+		out, err := (&Cluster{}).UpdatePolicies([]byte(caseIn), c.update)
 		if err != nil {
 			t.Errorf("[%s] %v", c.name, err)
 		} else if string(out) != caseOut {

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -128,8 +128,11 @@ func tryUpdate(def []byte, newImage flux.ImageID, out io.Writer) error {
 	indent := matches[1]
 
 	// Replace the container images
+	// Parse out all the container blocks
 	containersRE := regexp.MustCompile(`(?m:^` + indent + `containers:\s*(?:#.*)*$(?:\n(?:` + indent + `[-\s].*)?)*)`)
+	// Parse out an individual container blog
 	containerRE := regexp.MustCompile(`(?m:` + indent + `-.*(?:\n(?:` + indent + `\s+.*)?)*)`)
+	// Parse out the image ID
 	imageRE := regexp.MustCompile(`(` + indent + `[-\s]\s*"?image"?:\s*)"?(?:[\w\.\-/:]+\s*?)*"?([\t\f #]+.*)?`)
 	imageReplacement := fmt.Sprintf("${1}%s${2}", maybeQuote(newImage.String()))
 	// Find the block of container specs

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -90,9 +90,9 @@ func tryUpdate(def []byte, newImage flux.ImageID, out io.Writer) error {
 		return fmt.Errorf("could not find resource name")
 	}
 
-	// Check if any containers need updating. As we go though, we calculate the
-	// new manifest name, in case it includes the image tag (as in the case of
-	// replication controllers).
+	// Check if any containers need updating. As we go through, we calculate the
+	// new manifest name, in case it includes the image tag (as in replication
+	// controllers).
 	newDefName := manifest.Metadata.Name
 	matchingContainers := map[int]Container{}
 	for i, c := range manifest.Spec.Template.Spec.Containers {
@@ -129,7 +129,6 @@ func tryUpdate(def []byte, newImage flux.ImageID, out io.Writer) error {
 
 	// Replace the container images
 	containersRE := regexp.MustCompile(`(?m:^` + indent + `containers:\s*(?:#.*)*$(?:\n(?:` + indent + `[-\s].*)?)*)`)
-	//containerRE := regexp.MustCompile(`(?m:^` + indent + `-.*(?:\n(?:` + indent + `\s+.*)?)*)`)
 	containerRE := regexp.MustCompile(`(?m:` + indent + `-.*(?:\n(?:` + indent + `\s+.*)?)*)`)
 	imageRE := regexp.MustCompile(`(` + indent + `[-\s]\s*"?image"?:\s*)"?(?:[\w\.\-/:]+\s*?)*"?([\t\f #]+.*)?`)
 	imageReplacement := fmt.Sprintf("${1}%s${2}", maybeQuote(newImage.String()))
@@ -147,7 +146,7 @@ func tryUpdate(def []byte, newImage flux.ImageID, out io.Writer) error {
 		})
 	})
 
-	// The name we want is that under `metadata:`, which will be the first one
+	// The name we want is that under `metadata:`, which will *probably* be the first one
 	replacedName := false
 	replaceRCNameRE := regexp.MustCompile(`(\s+"?name"?:\s*)"?(?:[\w\.\-/:]+\s*?)"?([\t\f #]+.*)`)
 	replaceRCNameRE.ReplaceAllStringFunc(newDef, func(found string) string {

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -14,15 +14,13 @@ func testUpdate(t *testing.T, name, caseIn, updatedImage, caseOut string) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var trace, out bytes.Buffer
-	if err := tryUpdate(caseIn, id, &trace, &out); err != nil {
+	var out bytes.Buffer
+	if err := tryUpdate(caseIn, id, &out); err != nil {
 		fmt.Fprintln(os.Stderr, "Failed:", name)
-		fmt.Fprintf(os.Stderr, "--- TRACE ---\n"+trace.String()+"\n---\n")
 		t.Fatal(err)
 	}
 	if string(out.Bytes()) != caseOut {
 		fmt.Fprintln(os.Stderr, "Failed:", name)
-		fmt.Fprintf(os.Stderr, "--- TRACE ---\n"+trace.String()+"\n---\n")
 		t.Fatalf("Did not get expected result:\n\n%s\n\nInstead got:\n\n%s", caseOut, string(out.Bytes()))
 	}
 }


### PR DESCRIPTION
This was prompted by flux failing to release an image, because I had the `name` and `image` attributes of the map in a different order.

There are still a slew of bugs remaining in this (and policy annotations), but I think they are mostly documented now.

PRed into the git-sync branch because these files have all moved and changed.