### PR TITLE
Init request metric

### DIFF
--- a/http/server/metrics.go
+++ b/http/server/metrics.go
@@ -5,6 +5,10 @@ import (
 	fluxmetrics "github.com/weaveworks/flux/metrics"
 )
 
+func init() {
+	stdprometheus.MustRegister(requestDuration)
+}
+
 var (
 	requestDuration = stdprometheus.NewHistogramVec(stdprometheus.HistogramOpts{
 		Namespace: "flux",


### PR DESCRIPTION
The HTTP request histogram is created as a Prometheus client library
histogram, rather than via gokit, so to be compatible with
weaveworks/common/middleware.

But that client library does not automatically register metrics when
they are created, so we have to do it ourselves.