### PR TITLE
Don't treat "no note for commit" as an error

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -158,6 +158,9 @@ func (d *Daemon) pullAndSync(logger log.Logger) {
 				// TODO: We're ignoring all errors here, not just the "no notes" error. Parse error to report proper errors.
 				continue
 			}
+			if n == nil {
+				continue
+			}
 
 			// If any of the commit notes has a release event, send
 			// that to the service

--- a/git/gittest/repo_test.go
+++ b/git/gittest/repo_test.go
@@ -29,6 +29,20 @@ func TestCheckout(t *testing.T) {
 	}
 	defer checkout.Clean()
 
+	// We don't expect any notes in the clone, yet. Make sure we get
+	// no note, rather than an error.
+	head, err := checkout.HeadRevision()
+	if err != nil {
+		t.Fatal(err)
+	}
+	note, err := checkout.GetNote(head)
+	if err != nil {
+		t.Error(err)
+	}
+	if note != nil {
+		t.Errorf("Expected no note on head revision; got %#v", note)
+	}
+
 	// Make a working clone and push changes back; then make sure they
 	// are visible in the original repo
 	working, err := checkout.WorkingClone()

--- a/git/operations.go
+++ b/git/operations.go
@@ -86,7 +86,7 @@ func refExists(workingDir, ref string) (bool, error) {
 	return true, nil
 }
 
-// Get the full ref for a shorthand notes ref
+// Get the full ref for a shorthand notes ref.
 func getNotesRef(workingDir, ref string) (string, error) {
 	out := &bytes.Buffer{}
 	if err := execGitCmd(workingDir, nil, out, "notes", "--ref", ref, "get-ref"); err != nil {
@@ -103,9 +103,13 @@ func addNote(workingDir, rev, notesRef string, note *Note) error {
 	return execGitCmd(workingDir, nil, nil, "notes", "--ref", notesRef, "add", "-m", string(b), rev)
 }
 
+// NB return values (*Note, nil), (nil, error), (nil, nil)
 func getNote(workingDir, notesRef, rev string) (*Note, error) {
 	out := &bytes.Buffer{}
 	if err := execGitCmd(workingDir, nil, out, "notes", "--ref", notesRef, "show", rev); err != nil {
+		if strings.Contains(err.Error(), "No note found for object") {
+			return nil, nil
+		}
 		return nil, err
 	}
 	var note Note

--- a/git/operations.go
+++ b/git/operations.go
@@ -107,7 +107,7 @@ func addNote(workingDir, rev, notesRef string, note *Note) error {
 func getNote(workingDir, notesRef, rev string) (*Note, error) {
 	out := &bytes.Buffer{}
 	if err := execGitCmd(workingDir, nil, out, "notes", "--ref", notesRef, "show", rev); err != nil {
-		if strings.Contains(err.Error(), "No note found for object") {
+		if strings.Contains(strings.ToLower(err.Error()), "no note found for object") {
 			return nil, nil
 		}
 		return nil, err


### PR DESCRIPTION
`git note show` will exit with 1 if there is no note for a given
commit (including the case of the notes ref being unknown). We want to
distinguish between this and there being a genuine error reading a
note: so, return `(nil, error)` if there was a problem, and `(nil,
nil)` if there was simply no note.

This needed better git error message parsing, so I cherry-picked a
commit doing just that from `resync-on-push-fail`.