### PR TITLE
Use port 3030 for the daemon

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 	// This mirrors how kubectl extracts information from the environment.
 	var (
-		listenAddr        = fs.StringP("listen", "l", ":3031", "Listen address where /metrics and API will be served")
+		listenAddr        = fs.StringP("listen", "l", ":3030", "Listen address where /metrics and API will be served")
 		kubernetesKubectl = fs.String("kubernetes-kubectl", "", "Optional, explicit path to kubectl tool")
 		versionFlag       = fs.Bool("version", false, "Get version number")
 		// Git repo & key etc.

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -20,6 +20,8 @@ spec:
       - name: fluxd
         image: quay.io/weaveworks/fluxd:latest
         imagePullPolicy: IfNotPresent
+        ports:
+        - containerPort: 3030 # informational
         volumeMounts:
         - name: git-key
           mountPath: /etc/fluxd/ssh

--- a/deploy/flux-service.yaml
+++ b/deploy/flux-service.yaml
@@ -14,6 +14,7 @@ metadata:
 spec:
   type: NodePort
   ports:
-    - port: 3030
+    - port: 80
+      targetPort: 3030
   selector:
     name: flux


### PR DESCRIPTION
You used to run the daemon and service in the same pod, meaning they had to listen on different ports.

But that's no longer necessary, in fact it's no longer necessary to run the service at all. And it's less confusing if the API is consistently at the same port.
