### PR TITLE
Resync on push fail, and poll images straight after automating something

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -336,7 +336,9 @@ func main() {
 	}
 
 	shutdownWg.Add(1)
-	go daemon.Loop(shutdown, shutdownWg, log.NewContext(logger).With("component", "sync-loop"))
+	go daemon.GitPollLoop(shutdown, shutdownWg, log.NewContext(logger).With("component", "sync-loop"))
+	shutdownWg.Add(1)
+	go daemon.ImagePollLoop(shutdown, shutdownWg, log.NewContext(logger).With("component", "image-poll-loop"))
 
 	// Update daemonRef so that upstream and handlers point to fully working daemon
 	daemonRef.UpdatePlatform(daemon)

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -320,17 +320,19 @@ func main() {
 	}
 
 	daemon := &daemon.Daemon{
-		V:                    version,
-		Cluster:              k8s,
-		Manifests:            k8sManifests,
-		Registry:             reg,
-		Checkout:             checkout,
-		Jobs:                 jobs,
-		JobStatusCache:       &job.StatusCache{Size: 100},
-		GitPollInterval:      *gitPollInterval,
-		RegistryPollInterval: *registryPollInterval,
-		EventWriter:          eventWriter,
-		Logger:               log.NewContext(logger).With("component", "daemon"),
+		V:              version,
+		Cluster:        k8s,
+		Manifests:      k8sManifests,
+		Registry:       reg,
+		Checkout:       checkout,
+		Jobs:           jobs,
+		JobStatusCache: &job.StatusCache{Size: 100},
+		EventWriter:    eventWriter,
+		Logger:         log.NewContext(logger).With("component", "daemon"),
+		LoopVars: &daemon.LoopVars{
+			GitPollInterval:      *gitPollInterval,
+			RegistryPollInterval: *registryPollInterval,
+		},
 	}
 
 	shutdownWg.Add(1)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -235,6 +235,10 @@ func (d *Daemon) UpdateManifests(spec update.Spec) (job.ID, error) {
 			}
 
 			if err := working.CommitAndPush(policyCommitMessage(s, spec.Cause), &git.Note{JobID: jobID, Spec: spec}); err != nil {
+				// On the chance pushing failed because it was not
+				// possible to fast-forward, ask for a sync so the
+				// next attempt is more likely to succeed.
+				d.askForSync()
 				return nil, err
 			}
 
@@ -265,6 +269,10 @@ func (d *Daemon) release(spec update.Spec, c release.Changes) DaemonJobFunc {
 				commitMsg = c.CommitMessage()
 			}
 			if err := working.CommitAndPush(commitMsg, &git.Note{JobID: jobID, Spec: spec, Result: result}); err != nil {
+				// On the chance pushing failed because it was not
+				// possible to fast-forward, ask for a sync so the
+				// next attempt is more likely to succeed.
+				d.askForSync()
 				return nil, err
 			}
 			revision, err = working.HeadRevision()

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
-	gosync "sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
@@ -29,21 +28,18 @@ var ErrUnknownJob = fmt.Errorf("unknown job")
 // Combine these things to form Devasta^Wan implementation of
 // Platform.
 type Daemon struct {
-	V                    string
-	Cluster              cluster.Cluster
-	Manifests            cluster.Manifests
-	Registry             registry.Registry
-	Repo                 git.Repo
-	Checkout             *git.Checkout
-	Jobs                 *job.Queue
-	JobStatusCache       *job.StatusCache
-	GitPollInterval      time.Duration
-	RegistryPollInterval time.Duration
-	EventWriter          history.EventWriter
-	Logger               log.Logger
+	V              string
+	Cluster        cluster.Cluster
+	Manifests      cluster.Manifests
+	Registry       registry.Registry
+	Repo           git.Repo
+	Checkout       *git.Checkout
+	Jobs           *job.Queue
+	JobStatusCache *job.StatusCache
+	EventWriter    history.EventWriter
+	Logger         log.Logger
 	// bookkeeping
-	syncSoon     chan struct{}
-	initSyncSoon gosync.Once
+	*LoopVars
 }
 
 // Invariant.

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -410,7 +410,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), *cluster.Mock, history.EventRead
 	}
 
 	wg.Add(1)
