### PR TITLE
Update sync tag in pullAndSync

### DIFF
--- a/cmd/fluxctl/await.go
+++ b/cmd/fluxctl/await.go
@@ -85,10 +85,11 @@ func backoff(initialDelay, factor, maxFactor, timeout time.Duration, f func() (b
 		if ok || err != nil {
 			return err
 		}
-		// If we will have time to try again, sleep
-		if time.Now().UTC().Add(delay).Before(finish) {
-			time.Sleep(delay)
+		// If we don't have time to try again, stop
+		if time.Now().UTC().Add(delay).After(finish) {
+			break
 		}
+		time.Sleep(delay)
 	}
 	return ErrTimeout
 }

--- a/git/operations.go
+++ b/git/operations.go
@@ -116,9 +116,9 @@ func getNote(workingDir, notesRef, rev string) (*Note, error) {
 }
 
 // Get the commit hash for HEAD
-func headRevision(path string) (string, error) {
+func refRevision(path, ref string) (string, error) {
 	out := &bytes.Buffer{}
-	if err := execGitCmd(path, "", out, "rev-list", "--max-count", "1", "HEAD"); err != nil {
+	if err := execGitCmd(path, "", out, "rev-list", "--max-count", "1", ref); err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(out.String()), nil

--- a/git/repo.go
+++ b/git/repo.go
@@ -160,7 +160,7 @@ func (c *Checkout) CommitAndPush(commitMessage string, note *Note) error {
 	}
 
 	if note != nil {
-		rev, err := headRevision(c.Dir)
+		rev, err := refRevision(c.Dir, "HEAD")
 		if err != nil {
 			return err
 		}
@@ -214,7 +214,13 @@ func (c *Checkout) Pull() error {
 func (c *Checkout) HeadRevision() (string, error) {
 	c.RLock()
 	defer c.RUnlock()
-	return headRevision(c.Dir)
+	return refRevision(c.Dir, "HEAD")
+}
+
+func (c *Checkout) TagRevision(tag string) (string, error) {
+	c.RLock()
+	defer c.RUnlock()
+	return refRevision(c.Dir, tag)
 }
 
 func (c *Checkout) RevisionsBetween(ref1, ref2 string) ([]string, error) {


### PR DESCRIPTION
Fixes an issue where `fluxctl release ...` would successfully execute but appear to timeout. This happened because fluxd didn't pull the sync tag after it was updated and pushed.