### PR TITLE
Fix cause of release events

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -476,7 +476,9 @@ func updateImage(d *Daemon, t *testing.T) job.ID {
 	return updateManifest(t, d, update.Spec{
 		Type: update.Images,
 		Spec: update.ReleaseSpec{
-			ImageSpec: newHelloImage,
+			Kind:         update.ReleaseKindExecute,
+			ServiceSpecs: []update.ServiceSpec{update.ServiceSpecAll},
+			ImageSpec:    newHelloImage,
 		},
 	})
 }

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -77,7 +77,7 @@ func (d *Daemon) NewImage(imageID flux.ImageID) error {
 	}
 	cause := update.Cause{
 		User:    update.UserAutomated,
-		Message: fmt.Sprintf("due to new image %s", imageID.String()),
+		Message: fmt.Sprintf("Release due to new image %s", imageID.String()),
 	}
 
 	_, err := d.UpdateManifests(update.Spec{Type: update.Images, Cause: cause, Spec: spec})

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -159,17 +159,12 @@ func (d *Daemon) pullAndSync(logger log.Logger) {
 				continue
 			}
 
-			// If one of the notes has a release event, send that to the service
+			// If any of the commit notes has a release event, send
+			// that to the service
 			if n.Spec.Type == update.Images {
 				// Map new note.Spec into ReleaseSpec
 				spec := n.Spec.Spec.(update.ReleaseSpec)
 				// And create a release event
-				releaseEvent := update.Release{
-					StartedAt: started,
-					EndedAt:   time.Now().UTC(),
-					Spec:      spec,
-					Result:    n.Result,
-				}
 				// Then wrap inside a ReleaseEventMetadata
 				if err := d.LogEvent(history.Event{
 					ServiceIDs: serviceIDs.ToSlice(),
@@ -178,8 +173,11 @@ func (d *Daemon) pullAndSync(logger log.Logger) {
 					EndedAt:    time.Now().UTC(),
 					LogLevel:   history.LogLevelInfo,
 					Metadata: &history.ReleaseEventMetadata{
-						Release: releaseEvent,
-						Error:   n.Result.Error(),
+						Revision: revisions[i],
+						Spec:     spec,
+						Cause:    n.Spec.Cause,
+						Result:   n.Result,
+						Error:    n.Result.Error(),
 					},
 				}); err != nil {
 					logger.Log("err", err)

--- a/history/event.go
+++ b/history/event.go
@@ -80,11 +80,11 @@ func (e Event) String() string {
 	switch e.Type {
 	case EventRelease:
 		metadata := e.Metadata.(*ReleaseEventMetadata)
-		strImageIDs := metadata.Release.Result.ImageIDs()
+		strImageIDs := metadata.Result.ImageIDs()
 		if len(strImageIDs) == 0 {
 			strImageIDs = []string{"no image changes"}
 		}
-		for _, spec := range metadata.Release.Spec.ServiceSpecs {
+		for _, spec := range metadata.Spec.ServiceSpecs {
 			switch spec {
 			case update.ServiceSpecAll:
 				strServiceIDs = []string{"all services"}
@@ -98,12 +98,12 @@ func (e Event) String() string {
 			strServiceIDs = []string{"no services"}
 		}
 		var user string
-		if metadata.Release.Cause.User != "" {
-			user = fmt.Sprintf(", by %s", metadata.Release.Cause.User)
+		if metadata.Cause.User != "" {
+			user = fmt.Sprintf(", by %s", metadata.Cause.User)
 		}
 		var msg string
-		if metadata.Release.Cause.Message != "" {
-			msg = fmt.Sprintf(", with message %q", metadata.Release.Cause.Message)
+		if metadata.Cause.Message != "" {
+			msg = fmt.Sprintf(", with message %q", metadata.Cause.Message)
 		}
 		return fmt.Sprintf(
 			"Released: %s to %s%s%s",
@@ -177,8 +177,10 @@ type SyncEventMetadata struct {
 
 // ReleaseEventMetadata is the metadata for when service(s) are released
 type ReleaseEventMetadata struct {
-	// Release points to this release
-	Release update.Release `json:"release"`
+	Revision string             // the revision which has the changes for the release
+	Spec     update.ReleaseSpec `json:"spec"`
+	Cause    update.Cause       `json:"cause"`
+	Result   update.Result      `json:"result"`
 	// Message of the error if there was one.
 	Error string `json:"error,omitempty"`
 }

--- a/history/event_test.go
+++ b/history/event_test.go
@@ -11,15 +11,18 @@ var (
 	spec = update.ReleaseSpec{
 		ImageSpec: update.ImageSpecLatest,
 	}
+	cause = update.Cause{
+		User:    "test user",
+		Message: "test message",
+	}
 )
 
 func TestEvent_ParseReleaseMetaData(t *testing.T) {
 	origEvent := Event{
 		Type: EventRelease,
 		Metadata: &ReleaseEventMetadata{
-			Release: update.Release{
-				Spec: spec,
-			},
+			Cause: cause,
+			Spec:  spec,
 		},
 	}
 
@@ -30,8 +33,14 @@ func TestEvent_ParseReleaseMetaData(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if e.Metadata.(*ReleaseEventMetadata).Release.Spec.ImageSpec != spec.ImageSpec {
-		t.Fatal("Release.Spec wasn't marshalled/unmarshalled")
+	switch r := e.Metadata.(type) {
+	case *ReleaseEventMetadata:
+		if r.Spec.ImageSpec != spec.ImageSpec ||
+			r.Cause != cause {
+			t.Fatal("Release event wasn't marshalled/unmarshalled")
+		}
+	default:
+		t.Fatal("Wrong event type unmarshalled")
 	}
 }
 

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -1,12 +1,13 @@
 package notifications
 
 import (
+	"github.com/weaveworks/flux/history"
 	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/update"
 )
 
 // Release performs post-release notifications for an instance
-func Release(cfg instance.Config, r update.Release, releaseError string) error {
+func Release(cfg instance.Config, r *history.ReleaseEventMetadata, releaseError string) error {
 	if r.Spec.Kind != update.ReleaseKindExecute {
 		return nil
 	}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -4,23 +4,18 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/history"
 	"github.com/weaveworks/flux/instance"
 	"github.com/weaveworks/flux/update"
 )
 
 // Generate an example release
-func exampleRelease(t *testing.T) update.Release {
-	now := time.Now().UTC()
+func exampleRelease(t *testing.T) *history.ReleaseEventMetadata {
 	img1a1, _ := flux.ParseImageID("img1:a1")
 	img1a2, _ := flux.ParseImageID("img1:a2")
-	return update.Release{
-		CreatedAt: now.Add(-1 * time.Minute),
-		StartedAt: now.Add(-30 * time.Second),
-		EndedAt:   now.Add(-1 * time.Second),
-
+	return &history.ReleaseEventMetadata{
 		Cause: update.Cause{
 			User:    "test-user",
 			Message: "this was to test notifications",

--- a/notifications/template_funcs_test.go
+++ b/notifications/template_funcs_test.go
@@ -45,7 +45,7 @@ func TestTemplateFunc_Last(t *testing.T) {
 		// Shouldn't panic
 		{0, struct{}{}, false, errors.New("unsupported type: struct {}")},
 		{0, nil, false, errors.New("unsupported type: <nil>")},
-		{0, update.Release{}, false, errors.New("unsupported type: update.Release")},
+		{0, update.Spec{}, false, errors.New("unsupported type: update.Spec")},
 	} {
 		gotVal, gotErr := last(test.i, test.a)
 		if gotVal != test.expectedVal {

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -387,7 +387,7 @@ func Test_ImageStatus(t *testing.T) {
 }
 
 func testRelease(t *testing.T, name string, ctx *ReleaseContext, spec update.ReleaseSpec, expected update.Result) {
-	_, results, err := Release(ctx, spec, update.Cause{}, log.NewNopLogger())
+	results, err := Release(ctx, spec, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -158,7 +158,7 @@ func (s *Server) LogEvent(instID flux.InstanceID, e history.Event) error {
 			return errors.Wrapf(err, "getting config")
 		}
 		releaseMeta := e.Metadata.(*history.ReleaseEventMetadata)
-		err = notifications.Release(cfg, releaseMeta.Release, releaseMeta.Error)
+		err = notifications.Release(cfg, releaseMeta, releaseMeta.Error)
 		if err != nil {
 			return errors.Wrapf(err, "notifying slack")
 		}

--- a/update/release.go
+++ b/update/release.go
@@ -2,7 +2,6 @@ package update
 
 import (
 	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -39,17 +38,6 @@ func ParseReleaseKind(s string) (ReleaseKind, error) {
 }
 
 const UserAutomated = "<automated>"
-
-// Release describes a release
-type Release struct {
-	CreatedAt time.Time `json:"createdAt"`
-	StartedAt time.Time `json:"startedAt"`
-	EndedAt   time.Time `json:"endedAt"`
-
-	Cause  Cause       `json:"cause"`
-	Spec   ReleaseSpec `json:"spec"`
-	Result Result      `json:"result"`
-}
 
 // NB: these get sent from fluxctl, so we have to maintain the json format of
 // this. Eugh.


### PR DESCRIPTION
Release events in history and notifications were not showing the user (e.g., "automation") or message (when supplied).

While rewriting for gitsyncness, the release event structure got a bit overcomplicated. This PR simplifies it, and makes sure that the cause (user and message) is faithfully transcribed to the event sent upstream to the service.

It also fixes a couple of minor bugs and makes a small refactor, as detailed in the first commit message.