### PR TITLE
Remove ImageSpecNone

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -15,7 +15,6 @@ type serviceReleaseOpts struct {
 	allServices bool
 	image       string
 	allImages   bool
-	noUpdate    bool
 	exclude     []string
 	dryRun      bool
 	outputOpts
@@ -34,7 +33,6 @@ func (opts *serviceReleaseOpts) Command() *cobra.Command {
 			"fluxctl release --service=default/foo --update-image=library/hello:v2",
 			"fluxctl release --all --update-image=library/hello:v2",
 			"fluxctl release --service=default/foo --update-all-images",
-			"fluxctl release --service=default/foo --no-update",
 		),
 		RunE: opts.RunE,
 	}
@@ -45,7 +43,6 @@ func (opts *serviceReleaseOpts) Command() *cobra.Command {
 	cmd.Flags().BoolVar(&opts.allServices, "all", false, "release all services")
 	cmd.Flags().StringVarP(&opts.image, "update-image", "i", "", "update a specific image")
 	cmd.Flags().BoolVar(&opts.allImages, "update-all-images", false, "update all images to latest versions")
-	cmd.Flags().BoolVar(&opts.noUpdate, "no-update", false, "don't update images; just deploy the service(s) as configured in the git repo")
 	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "exclude a service")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "do not release anything; just report back what would have been done")
 	return cmd
@@ -56,7 +53,7 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	if err := checkExactlyOne("--update-image=<image>, --update-all-images, or --no-update", opts.image != "", opts.allImages, opts.noUpdate); err != nil {
+	if err := checkExactlyOne("--update-image=<image> or --update-all-images", opts.image != "", opts.allImages); err != nil {
 		return err
 	}
 
@@ -88,8 +85,6 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		}
 	case opts.allImages:
 		image = update.ImageSpecLatest
-	case opts.noUpdate:
-		image = update.ImageSpecNone
 	}
 
 	var kind update.ReleaseKind = update.ReleaseKindExecute

--- a/cmd/fluxctl/release_cmd_test.go
+++ b/cmd/fluxctl/release_cmd_test.go
@@ -21,11 +21,6 @@ func TestReleaseCommand_CLIConversion(t *testing.T) {
 			"image":   string(update.ImageSpecLatest),
 			"kind":    string(update.ReleaseKindPlan),
 		}},
-		{[]string{"--no-update", "--all"}, map[string]string{
-			"service": string(update.ServiceSpecAll),
-			"image":   string(update.ImageSpecNone),
-			"kind":    string(update.ReleaseKindExecute),
-		}},
 		{[]string{"--update-image=alpine:latest", "--all"}, map[string]string{
 			"service": string(update.ServiceSpecAll),
 			"image":   "alpine:latest",

--- a/update/release.go
+++ b/update/release.go
@@ -13,7 +13,6 @@ const (
 	ServiceSpecAll       = ServiceSpec("<all>")
 	ServiceSpecAutomated = ServiceSpec("<automated>")
 	ImageSpecLatest      = ImageSpec("<all latest>")
-	ImageSpecNone        = ImageSpec("<no updates>")
 )
 
 var (
@@ -67,8 +66,6 @@ func (s ReleaseSpec) ReleaseType() string {
 	switch {
 	case s.ImageSpec == ImageSpecLatest:
 		return "latest_images"
-	case s.ImageSpec == ImageSpecNone:
-		return "config_only"
 	default:
 		return "specific_image"
 	}
@@ -104,7 +101,7 @@ func (s ServiceSpec) String() string {
 type ImageSpec string
 
 func ParseImageSpec(s string) (ImageSpec, error) {
-	if s == string(ImageSpecLatest) || s == string(ImageSpecNone) {
+	if s == string(ImageSpecLatest) {
 		return ImageSpec(s), nil
 	}
 

--- a/update/spec_test.go
+++ b/update/spec_test.go
@@ -8,7 +8,6 @@ func TestParseImageSpec(t *testing.T) {
 	parseSpec(t, ":tag", true)
 	parseSpec(t, "image:", true)
 	parseSpec(t, "image", true)
-	parseSpec(t, string(ImageSpecNone), false)
 	parseSpec(t, string(ImageSpecLatest), false)
 	parseSpec(t, "<invalid spec>", true)
 }


### PR DESCRIPTION
This was originally for supporting "just deploy what's in git"; but, now that's exactly what the sync loop should be doing.