### PR TITLE
Unwedge cluster loop

### DIFF
--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -380,8 +380,9 @@ func (c *Cluster) Sync(spec cluster.SyncDef) error {
 		}
 		if len(errs) > 0 {
 			errc <- errs
+		} else {
+			errc <- nil
 		}
-		errc <- nil
 	}
 	return <-errc
 }


### PR DESCRIPTION
Actions that update the (Kubernetes) cluster are serialised by sending
them as closures to a channel, from which a loop receives them and
executes them. This is wrapped by the Sync method which supplies a
channel for the outcome, and returns that.

In the case of errors, an error is sent to the channel, and for
successful actions, a nil value. However this latter was done
unconditionally, meaning that if there was an error, the second send
would block, the loop would not proceed, and anyone calling Sync
subsequently would be blocked.