### PR TITLE
Log state of jobs, deal with release errors

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -3,14 +3,18 @@ package job
 import (
 	"sync"
 
+	"github.com/go-kit/kit/log"
+
 	"github.com/weaveworks/flux/history"
 )
 
 type ID string
 
+type JobFunc func(log.Logger) error
+
 type Job struct {
 	ID ID
-	Do func() error
+	Do JobFunc
 }
 
 type StatusString string

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-kit/kit/log"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/cluster/kubernetes"
@@ -357,7 +359,7 @@ func Test_ImageStatus(t *testing.T) {
 }
 
 func testRelease(t *testing.T, name string, ctx *ReleaseContext, spec update.ReleaseSpec, expected update.Result) {
-	_, results, err := Release(ctx, spec)
+	_, results, err := Release(ctx, spec, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
 1. log the state of jobs, and plumb logging through into the release
 procedure so it can report what's happening
 2. make sure the daemon job reports any error it gets from the
 release procedure

Fixes #577.