### PR TITLE
Change how images are tagged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ FLUXCTL_DEPS:=$(call godeps,./cmd/fluxctl)
 
 MIGRATIONS:=$(shell find db/migrations -type f)
 
+IMAGE_TAG:=$(shell ./docker/image-tag)
+
 all: $(GOPATH)/bin/fluxctl $(GOPATH)/bin/fluxd $(GOPATH)/bin/fluxsvc build/.fluxd.done build/.fluxsvc.done
 
 release-bins:
@@ -44,7 +46,7 @@ build/migrations.tar: $(MIGRATIONS)
 build/.%.done: docker/Dockerfile.%
 	mkdir -p ./build/docker/$*
 	cp $^ ./build/docker/$*/
-	${DOCKER} build -t weaveworks/$* -f build/docker/$*/Dockerfile.$* ./build/docker/$*
+	${DOCKER} build -t weaveworks/$* -t weaveworks/$*:$(IMAGE_TAG) -t quay.io/weaveworks/$* -t quay.io/weaveworks/$*:$(IMAGE_TAG) -f build/docker/$*/Dockerfile.$* ./build/docker/$*
 	touch $@
 
 build/.fluxd.done: build/fluxd build/kubectl

--- a/circle.yml
+++ b/circle.yml
@@ -54,12 +54,10 @@ deployment:
       - |
           IMAGE_TAG="quay.io/weaveworks/fluxd:$(./docker/image-tag)"
           echo Pushing $IMAGE_TAG
-          docker tag weaveworks/fluxd "$IMAGE_TAG"
           docker push "$IMAGE_TAG"
           # Assumes that both images change in lock-step (they share a lot of code, so ..)
           IMAGE_TAG="quay.io/weaveworks/fluxsvc:$(./docker/image-tag)"
           echo Pushing $IMAGE_TAG
-          docker tag weaveworks/fluxsvc "$IMAGE_TAG"
           docker push "$IMAGE_TAG"
   release:
     tag: /[0-9]+(\.[0-9]+)*/
@@ -70,18 +68,14 @@ deployment:
       - |
           IMAGE_TAG="quay.io/weaveworks/fluxd:$(./docker/image-tag)"
           echo Pushing $IMAGE_TAG
-          docker tag weaveworks/fluxd "$IMAGE_TAG"
           docker push "$IMAGE_TAG"
           IMAGE_TAG="quay.io/weaveworks/fluxd:latest"
           echo Pushing $IMAGE_TAG
-          docker tag weaveworks/fluxd "$IMAGE_TAG"
           docker push "$IMAGE_TAG"
           # Assumes that both images change in lock-step (they share a lot of code, so ..)
           IMAGE_TAG="quay.io/weaveworks/fluxsvc:$(./docker/image-tag)"
           echo Pushing $IMAGE_TAG
-          docker tag weaveworks/fluxsvc "$IMAGE_TAG"
           docker push "$IMAGE_TAG"
           IMAGE_TAG="quay.io/weaveworks/fluxsvc:latest"
           echo Pushing $IMAGE_TAG
-          docker tag weaveworks/fluxsvc "$IMAGE_TAG"
           docker push "$IMAGE_TAG"


### PR DESCRIPTION
We've defaulted to `weaveworks/flux{d,svc}` in `Makefile`, but never push images to Docker Hub, and did re-tagging in `circle.yml`... This sets all the tags in one call to `docker build` and simplifies `circle.yml` also.