-	go d.Loop(shutdown, wg, logger)
+	go d.GitPollLoop(shutdown, wg, logger)
 
 	return d, func() {
 		// Close daemon first so we don't get errors if the queue closes before the daemon

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -406,6 +406,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), *cluster.Mock, history.EventRead
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
 		Logger:         logger,
+		LoopVars:       &LoopVars{},
 	}
 
 	wg.Add(1)

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -11,7 +11,7 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-func (d *Daemon) PollImages(logger log.Logger) {
+func (d *Daemon) pollForNewImages(logger log.Logger) {
 	logger.Log("msg", "polling images")
 
 	candidateServices, err := d.unlockedAutomatedServices()

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -17,6 +17,13 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
+type LoopVars struct {
+	GitPollInterval      time.Duration
+	RegistryPollInterval time.Duration
+	syncSoon             chan struct{}
+	initSyncSoon         sync.Once
+}
+
 // Loop for potentially long-running stuff. This includes running
 // jobs, and looking for new commits.
 
@@ -65,7 +72,7 @@ func (d *Daemon) Loop(stop chan struct{}, wg *sync.WaitGroup, logger log.Logger)
 }
 
 // Ask for a sync, or if there's one waiting, let that happen.
-func (d *Daemon) askForSync() {
+func (d *LoopVars) askForSync() {
 	d.initSyncSoon.Do(func() {
 		d.syncSoon = make(chan struct{}, 1)
 	})
@@ -74,6 +81,8 @@ func (d *Daemon) askForSync() {
 	default:
 	}
 }
+
+// -- extra bits the loop needs
 
 func (d *Daemon) pullAndSync(logger log.Logger) {
 	started := time.Now().UTC()

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -97,7 +97,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 		return nil
 	}
 
-	d.pullAndSync(log.NewLogfmtLogger(ioutil.Discard))
+	d.doSync(log.NewLogfmtLogger(ioutil.Discard))
 
 	// It applies everything
 	if syncCalled != 1 {
@@ -134,7 +134,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 	}
 }
 
-func TestPullAndSync_NoNewCommits(t *testing.T) {
+func TestDoSync_NoNewCommits(t *testing.T) {
 	// Tag exists
 	d, cleanup := daemon(t)
 	defer cleanup()
@@ -152,7 +152,7 @@ func TestPullAndSync_NoNewCommits(t *testing.T) {
 		return nil
 	}
 
-	d.pullAndSync(log.NewLogfmtLogger(ioutil.Discard))
+	d.doSync(log.NewLogfmtLogger(ioutil.Discard))
 
 	// It applies everything
 	if syncCalled != 1 {
@@ -186,7 +186,7 @@ func TestPullAndSync_NoNewCommits(t *testing.T) {
 	}
 }
 
-func TestPullAndSync_WithNewCommit(t *testing.T) {
+func TestDoSync_WithNewCommit(t *testing.T) {
 	// Tag exists
 	d, cleanup := daemon(t)
 	defer cleanup()
@@ -223,7 +223,7 @@ func TestPullAndSync_WithNewCommit(t *testing.T) {
 		return nil
 	}
 
-	d.pullAndSync(log.NewLogfmtLogger(ioutil.Discard))
+	d.doSync(log.NewLogfmtLogger(ioutil.Discard))
 
 	// It applies everything
 	if syncCalled != 1 {

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -70,6 +70,7 @@ func daemon(t *testing.T) (*Daemon, func()) {
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
 		Logger:         log.NewLogfmtLogger(os.Stdout),
+		LoopVars:       &LoopVars{},
 	}
 	return d, func() {
 		close(shutdown)


### PR DESCRIPTION
Rewrites the loop so that

 1. if a job fails when pushing new commits, a pull will be done straight after so that a subsequent attempt has more chance of succeeding (issue #595)
 2. if something has been automated, run an image poll ASAP so that the something will be updated (issue #591)

Also improves a couple of minor things: error messages from git are slightly better (looks for git output beginning with `error: ` as well as `fatal: `); and adapts a use of `logrus` (how did it get there?) to `go-kit/kit/log` which we use everywhere else.