### PR TITLE
Use time.Time rather than *time.Time, and conflate Image and ImageDescription

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -90,7 +90,7 @@ func (opts *serviceShowOpts) RunE(_ *cobra.Command, args []string) error {
 				}
 				if printLine {
 					createdAt := ""
-					if available.CreatedAt != nil {
+					if !available.CreatedAt.IsZero() {
 						createdAt = available.CreatedAt.Format(time.RFC822)
 					}
 					fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, tag, createdAt)

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -74,7 +74,7 @@ func setup() {
 				Containers: []flux.Container{
 					flux.Container{
 						Name: "helloworld",
-						Current: flux.ImageDescription{
+						Current: flux.Image{
 							ID: imageID,
 						},
 					},
@@ -88,7 +88,7 @@ func setup() {
 				Containers: []flux.Container{
 					flux.Container{
 						Name: "helloworld",
-						Current: flux.ImageDescription{
+						Current: flux.Image{
 							ID: imageID,
 						},
 					},
@@ -99,7 +99,7 @@ func setup() {
 				Containers: []flux.Container{
 					flux.Container{
 						Name: "helloworld",
-						Current: flux.ImageDescription{
+						Current: flux.Image{
 							ID: imageID,
 						},
 					},

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -318,7 +318,7 @@ func containers2containers(cs []cluster.Container) []flux.Container {
 		id, _ := flux.ParseImageID(c.Image)
 		res[i] = flux.Container{
 			Name: c.Name,
-			Current: flux.ImageDescription{
+			Current: flux.Image{
 				ID: id,
 			},
 		}
@@ -333,7 +333,7 @@ func containersWithAvailable(service cluster.Service, images release.ImageMap) (
 		available := images[repo]
 		res = append(res, flux.Container{
 			Name: c.Name,
-			Current: flux.ImageDescription{
+			Current: flux.Image{
 				ID: id,
 			},
 			Available: available,

--- a/registry/mock.go
+++ b/registry/mock.go
@@ -8,7 +8,7 @@ import (
 )
 
 type mockClientAdapter struct {
-	imgs []flux.ImageDescription
+	imgs []flux.Image
 	err  error
 }
 
@@ -92,7 +92,7 @@ func (m *mockRegistry) GetRepository(repository Repository) ([]flux.Image, error
 	var imgs []flux.Image
 	for _, i := range m.imgs {
 		// include only if it's the same repository in the same place
-		if i.ImageID.NamespaceImage() == repository.NamespaceImage() {
+		if i.ID.NamespaceImage() == repository.NamespaceImage() {
 			imgs = append(imgs, i)
 		}
 	}
@@ -102,7 +102,7 @@ func (m *mockRegistry) GetRepository(repository Repository) ([]flux.Image, error
 func (m *mockRegistry) GetImage(repository Repository, tag string) (flux.Image, error) {
 	if len(m.imgs) > 0 {
 		for _, i := range m.imgs {
-			if i.String() == repository.ToImage(tag).String() {
+			if i.ID.String() == repository.ToImage(tag).ID.String() {
 				return i, nil
 			}
 		}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -128,14 +128,14 @@ type byCreatedDesc []flux.Image
 func (is byCreatedDesc) Len() int      { return len(is) }
 func (is byCreatedDesc) Swap(i, j int) { is[i], is[j] = is[j], is[i] }
 func (is byCreatedDesc) Less(i, j int) bool {
-	if is[i].CreatedAt == nil {
+	switch {
+	case is[i].CreatedAt.IsZero():
 		return true
-	}
-	if is[j].CreatedAt == nil {
+	case is[j].CreatedAt.IsZero():
 		return false
+	case is[i].CreatedAt.Equal(is[j].CreatedAt):
+		return is[i].ID.String() < is[j].ID.String()
+	default:
+		return is[i].CreatedAt.After(is[j].CreatedAt)
 	}
-	if is[i].CreatedAt.Equal(*is[j].CreatedAt) {
-		return is[i].String() < is[j].String()
-	}
-	return is[i].CreatedAt.After(*is[j].CreatedAt)
 }

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -1,6 +1,7 @@
 package registry
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"testing"
@@ -16,24 +17,24 @@ var (
 	testTags    = []string{testTagStr, "anotherTag"}
 	mRemote     = NewMockRemote(img, testTags, nil)
 	mRemoteFact = NewMockRemoteFactory(mRemote, nil)
-	testTime, _ = time.Parse(constTime, time.RFC3339Nano)
+	testTime, _ = time.Parse(time.RFC3339Nano, constTime)
 )
 
 func TestRegistry_GetImage(t *testing.T) {
 	reg := NewRegistry(mRemoteFact, log.NewNopLogger())
-	newImg, err := reg.GetImage(testRepository, img.Tag)
+	newImg, err := reg.GetImage(testRepository, img.ID.Tag)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if img.String() != newImg.String() {
-		t.Fatal("Expected %v, but got %v", img.String(), newImg.String())
+	if img.ID.String() != newImg.ID.String() {
+		t.Fatal("Expected %v, but got %v", img.ID.String(), newImg.ID.String())
 	}
 }
 
 func TestRegistry_GetImageFactoryErr(t *testing.T) {
 	errFact := NewMockRemoteFactory(mRemote, errors.New(""))
 	reg := NewRegistry(errFact, nil)
-	_, err := reg.GetImage(testRepository, img.Tag)
+	_, err := reg.GetImage(testRepository, img.ID.Tag)
 	if err == nil {
 		t.Fatal("Expecting error")
 	}
@@ -43,7 +44,7 @@ func TestRegistry_GetImageRemoteErr(t *testing.T) {
 	r := NewMockRemote(img, testTags, errors.New(""))
 	errFact := NewMockRemoteFactory(r, nil)
 	reg := NewRegistry(errFact, log.NewNopLogger())
-	_, err := reg.GetImage(testRepository, img.Tag)
+	_, err := reg.GetImage(testRepository, img.ID.Tag)
 	if err == nil {
 		t.Fatal("Expecting error")
 	}
@@ -92,19 +93,20 @@ func TestRegistry_GetRepositoryManifestError(t *testing.T) {
 }
 
 func TestRegistry_OrderByCreationDate(t *testing.T) {
+	fmt.Printf("testTime: %s\n", testTime)
 	time0 := testTime.Add(time.Second)
 	time2 := testTime.Add(-time.Second)
-	imA, _ := flux.ParseImage("my/Image:3", &testTime)
-	imB, _ := flux.ParseImage("my/Image:1", &time0)
-	imC, _ := flux.ParseImage("my/Image:4", &time2)
-	imD, _ := flux.ParseImage("my/Image:0", nil)       // test nil
-	imE, _ := flux.ParseImage("my/Image:2", &testTime) // test equal
+	imA, _ := flux.ParseImage("my/Image:3", testTime)
+	imB, _ := flux.ParseImage("my/Image:1", time0)
+	imC, _ := flux.ParseImage("my/Image:4", time2)
+	imD, _ := flux.ParseImage("my/Image:0", time.Time{}) // test nil
+	imE, _ := flux.ParseImage("my/Image:2", testTime)    // test equal
 	imgs := []flux.Image{imA, imB, imC, imD, imE}
 	sort.Sort(byCreatedDesc(imgs))
 	for i, im := range imgs {
-		if strconv.Itoa(i) != im.Tag {
+		if strconv.Itoa(i) != im.ID.Tag {
 			for j, jim := range imgs {
-				t.Logf("%v: %v", j, jim.String())
+				t.Logf("%v: %v %s", j, jim.ID.String(), jim.CreatedAt)
 			}
 			t.Fatalf("Not sorted in expected order: %#v", imgs)
 		}

--- a/registry/remote.go
+++ b/registry/remote.go
@@ -34,7 +34,7 @@ func (rc *remote) Tags(repository Repository) (_ []string, err error) {
 }
 
 func (rc *remote) Manifest(repository Repository, tag string) (img flux.Image, err error) {
-	img, err = flux.ParseImage(fmt.Sprintf("%s:%s", repository.String(), tag), nil)
+	img, err = flux.ParseImage(fmt.Sprintf("%s:%s", repository.String(), tag), time.Time{})
 	if err != nil {
 		return
 	}
@@ -55,7 +55,7 @@ func (rc *remote) Manifest(repository Repository, tag string) (img flux.Image, e
 	if len(history) > 0 {
 		if err = json.Unmarshal([]byte(history[0].V1Compatibility), &topmost); err == nil {
 			if !topmost.Created.IsZero() {
-				img.CreatedAt = &topmost.Created
+				img.CreatedAt = topmost.Created
 			}
 		}
 	}

--- a/registry/remote_factory_test.go
+++ b/registry/remote_factory_test.go
@@ -18,7 +18,7 @@ import (
 func TestRemoteFactory_CreateForDockerHub(t *testing.T) {
 	// No credentials required for public Image
 	fact := NewRemoteClientFactory(Credentials{}, log.NewNopLogger(), nil, time.Second)
-	img, err := flux.ParseImage("alpine:latest", nil)
+	img, err := flux.ParseImage("alpine:latest", time.Time{})
 	testRepository = RepositoryFromImage(img)
 	if err != nil {
 		t.Fatal(err)
@@ -27,19 +27,19 @@ func TestRemoteFactory_CreateForDockerHub(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	res, err := r.Manifest(testRepository, img.Tag)
+	res, err := r.Manifest(testRepository, img.ID.Tag)
 	if err != nil {
 		t.Fatal(err)
 	}
 	expected := "index.docker.io/library/alpine:latest"
-	if res.FullID() != expected {
-		t.Fatal("Expected %q. Got %q", expected, res.FullID())
+	if res.ID.FullID() != expected {
+		t.Fatal("Expected %q. Got %q", expected, res.ID.FullID())
 	}
 }
 
 func TestRemoteFactory_InvalidHost(t *testing.T) {
 	fact := NewRemoteClientFactory(Credentials{}, log.NewNopLogger(), nil, time.Second)
-	img, err := flux.ParseImage("invalid.host/library/alpine:latest", nil)
+	img, err := flux.ParseImage("invalid.host/library/alpine:latest", time.Time{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -48,7 +48,7 @@ func TestRemoteFactory_InvalidHost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, err = r.Manifest(testRepository, img.Tag)
+	_, err = r.Manifest(testRepository, img.ID.Tag)
 	if err == nil {
 		t.Fatal("Expected error due to invalid host but got none.")
 	}

--- a/registry/remote_test.go
+++ b/registry/remote_test.go
@@ -15,7 +15,7 @@ const testImageStr = "index.docker.io/test/Image:" + testTagStr
 const constTime = "2017-01-13T16:22:58.009923189Z"
 
 var (
-	img, _         = flux.ParseImage(testImageStr, nil)
+	img, _         = flux.ParseImage(testImageStr, time.Time{})
 	testRepository = RepositoryFromImage(img)
 
 	man = schema1.SignedManifest{
@@ -38,12 +38,12 @@ func TestRemoteClient_ParseManifest(t *testing.T) {
 		client: NewMockDockerClient(manifestFunc, nil),
 	}
 	testRepository = RepositoryFromImage(img)
-	desc, err := c.Manifest(testRepository, img.Tag)
+	desc, err := c.Manifest(testRepository, img.ID.Tag)
 	if err != nil {
 		t.Fatal(err.Error())
 	}
-	if string(desc.FullID()) != testImageStr {
-		t.Fatalf("Expecting %q but got %q", testImageStr, string(desc.FullID()))
+	if string(desc.ID.FullID()) != testImageStr {
+		t.Fatalf("Expecting %q but got %q", testImageStr, string(desc.ID.FullID()))
 	}
 	if desc.CreatedAt.Format(time.RFC3339Nano) != constTime {
 		t.Fatalf("Expecting %q but got %q", constTime, desc.CreatedAt.Format(time.RFC3339Nano))
@@ -95,7 +95,7 @@ func TestRemoteClient_RemoteErrors(t *testing.T) {
 	if err == nil {
 		t.Fatal("Expected error")
 	}
-	_, err = c.Manifest(testRepository, img.Tag)
+	_, err = c.Manifest(testRepository, img.ID.Tag)
 	if err == nil {
 		t.Fatal("Expected error")
 	}

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -1,6 +1,8 @@
 package registry
 
 import (
+	"time"
+
 	"github.com/weaveworks/flux"
 )
 
@@ -15,7 +17,7 @@ func RepositoryFromImage(img flux.Image) Repository {
 }
 
 func ParseRepository(imgStr string) (Repository, error) {
-	i, err := flux.ParseImage(imgStr, nil)
+	i, err := flux.ParseImage(imgStr, time.Time{})
 	if err != nil {
 		return Repository{}, err
 	}
@@ -25,19 +27,19 @@ func ParseRepository(imgStr string) (Repository, error) {
 }
 
 func (r Repository) NamespaceImage() string {
-	return r.img.NamespaceImage()
+	return r.img.ID.NamespaceImage()
 }
 
 func (r Repository) Host() string {
-	return r.img.Host
+	return r.img.ID.Host
 }
 
 func (r Repository) String() string {
-	return r.img.HostNamespaceImage()
+	return r.img.ID.HostNamespaceImage()
 }
 
 func (r Repository) ToImage(tag string) flux.Image {
 	newImage := r.img
-	newImage.Tag = tag
+	newImage.ID.Tag = tag
 	return newImage
 }

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -76,12 +76,12 @@ var (
 	timeNow       = time.Now()
 	mockRegistry  = registry.NewMockRegistry([]flux.Image{
 		flux.Image{
-			ImageID:   newImageID,
-			CreatedAt: &timeNow,
+			ID:        newImageID,
+			CreatedAt: timeNow,
 		},
 		flux.Image{
-			ImageID:   newLockedID,
-			CreatedAt: &timeNow,
+			ID:        newLockedID,
+			CreatedAt: timeNow,
 		},
 	}, nil)
 )
@@ -294,12 +294,12 @@ func Test_ImageStatus(t *testing.T) {
 
 	upToDateRegistry := registry.NewMockRegistry([]flux.Image{
 		flux.Image{
-			ImageID:   oldImageID,
-			CreatedAt: &timeNow,
+			ID:        oldImageID,
+			CreatedAt: timeNow,
 		},
 		flux.Image{
-			ImageID:   sidecarImageID,
-			CreatedAt: &timeNow,
+			ID:        sidecarImageID,
+			CreatedAt: timeNow,
 		},
 	}, nil)
 

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -96,7 +96,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 	services := flux.ServiceIDSet{}
 	services.Add(serviceList)
 
-	now := time.Now()
+	now := time.Now().UTC()
 
 	imageID, _ := flux.ParseImageID("quay.io/example.com/frob:v0.4.5")
 	serviceAnswer := []flux.ServiceStatus{
@@ -106,9 +106,9 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 			Containers: []flux.Container{
 				flux.Container{
 					Name: "frobnicator",
-					Current: flux.ImageDescription{
+					Current: flux.Image{
 						ID:        imageID,
-						CreatedAt: &now,
+						CreatedAt: now,
 					},
 				},
 			},
@@ -118,8 +118,15 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 
 	imagesAnswer := []flux.ImageStatus{
 		flux.ImageStatus{
-			ID:         flux.ServiceID("barfoo/yello"),
-			Containers: []flux.Container{},
+			ID: flux.ServiceID("barfoo/yello"),
+			Containers: []flux.Container{
+				{
+					Name: "flubnicator",
+					Current: flux.Image{
+						ID: imageID,
+					},
+				},
+			},
 		},
 	}
 

--- a/service.go
+++ b/service.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 )
@@ -160,13 +159,8 @@ type ServiceStatus struct {
 
 type Container struct {
 	Name      string
-	Current   ImageDescription
-	Available []ImageDescription
-}
-
-type ImageDescription struct {
-	ID        ImageID
-	CreatedAt *time.Time `json:",omitempty"`
+	Current   Image
+	Available []Image
 }
 
 // TODO: How similar should this be to the `get-config` result?


### PR DESCRIPTION
Use a time.Time value rather than a pointer, and fall back to time.IsZero() to detect missing/uninitialised values. Although it's nice to have a nullable value and rely on the JSON encoder to miss it out or serialise it to `null`, it is also a repeating source of confusion, since it's unusual to use a pointer to a value type.

The custom JSON marshalling is not strictly necessary (a zero time value will roundtrip), it's tidier and matches the expectation from clients of the API.

The two types Image and ImageDescription have the same fields and are put to the same use, so
just use one of them.

(The existing HTTP API is also the reason for naming the ID field instead of embedding it: in the API it is serialised as `ID`, so it is simpler to just call it that everywhere.)