### PR TITLE
Reinstate slack notifications to git-sync branch

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -164,6 +164,7 @@ func (d *Daemon) pullAndSync(logger log.Logger) {
 			n, err := working.GetNote(rev)
 			if err != nil {
 				logger.Log("err", errors.Wrap(err, "loading notes from repo; possibly no notes"))
+				// TODO: We're ignoring all errors here, not just the "no notes" error. Parse error to report proper errors.
 				continue
 			}
 

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -13,8 +13,8 @@ import (
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/history"
 	"github.com/weaveworks/flux/resource"
-	"github.com/weaveworks/flux/update"
 	fluxsync "github.com/weaveworks/flux/sync"
+	"github.com/weaveworks/flux/update"
 )
 
 const (
@@ -156,8 +156,8 @@ func (d *Daemon) pullAndSync(logger log.Logger) {
 		}
 
 		// Find notes in revisions.
-		for _, rev := range revisions {
-			n, err := working.GetNote(rev)
+		for i := len(revisions) - 1; i >= 0; i-- {
+			n, err := working.GetNote(revisions[i])
 			if err != nil {
 				logger.Log("err", errors.Wrap(err, "loading notes from repo; possibly no notes"))
 				// TODO: We're ignoring all errors here, not just the "no notes" error. Parse error to report proper errors.

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -167,17 +167,10 @@ func TestPullAndSync_NoNewCommits(t *testing.T) {
 	es, err := events.AllEvents(time.Time{}, -1)
 	if err != nil {
 		t.Error(err)
-	} else if len(es) != 1 {
+	} else if len(es) != 0 {
 		t.Errorf("Unexpected events: %#v", es)
-	} else if es[0].Type != history.EventSync {
-		t.Errorf("Unexpected event type: %#v", es[0])
-	} else {
-		gotServiceIDs := es[0].ServiceIDs
-		flux.ServiceIDs(gotServiceIDs).Sort()
-		if !reflect.DeepEqual(gotServiceIDs, []flux.ServiceID{}) {
-			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotServiceIDs, []flux.ServiceID{})
-		}
 	}
+
 	// It doesn't move the tag
 	oldRevs, err := d.Checkout.RevisionsBefore(gitSyncTag)
 	if err != nil {

--- a/history/event.go
+++ b/history/event.go
@@ -210,11 +210,13 @@ func (e *Event) UnmarshalJSON(in []byte) error {
 		e.Metadata = metadata
 		break
 	default:
-		var metadata interface{}
-		if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
-			return err
+		if len(wireEvent.MetadataBytes) > 0 {
+			var metadata interface{}
+			if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
+				return err
+			}
+			e.Metadata = metadata
 		}
-		e.Metadata = metadata
 	}
 
 	// By default, leave the Event Metadata as map[string]interface{}

--- a/history/event_test.go
+++ b/history/event_test.go
@@ -1,0 +1,57 @@
+package history
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/weaveworks/flux/update"
+	"testing"
+)
+
+const (
+	releaseID = "1"
+)
+
+func TestEvent_ParseReleaseMetaData(t *testing.T) {
+	origEvent := Event{
+		Type: EventRelease,
+		Metadata: &ReleaseEventMetadata{
+			Release: update.Release{
+				ID: releaseID,
+			},
+		},
+	}
+
+	bytes, _ := json.Marshal(origEvent)
+
+	e := Event{}
+	err := e.UnmarshalJSON(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Metadata.(ReleaseEventMetadata).Release.ID != releaseID {
+		t.Fatal("Release.ID wasn't marshalled/unmarshalled")
+	}
+}
+
+func TestEvent_ParseNormalMetadata(t *testing.T) {
+	origEvent := Event{
+		Type: EventSync,
+		Metadata: &SyncEventMetadata{
+			Revisions: []string{"1"},
+		},
+	}
+
+	bytes, _ := json.Marshal(origEvent)
+
+	e := Event{}
+	err := e.UnmarshalJSON(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Metadata == nil {
+		t.Fatal("Hasn't been unmarshalled properly")
+	}
+	if fmt.Sprint(e.Metadata) != "map[revisions:[1]]" {
+		t.Fatal("Expected metadata")
+	}
+}

--- a/history/event_test.go
+++ b/history/event_test.go
@@ -55,3 +55,20 @@ func TestEvent_ParseNormalMetadata(t *testing.T) {
 		t.Fatal("Expected metadata")
 	}
 }
+
+func TestEvent_ParseNoMetadata(t *testing.T) {
+	origEvent := Event{
+		Type: EventLock,
+	}
+
+	bytes, _ := json.Marshal(origEvent)
+
+	e := Event{}
+	err := e.UnmarshalJSON(bytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if e.Metadata != nil {
+		t.Fatal("Hasn't been unmarshalled properly")
+	}
+}

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Release performs post-release notifications for an instance
-func Release(cfg instance.Config, r update.Release, releaseError error) error {
+func Release(cfg instance.Config, r update.Release, releaseError string) error {
 	if r.Spec.Kind != update.ReleaseKindExecute {
 		return nil
 	}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -67,7 +67,7 @@ func TestRelease_DryRun(t *testing.T) {
 				HookURL: server.URL,
 			},
 		},
-	}, r, nil); err != nil {
+	}, r, ""); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/notifications/slack.go
+++ b/notifications/slack.go
@@ -25,7 +25,7 @@ var (
 	httpClient = &http.Client{Timeout: 5 * time.Second}
 )
 
-func slackNotifyRelease(config flux.NotifierConfig, release update.Release, releaseError error) error {
+func slackNotifyRelease(config flux.NotifierConfig, release update.Release, releaseError string) error {
 	if release.Spec.Kind == update.ReleaseKindPlan {
 		return nil
 	}
@@ -36,8 +36,8 @@ func slackNotifyRelease(config flux.NotifierConfig, release update.Release, rele
 	}
 
 	errorMessage := ""
-	if releaseError != nil {
-		errorMessage = releaseError.Error()
+	if releaseError != "" {
+		errorMessage = releaseError
 	}
 	text, err := instantiateTemplate("release", template, struct {
 		update.Release

--- a/notifications/slack_test.go
+++ b/notifications/slack_test.go
@@ -3,7 +3,6 @@ package notifications
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -27,7 +26,7 @@ func TestSlackNotifier(t *testing.T) {
 	if err := slackNotifyRelease(flux.NotifierConfig{
 		HookURL:  server.URL,
 		Username: "user1",
-	}, exampleRelease(t), fmt.Errorf("test-error")); err != nil {
+	}, exampleRelease(t), "test-error"); err != nil {
 		t.Fatal(err)
 	}
 	if gotReq == nil {
@@ -62,7 +61,7 @@ func TestSlackNotifierDryRun(t *testing.T) {
 	// It should send releases to slack
 	release := exampleRelease(t)
 	release.Spec.Kind = update.ReleaseKindPlan
-	if err := slackNotifyRelease(flux.NotifierConfig{HookURL: server.URL}, release, fmt.Errorf("test-error")); err != nil {
+	if err := slackNotifyRelease(flux.NotifierConfig{HookURL: server.URL}, release, "test-error"); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -81,7 +80,7 @@ func TestSlackNotifierCustomTemplate(t *testing.T) {
 	if err := slackNotifyRelease(flux.NotifierConfig{
 		HookURL:         server.URL,
 		ReleaseTemplate: "My custom template here",
-	}, exampleRelease(t), fmt.Errorf("test-error")); err != nil {
+	}, exampleRelease(t), "test-error"); err != nil {
 		t.Fatal(err)
 	}
 	if gotReq == nil {
@@ -114,7 +113,7 @@ func TestSlackNotifierErrorHandling(t *testing.T) {
 	defer server.Close()
 
 	// It should get an error back from slack
-	err := slackNotifyRelease(flux.NotifierConfig{HookURL: server.URL}, exampleRelease(t), fmt.Errorf("test-error"))
+	err := slackNotifyRelease(flux.NotifierConfig{HookURL: server.URL}, exampleRelease(t), "test-error")
 	if err == nil {
 		t.Fatal("Expected an error back")
 	}


### PR DESCRIPTION
To test, create a working setup of flux with both fluxd and fluxsvc with a valid flux helloworld repo.

Add a nodeport to the service manifest so we can access the API.

Make sure you can access the api with `curl -XGET http://192.168.99.100:30303/v4/config`

Now push your slack settings to fluxsvc: `curl -XPOST http://192.168.99.100:30303/v4/config -d @flux.json`

Where flux.json looks like:
```
{"git":{"URL":"","path":"","branch":"","key":""},"slack":{"hookURL":"https://hooks.slack.com/services/JFIODSA/432feas/specialr53wfds","username":"phils-test-flux","releaseTemplate":""},"registry":{"auths":null}}
```
Make sure you change the `hookURL` to point at your slack service URL (available from slack).

Now perform some sort of release and watch it ping your slack:
`fluxctl -u http://192.168.99.100:30303 release --service=default/helloworld --user=phil --message="Because I had to" --update-image=quay.io/weaveworks/helloworld:master-a000001`