### PR TITLE
Do not close the ready channel when shutting the queue down

### DIFF
--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -58,10 +58,8 @@ func daemon(t *testing.T) (*Daemon, func()) {
 	events = history.NewMock()
 
 	wg := &sync.WaitGroup{}
-	jobs := job.NewQueue()
 	shutdown := make(chan struct{})
-	wg.Add(1)
-	go jobs.Loop(shutdown, wg)
+	jobs := job.NewQueue(shutdown, wg)
 	d := &Daemon{
 		Cluster:        k8s,
 		Manifests:      k8s,

--- a/job/job_test.go
+++ b/job/job_test.go
@@ -1,0 +1,46 @@
+package job
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestQueue(t *testing.T) {
+	shutdown := make(chan struct{})
+	wg := &sync.WaitGroup{}
+	defer close(shutdown)
+	q := NewQueue(shutdown, wg)
+	if q.Len() != 0 {
+		t.Errorf("Fresh queue has length %d (!= 0)", q.Len())
+	}
+
+	select {
+	case <-q.Ready():
+		t.Error("Value from q.Ready before any values enqueued")
+	default:
+	}
+
+	// When this proceeds, the value will be in the queue
+	q.Enqueue(&Job{"job 1", nil})
+	q.Sync()
+	if q.Len() != 1 {
+		t.Errorf("Queue has length %d (!= 1) after enqueuing one item (and sync)", q.Len())
+	}
+
+	// This should proceed eventually
+	j := <-q.Ready()
+	if j.ID != "job 1" {
+		t.Errorf("Dequeued odd job: %#v", j)
+	}
+	q.Sync()
+	if q.Len() != 0 {
+		t.Errorf("Queue has length %d (!= 0) after dequeuing only item (and sync)", q.Len())
+	}
+
+	// This should not proceed, because the queue is empty
+	select {
+	case j = <-q.Ready():
+		t.Errorf("Dequeued from empty queue: %#v", j)
+	default:
+	}
+}


### PR DESCRIPTION
Formerly it was possible to get an arbitrary number of `nil`s from the
job queue once you shut it down, since it closed the ready channel
when stopping.

Closing the ready channel was intended to let any goroutine that was
blocked on receiving from it proceed. Unfortunately, when used in a
select loop, it means that case will always succeed.

This makes the ready channel always block, on the understanding that
it will be used in a select block with at least one other case that
will eventually succeed.

It also removes a similar attempt to unblock goroutines trying to
enqueue items -- this would never work in general, since it only
received one value!

For the purpose of testing, I added a `q.Sync()`, with heavy
caveats.