### PR TITLE
Explicitly model "not ready" daemon state

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -23,6 +24,7 @@ import (
 	"github.com/weaveworks/flux/cluster/kubernetes"
 	"github.com/weaveworks/flux/daemon"
 	"github.com/weaveworks/flux/git"
+	"github.com/weaveworks/flux/history"
 	transport "github.com/weaveworks/flux/http"
 	daemonhttp "github.com/weaveworks/flux/http/daemon"
 	"github.com/weaveworks/flux/job"
@@ -196,6 +198,58 @@ func main() {
 		reg = registry.NewInstrumentedRegistry(reg)
 	}
 
+	// Indirect reference to a daemon, initially of the NotReady variety
+	notReadyDaemon := daemon.NewNotReadyDaemon(
+		version,
+		k8s,
+		errors.New("waiting to clone repo"))
+
+	daemonRef := daemon.NewRef(notReadyDaemon)
+
+	var eventWriter history.EventWriter
+	{
+		// Connect to fluxsvc if given an upstream address
+		if *upstreamURL != "" {
+			upstreamLogger := log.NewContext(logger).With("component", "upstream")
+			upstreamLogger.Log("URL", *upstreamURL)
+			upstream, err := daemonhttp.NewUpstream(
+				&http.Client{Timeout: 10 * time.Second},
+				fmt.Sprintf("fluxd/%v", version),
+				flux.Token(*token),
+				transport.NewServiceRouter(), // TODO should be NewUpstreamRouter, since it only needs the registration endpoint
+				*upstreamURL,
+				&remote.ErrorLoggingPlatform{daemonRef, upstreamLogger},
+				upstreamLogger,
+			)
+			if err != nil {
+				logger.Log("err", err)
+				os.Exit(1)
+			}
+			eventWriter = upstream
+			defer upstream.Close()
+		} else {
+			logger.Log("upstream", "no upstream URL given")
+		}
+	}
+
+	// Mechanical components.
+	errc := make(chan error)
+	go func() {
+		c := make(chan os.Signal)
+		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
+		errc <- fmt.Errorf("%s", <-c)
+	}()
+
+	// HTTP transport component, for metrics
+	go func() {
+		mux := http.NewServeMux()
+		mux.Handle("/metrics", promhttp.Handler())
+		handler := daemonhttp.NewHandler(daemonRef, daemonhttp.NewRouter())
+		mux.Handle("/api/flux/", http.StripPrefix("/api/flux", handler))
+		logger.Log("addr", *listenAddr)
+		errc <- http.ListenAndServe(*listenAddr, mux)
+	}()
+
 	var checkout *git.Checkout
 	{
 		repo := git.Repo{
@@ -211,18 +265,21 @@ func main() {
 			UserEmail: *gitEmail,
 		}
 
-		working, err := repo.Clone(gitConfig)
-		if err != nil {
-			logger.Log("component", "git", "err", err.Error())
-			os.Exit(1)
+		for checkout == nil {
+			working, err := repo.Clone(gitConfig)
+			if err != nil {
+				logger.Log("component", "git", "err", err.Error())
+				notReadyDaemon.UpdateReason(err)
+				time.Sleep(10 * time.Second)
+			} else {
+				logger.Log("working-dir", working.Dir,
+					"user", *gitUser,
+					"email", *gitEmail,
+					"sync-tag", *gitSyncTag,
+					"notes-ref", *gitNotesRef)
+				checkout = working
+			}
 		}
-
-		logger.Log("working-dir", working.Dir,
-			"user", *gitUser,
-			"email", *gitEmail,
-			"sync-tag", *gitSyncTag,
-			"notes-ref", *gitNotesRef)
-		checkout = working
 	}
 
 	shutdown := make(chan struct{})
@@ -245,50 +302,14 @@ func main() {
 		JobStatusCache: &job.StatusCache{Size: 100},
 	}
 
-	// Connect to fluxsvc if given an upstream address
-	if *upstreamURL != "" {
-		upstreamLogger := log.NewContext(logger).With("component", "upstream")
-		upstreamLogger.Log("URL", *upstreamURL)
-		upstream, err := daemonhttp.NewUpstream(
-			&http.Client{Timeout: 10 * time.Second},
-			fmt.Sprintf("fluxd/%v", version),
-			flux.Token(*token),
-			transport.NewServiceRouter(), // TODO should be NewUpstreamRouter, since it only needs the registration endpoint
-			*upstreamURL,
-			&remote.ErrorLoggingPlatform{daemon, upstreamLogger},
-			upstreamLogger,
-		)
-		if err != nil {
-			logger.Log("err", err)
-			os.Exit(1)
-		}
-		daemon.EventWriter = upstream
-		defer upstream.Close()
-	} else {
-		logger.Log("upstream", "no upstream URL given")
-	}
+	daemon.EventWriter = eventWriter
 
 	daemonWg := &sync.WaitGroup{}
 	daemonWg.Add(1)
 	go daemon.Loop(shutdown, daemonWg, log.NewContext(logger).With("component", "sync-loop"))
 
-	// Mechanical components.
-	errc := make(chan error)
-	go func() {
-		c := make(chan os.Signal)
-		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
-		errc <- fmt.Errorf("%s", <-c)
-	}()
-
-	// HTTP transport component, for metrics
-	go func() {
-		mux := http.NewServeMux()
-		mux.Handle("/metrics", promhttp.Handler())
-		handler := daemonhttp.NewHandler(daemon, daemonhttp.NewRouter())
-		mux.Handle("/api/flux/", http.StripPrefix("/api/flux", handler))
-		logger.Log("addr", *listenAddr)
-		errc <- http.ListenAndServe(*listenAddr, mux)
-	}()
+	// Update daemonRef so that upstream and handlers point to fully working daemon
+	daemonRef.UpdatePlatform(daemon)
 
 	// Go!
 	logger.Log("exiting", <-errc)

--- a/daemon/notready.go
+++ b/daemon/notready.go
@@ -1,0 +1,83 @@
+package daemon
+
+import (
+	"sync"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/job"
+	"github.com/weaveworks/flux/ssh"
+	"github.com/weaveworks/flux/update"
+)
+
+// NotReadyDaemon is a stub implementation used to serve a subset of the
+// API when we have yet to successfully clone the config repo.
+type NotReadyDaemon struct {
+	sync.RWMutex
+	version string
+	cluster cluster.Cluster
+	reason  error
+}
+
+func NewNotReadyDaemon(version string, cluster cluster.Cluster, reason error) (nrd *NotReadyDaemon) {
+	return &NotReadyDaemon{
+		version: version,
+		cluster: cluster,
+		reason:  reason,
+	}
+}
+
+func (nrd *NotReadyDaemon) Reason() error {
+	nrd.RLock()
+	defer nrd.RUnlock()
+	return nrd.reason
+}
+
+func (nrd *NotReadyDaemon) UpdateReason(reason error) {
+	nrd.Lock()
+	nrd.reason = reason
+	nrd.Unlock()
+}
+
+// 'Not ready' platform implementation
+
+func (nrd *NotReadyDaemon) Ping() error {
+	return nrd.cluster.Ping()
+}
+
+func (nrd *NotReadyDaemon) Version() (string, error) {
+	return nrd.version, nil
+}
+
+func (nrd *NotReadyDaemon) Export() ([]byte, error) {
+	return nrd.cluster.Export()
+}
+
+func (nrd *NotReadyDaemon) ListServices(namespace string) ([]flux.ServiceStatus, error) {
+	return nil, nrd.Reason()
+}
+
+func (nrd *NotReadyDaemon) ListImages(update.ServiceSpec) ([]flux.ImageStatus, error) {
+	return nil, nrd.Reason()
+}
+
+func (nrd *NotReadyDaemon) UpdateManifests(update.Spec) (job.ID, error) {
+	var id job.ID
+	return id, nrd.Reason()
+}
+
+func (nrd *NotReadyDaemon) SyncNotify() error {
+	return nrd.Reason()
+}
+
+func (nrd *NotReadyDaemon) JobStatus(id job.ID) (job.Status, error) {
+	return job.Status{}, nrd.Reason()
+}
+
+func (nrd *NotReadyDaemon) SyncStatus(string) ([]string, error) {
+	return nil, nrd.Reason()
+}
+
+func (nrd *NotReadyDaemon) PublicSSHKey(regenerate bool) (ssh.PublicKey, error) {
+	return nrd.cluster.PublicSSHKey(regenerate)
+}

--- a/daemon/ref.go
+++ b/daemon/ref.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"sync"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/job"
+	"github.com/weaveworks/flux/remote"
+	"github.com/weaveworks/flux/ssh"
+	"github.com/weaveworks/flux/update"
+)
+
+type Ref struct {
+	sync.RWMutex
+	platform remote.Platform
+}
+
+func NewRef(platform remote.Platform) (pr *Ref) {
+	return &Ref{platform: platform}
+}
+
+func (pr *Ref) Platform() remote.Platform {
+	pr.RLock()
+	defer pr.RUnlock()
+	return pr.platform
+}
+
+func (pr *Ref) UpdatePlatform(platform remote.Platform) {
+	pr.Lock()
+	pr.platform = platform
+	pr.Unlock()
+}
+
+// remote.Platform implementation so clients don't need to be refactored around
+// Platform() API
+
+func (pr *Ref) Ping() error {
+	return pr.Platform().Ping()
+}
+
+func (pr *Ref) Version() (string, error) {
+	return pr.Platform().Version()
+}
+
+func (pr *Ref) Export() ([]byte, error) {
+	return pr.Platform().Export()
+}
+
+func (pr *Ref) ListServices(namespace string) ([]flux.ServiceStatus, error) {
+	return pr.Platform().ListServices(namespace)
+}
+
+func (pr *Ref) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+	return pr.Platform().ListImages(spec)
+}
+
+func (pr *Ref) UpdateManifests(spec update.Spec) (job.ID, error) {
+	return pr.Platform().UpdateManifests(spec)
+}
+
+func (pr *Ref) SyncNotify() error {
+	return pr.Platform().SyncNotify()
+}
+
+func (pr *Ref) JobStatus(id job.ID) (job.Status, error) {
+	return pr.Platform().JobStatus(id)
+}
+
+func (pr *Ref) SyncStatus(ref string) ([]string, error) {
+	return pr.Platform().SyncStatus(ref)
+}
+
+func (pr *Ref) PublicSSHKey(regenerate bool) (ssh.PublicKey, error) {
+	return pr.Platform().PublicSSHKey(regenerate)
+}

--- a/git/errors.go
+++ b/git/errors.go
@@ -36,7 +36,7 @@ there is a deploy key with write permissions to the repository. In
 GitHub, you can do this via the settings for the repository, and
 cross-check with the fingerprint given by
 
-    fluxctl get-config --fingerprint=md5
+    fluxctl identity
 
 `,
 	}}
@@ -60,14 +60,12 @@ In GitHub, please check via the repository settings that the deploy
 key is "Read/write". You can cross-check the fingerprint with that
 given by
 
-    fluxctl get-config --fingerprint=md5
+    fluxctl identity
 
 If the key is present but read-only, you will need to delete it and
 create a new deploy key. To create a new one, use
 
-    fluxctl set-config --generate-deploy-key
-    # then retrieve the public key
-    fluxctl get-config
+    fluxctl identity --regenerate
 
 The public key this outputs can then be given to GitHub; make sure you
 check the box to allow write access.

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -10,11 +10,11 @@ import (
 	"github.com/weaveworks/common/middleware"
 
 	"github.com/weaveworks/flux"
-	"github.com/weaveworks/flux/daemon"
 	transport "github.com/weaveworks/flux/http"
 	"github.com/weaveworks/flux/job"
 	fluxmetrics "github.com/weaveworks/flux/metrics"
 	"github.com/weaveworks/flux/policy"
+	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -39,7 +39,7 @@ func NewRouter() *mux.Router {
 	return r
 }
 
-func NewHandler(d *daemon.Daemon, r *mux.Router) http.Handler {
+func NewHandler(d remote.Platform, r *mux.Router) http.Handler {
 	handle := HTTPServer{d}
 	r.Get("SyncNotify").HandlerFunc(handle.SyncNotify)
 	r.Get("JobStatus").HandlerFunc(handle.JobStatus)
@@ -59,7 +59,7 @@ func NewHandler(d *daemon.Daemon, r *mux.Router) http.Handler {
 }
 
 type HTTPServer struct {
-	daemon *daemon.Daemon
+	daemon remote.Platform
 }
 
 func (s HTTPServer) SyncNotify(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
To facilitate configuration of a generated keypair as a deploy key via
the UI, it is necessary to move the initial git clone operation after
the upstream connection, and to retry it periodically until it is
successful. This commit introduces a NotReadyDaemon which is capable of
supporting specific operations critical to the task (e.g. getting the
public key) but not others which depend on the cloned config repository;
once the full daemon is available, it is substituted in its place.