### PR TITLE
Skip deleted files when seeing what's changed

### DIFF
--- a/git/operations.go
+++ b/git/operations.go
@@ -153,7 +153,10 @@ func moveTagAndPush(path string, keyRing ssh.KeyRing, tag, ref, msg, upstream st
 
 func changedFiles(path, subPath, ref string) ([]string, error) {
 	out := &bytes.Buffer{}
-	if err := execGitCmd(path, nil, out, "diff", "--name-only", ref, "--", subPath); err != nil {
+	// This uses --diff-filter to only look at changes for file _in
+	// the working dir_; i.e, we do not report on things that no
+	// longer appear.
+	if err := execGitCmd(path, nil, out, "diff", "--name-only", "--diff-filter=ACMRT", ref, "--", subPath); err != nil {
 		return nil, err
 	}
 	return splitList(out.String()), nil


### PR DESCRIPTION
One of the things the sync loop does is report on which services have
chnaged in a sync event. To do that, it looks at which files in the
repo changed between where we last synced, and the working directory,
using git.

However, `git diff --name-only` will report _deleted_ files, and as
they are not around to parse, the next part (parsing the changed
files) will fail; and the sync, despite having done its main job, will
fail.

The failsafe is that it will *also* fail to push the sync tag, so next
time around it will at least give it another go (though it will be
doomed to fail that as well).

The solution is to filter deleted files from the diff, so it only
tries to parse added or changed (or renamed) files.