### PR TITLE
Compare repos on image release

### DIFF
--- a/release/context.go
+++ b/release/context.go
@@ -15,14 +15,15 @@ import (
 )
 
 const (
-	Locked         = "locked"
-	NotIncluded    = "not included"
-	Excluded       = "excluded"
-	DifferentImage = "a different image"
-	NotInCluster   = "not running in cluster"
-	NotInRepo      = "not found in repository"
-	ImageNotFound  = "cannot find one or more images"
-	ImageUpToDate  = "image(s) up to date"
+	Locked          = "locked"
+	NotIncluded     = "not included"
+	Excluded        = "excluded"
+	DifferentImage  = "a different image"
+	NotInCluster    = "not running in cluster"
+	NotInRepo       = "not found in repository"
+	ImageNotFound   = "cannot find one or more images"
+	ImageUpToDate   = "image(s) up to date"
+	DoesNotUseImage = "does not use image(s)"
 )
 
 type ReleaseContext struct {

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -184,6 +184,7 @@ specs:
 func calculateImageUpdates(rc *ReleaseContext, candidates []*ServiceUpdate, spec *update.ReleaseSpec, results update.Result) ([]*ServiceUpdate, error) {
 	// Compile an `ImageMap` of all relevant images
 	var images ImageMap
+	var repo string
 	var err error
 
 	switch spec.ImageSpec {
@@ -193,6 +194,7 @@ func calculateImageUpdates(rc *ReleaseContext, candidates []*ServiceUpdate, spec
 		var image flux.ImageID
 		image, err = spec.ImageSpec.AsID()
 		if err == nil {
+			repo = image.Repository()
 			images, err = ExactImages(rc.Registry, []flux.ImageID{image})
 		}
 	}
@@ -230,7 +232,11 @@ func calculateImageUpdates(rc *ReleaseContext, candidates []*ServiceUpdate, spec
 
 			latestImage := images.LatestImage(currentImageID.Repository())
 			if latestImage == nil {
-				ignoredOrSkipped = update.ReleaseStatusUnknown
+				if currentImageID.Repository() != repo {
+					ignoredOrSkipped = update.ReleaseStatusIgnored
+				} else {
+					ignoredOrSkipped = update.ReleaseStatusUnknown
+				}
 				continue
 			}
 

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -273,7 +273,7 @@ func calculateImageUpdates(rc *ReleaseContext, candidates []*ServiceUpdate, spec
 		case ignoredOrSkipped == update.ReleaseStatusIgnored:
 			results[u.ServiceID] = update.ServiceResult{
 				Status: update.ReleaseStatusIgnored,
-				Error:  "does not use image(s)",
+				Error:  DoesNotUseImage,
 			}
 		case ignoredOrSkipped == update.ReleaseStatusUnknown:
 			results[u.ServiceID] = update.ServiceResult{

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -56,7 +56,7 @@ var (
 		},
 	}
 
-	testScv = cluster.Service{
+	testSvc = cluster.Service{
 		ID: "default/test-service",
 		Containers: cluster.ContainersOrExcuse{
 			Containers: []cluster.Container{
@@ -67,12 +67,12 @@ var (
 			},
 		},
 	}
-	testSvcSpec, _ = update.ParseServiceSpec(testScv.ID.String())
+	testSvcSpec, _ = update.ParseServiceSpec(testSvc.ID.String())
 
 	allSvcs = []cluster.Service{
 		hwSvc,
 		lockedSvc,
-		testScv,
+		testSvc,
 	}
 	newImageID, _ = flux.ParseImageID("quay.io/weaveworks/helloworld:master-a000002")
 	timeNow       = time.Now()
@@ -306,7 +306,7 @@ func Test_ImageStatus(t *testing.T) {
 			return []cluster.Service{
 				hwSvc,
 				lockedSvc,
-				testScv,
+				testSvc,
 			}, nil
 		},
 	}
@@ -322,7 +322,7 @@ func Test_ImageStatus(t *testing.T) {
 		},
 	}, nil)
 
-	testSvcSpec, _ := update.ParseServiceSpec(testScv.ID.String())
+	testSvcSpec, _ := update.ParseServiceSpec(testSvc.ID.String())
 	for _, tst := range []struct {
 		Name     string
 		Spec     update.ReleaseSpec
@@ -346,8 +346,8 @@ func Test_ImageStatus(t *testing.T) {
 					Error:  NotIncluded,
 				},
 				flux.ServiceID("default/test-service"): update.ServiceResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  ImageNotFound,
+					Status: update.ReleaseStatusIgnored,
+					Error:  DoesNotUseImage,
 				},
 			},
 		}, {


### PR DESCRIPTION
The misleading description in @squaremo's particular case arose because we try to update all containers within the service with a subset of all images.

We currently call ExactImages with the 'update-image' which gives us an ImageMap containing only a key for that repository, so calling LatestImage for any other repository will always return nil.


Fixes #579