### PR TITLE
Simplify the logging of kubectl apply commands

### DIFF
--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -47,6 +47,13 @@ type apiObject struct {
 	} `yaml:"metadata"`
 }
 
+func (obj *apiObject) namespaceOrDefault() string {
+	if obj.Metadata.Namespace == "" {
+		return "default"
+	}
+	return obj.Metadata.Namespace
+}
+
 // --- add-ons
 
 // Kubernetes has a mechanism of "Add-ons", whereby manifest files
@@ -357,6 +364,7 @@ func (c *Cluster) Sync(spec cluster.SyncDef) error {
 	c.actionc <- func() {
 		errs := cluster.SyncError{}
 		for _, action := range spec.Actions {
+			logger := log.NewContext(logger).With("resource", action.ResourceID)
 			if len(action.Delete) > 0 {
 				obj, err := definitionObj(action.Delete)
 				if err == nil {


### PR DESCRIPTION
This commit makes the output from a sync more compact and thus easier to skip through when unimportant (which is most of the time).

Old format:

```
ts=2017-06-09T13:25:56Z caller=main.go:285 working-dir=/tmp/flux-gitclone518133599/repo user="Weave Flux" email=support@weave.works sync-tag=flux-sync notes-ref=flux
ts=2017-06-09T13:25:59Z caller=release.go:64 component=platform method=Sync resource=0 cmd="--namespace olleh apply -f -"
service "helloworld" configured
ts=2017-06-09T13:25:59Z caller=release.go:73 component=platform method=Sync resource=0 result=success took=290.651698ms
ts=2017-06-09T13:25:59Z caller=release.go:64 component=platform method=Sync resource=1 cmd="--namespace default apply -f -"
namespace "olleh" configured
ts=2017-06-09T13:26:00Z caller=release.go:73 component=platform method=Sync resource=1 result=success took=217.412719ms
ts=2017-06-09T13:26:00Z caller=release.go:64 component=platform method=Sync resource=2 cmd="--namespace default apply -f -"
namespace "hello" configured
ts=2017-06-09T13:26:00Z caller=release.go:73 component=platform method=Sync resource=2 result=success took=197.253241ms
ts=2017-06-09T13:26:00Z caller=release.go:64 component=platform method=Sync resource=3 cmd="--namespace hello apply -f -"
deployment "helloworld" configured
ts=2017-06-09T13:26:00Z caller=release.go:73 component=platform method=Sync resource=3 result=success took=197.185622ms
ts=2017-06-09T13:26:00Z caller=release.go:64 component=platform method=Sync resource=4 cmd="--namespace olleh apply -f -"
deployment "helloworld" configured
ts=2017-06-09T13:26:00Z caller=release.go:73 component=platform method=Sync resource=4 result=success took=178.415873ms
ts=2017-06-09T13:26:00Z caller=release.go:64 component=platform method=Sync resource=5 cmd="--namespace hello apply -f -"
service "memcached" configured
ts=2017-06-09T13:26:00Z caller=release.go:73 component=platform method=Sync resource=5 result=success took=197.298101ms
ts=2017-06-09T13:26:00Z caller=release.go:64 component=platform method=Sync resource=6 cmd="--namespace hello apply -f -"
deployment "memcached" configured
```

New format:
```
ts=2017-06-09T14:47:18Z caller=release.go:73 component=platform method=Sync resource="Service hello/memcached" cmd="kubectl --namespace hello apply -f -" took=288.541867ms err=null output="service \"memcached\" configured"
ts=2017-06-09T14:47:18Z caller=release.go:73 component=platform method=Sync resource="Service olleh/helloworld" cmd="kubectl --namespace olleh apply -f -" took=163.107514ms err=null output="service \"helloworld\" configured"
ts=2017-06-09T14:47:18Z caller=release.go:73 component=platform method=Sync resource="Namespace olleh" cmd="kubectl --namespace default apply -f -" took=168.578734ms err=null output="namespace \"olleh\" configured"
ts=2017-06-09T14:47:18Z caller=release.go:73 component=platform method=Sync resource="Deployment hello/flux" cmd="kubectl --namespace hello apply -f -" took=166.45378ms err=null output="deployment \"flux\" configured"
ts=2017-06-09T14:47:18Z caller=release.go:73 component=platform method=Sync resource="Namespace hello" cmd="kubectl --namespace default apply -f -" took=204.936338ms err=null output="namespace \"hello\" configured"
ts=2017-06-09T14:47:19Z caller=release.go:73 component=platform method=Sync resource="Service hello/helloworld" cmd="kubectl --namespace hello apply -f -" took=161.615542ms err=null output="service \"helloworld\" configured"
ts=2017-06-09T14:47:19Z caller=release.go:73 component=platform method=Sync resource="Deployment hello/memcached" cmd="kubectl --namespace hello apply -f -" took=152.926429ms err=null output="deployment \"memcached\" configured"
ts=2017-06-09T14:47:19Z caller=release.go:73 component=platform method=Sync resource="Service hello/flux" cmd="kubectl --namespace hello apply -f -" took=180.609663ms err=null output="service \"flux\" configured"
ts=2017-06-09T14:47:19Z caller=release.go:73 component=platform method=Sync resource="Deployment hello/helloworld" cmd="kubectl --namespace hello apply -f -" took=158.735628ms err=null output="deployment \"helloworld\" configured"
ts=2017-06-09T14:47:19Z caller=release.go:73 component=platform method=Sync resource="Deployment olleh/helloworld" cmd="kubectl --namespace olleh apply -f -" took=152.592855ms err=null output="deployment \"helloworld\" configured"
ts
```
```