### PR TITLE
Bump alpine base image to 3.6

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 WORKDIR /home/flux
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'

--- a/docker/Dockerfile.flux-service
+++ b/docker/Dockerfile.flux-service
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 WORKDIR /home/flux
 ENTRYPOINT [ "/sbin/tini", "--", "fluxsvc" ]
 RUN apk add --no-cache ca-certificates tini


### PR DESCRIPTION
quay.io security scanner reports a security vulnerability in zlib which is addressed in alpine 3.6