### PR TITLE
Add 'after' parameter to history API

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -22,7 +22,7 @@ type ClientService interface {
 	JobStatus(flux.InstanceID, job.ID) (job.Status, error)
 	SyncStatus(flux.InstanceID, string) ([]string, error)
 	UpdatePolicies(flux.InstanceID, policy.Updates, update.Cause) (job.ID, error)
-	History(flux.InstanceID, update.ServiceSpec, time.Time, int64) ([]history.Entry, error)
+	History(flux.InstanceID, update.ServiceSpec, time.Time, int64, time.Time) ([]history.Entry, error)
 	GetConfig(_ flux.InstanceID, fingerprint string) (flux.InstanceConfig, error)
 	SetConfig(flux.InstanceID, flux.UnsafeInstanceConfig) error
 	PatchConfig(flux.InstanceID, flux.ConfigPatch) error

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -279,7 +279,7 @@ func TestFluxsvc_History(t *testing.T) {
 	}
 
 	// Test History
-	hist, err := apiClient.History("", helloWorldSvc, time.Now().UTC(), -1)
+	hist, err := apiClient.History("", helloWorldSvc, time.Now().UTC(), -1, time.Unix(0, 0))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -176,7 +176,7 @@ func TestDaemon_SyncNotify(t *testing.T) {
 	// Check that history was written to
 	var e []history.Event
 	w.Eventually(func() bool {
-		e, _ = events.AllEvents(time.Time{}, -1)
+		e, _ = events.AllEvents(time.Time{}, -1, time.Time{})
 		return len(e) > 0
 	}, "Waiting for new events")
 	if 1 != len(e) {

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -109,7 +109,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 	}
 
 	// The emitted event has all service ids
-	es, err := events.AllEvents(time.Time{}, -1)
+	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
 	if err != nil {
 		t.Error(err)
 	} else if len(es) != 1 {
@@ -164,7 +164,7 @@ func TestPullAndSync_NoNewCommits(t *testing.T) {
 	}
 
 	// The emitted event has no service ids
-	es, err := events.AllEvents(time.Time{}, -1)
+	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
 	if err != nil {
 		t.Error(err)
 	} else if len(es) != 0 {
@@ -235,7 +235,7 @@ func TestPullAndSync_WithNewCommit(t *testing.T) {
 	}
 
 	// The emitted event has no service ids
-	es, err := events.AllEvents(time.Time{}, -1)
+	es, err := events.AllEvents(time.Time{}, -1, time.Time{})
 	if err != nil {
 		t.Error(err)
 	} else if len(es) != 1 {

--- a/history/history.go
+++ b/history/history.go
@@ -20,11 +20,11 @@ type EventWriter interface {
 type EventReader interface {
 	// AllEvents returns a history for every service. Events must be
 	// returned in descending timestamp order.
-	AllEvents(time.Time, int64) ([]Event, error)
+	AllEvents(time.Time, int64, time.Time) ([]Event, error)
 
 	// EventsForService returns the history for a particular
 	// service. Events must be returned in descending timestamp order.
-	EventsForService(flux.ServiceID, time.Time, int64) ([]Event, error)
+	EventsForService(flux.ServiceID, time.Time, int64, time.Time) ([]Event, error)
 
 	// GetEvent finds a single event, by ID.
 	GetEvent(EventID) (Event, error)
@@ -32,8 +32,8 @@ type EventReader interface {
 
 type DB interface {
 	LogEvent(flux.InstanceID, Event) error
-	AllEvents(flux.InstanceID, time.Time, int64) ([]Event, error)
-	EventsForService(flux.InstanceID, flux.ServiceID, time.Time, int64) ([]Event, error)
+	AllEvents(flux.InstanceID, time.Time, int64, time.Time) ([]Event, error)
+	EventsForService(flux.InstanceID, flux.ServiceID, time.Time, int64, time.Time) ([]Event, error)
 	GetEvent(EventID) (Event, error)
 	io.Closer
 }

--- a/history/metrics.go
+++ b/history/metrics.go
@@ -43,24 +43,24 @@ func (i *instrumentedDB) LogEvent(inst flux.InstanceID, e Event) (err error) {
 	return i.db.LogEvent(inst, e)
 }
 
-func (i *instrumentedDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64) (e []Event, err error) {
+func (i *instrumentedDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64, after time.Time) (e []Event, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			LabelMethod, "AllEvents",
 			LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.db.AllEvents(inst, before, limit)
+	return i.db.AllEvents(inst, before, limit, after)
 }
 
-func (i *instrumentedDB) EventsForService(inst flux.InstanceID, s flux.ServiceID, before time.Time, limit int64) (e []Event, err error) {
+func (i *instrumentedDB) EventsForService(inst flux.InstanceID, s flux.ServiceID, before time.Time, limit int64, after time.Time) (e []Event, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			LabelMethod, "EventsForService",
 			LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.db.EventsForService(inst, s, before, limit)
+	return i.db.EventsForService(inst, s, before, limit, after)
 }
 
 func (i *instrumentedDB) GetEvent(id EventID) (e Event, err error) {

--- a/history/mock.go
+++ b/history/mock.go
@@ -17,13 +17,13 @@ func NewMock() EventReadWriter {
 	return &Mock{}
 }
 
-func (m *Mock) AllEvents(_ time.Time, _ int64) ([]Event, error) {
+func (m *Mock) AllEvents(_ time.Time, _ int64, _ time.Time) ([]Event, error) {
 	m.RLock()
 	defer m.RUnlock()
 	return m.events, nil
 }
 
-func (m *Mock) EventsForService(serviceID flux.ServiceID, _ time.Time, _ int64) ([]Event, error) {
+func (m *Mock) EventsForService(serviceID flux.ServiceID, _ time.Time, _ int64, _ time.Time) ([]Event, error) {
 	m.RLock()
 	defer m.RUnlock()
 	var found []Event

--- a/history/sql/pg.go
+++ b/history/sql/pg.go
@@ -84,21 +84,23 @@ func (db *pgDB) scanEvents(query squirrel.Sqlizer) ([]history.Event, error) {
 	return events, rows.Err()
 }
 
-func (db *pgDB) EventsForService(inst flux.InstanceID, service flux.ServiceID, before time.Time, limit int64) ([]history.Event, error) {
+func (db *pgDB) EventsForService(inst flux.InstanceID, service flux.ServiceID, before time.Time, limit int64, after time.Time) ([]history.Event, error) {
 	q := db.eventsQuery().
 		Where("instance_id = ?", string(inst)).
 		Where("service_ids @> ?", pq.StringArray{string(service)}).
-		Where("started_at < ?", before)
+		Where("started_at < ?", before).
+		Where("started_at > ?", after)
 	if limit >= 0 {
 		q = q.Limit(uint64(limit))
 	}
 	return db.scanEvents(q)
 }
 
-func (db *pgDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64) ([]history.Event, error) {
+func (db *pgDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64, after time.Time) ([]history.Event, error) {
 	q := db.eventsQuery().
 		Where("instance_id = ?", string(inst)).
-		Where("started_at < ?", before)
+		Where("started_at < ?", before).
+		Where("started_at > ?", after)
 	if limit >= 0 {
 		q = q.Limit(uint64(limit))
 	}

--- a/history/sql/ql.go
+++ b/history/sql/ql.go
@@ -78,11 +78,12 @@ func (db *qlDB) scanEvents(query squirrel.Sqlizer) ([]history.Event, error) {
 	return events, rows.Err()
 }
 
-func (db *qlDB) EventsForService(inst flux.InstanceID, service flux.ServiceID, before time.Time, limit int64) ([]history.Event, error) {
+func (db *qlDB) EventsForService(inst flux.InstanceID, service flux.ServiceID, before time.Time, limit int64, after time.Time) ([]history.Event, error) {
 	q := db.eventsQuery().
 		Where("instance_id = ?", string(inst)).
 		Where("id(e) IN (select event_id from event_service_ids WHERE service_id = ?)", string(service)).
-		Where("started_at < ?", before)
+		Where("started_at < ?", before).
+		Where("started_at > ?", after)
 	if limit >= 0 {
 		q = q.Limit(uint64(limit))
 	}
@@ -93,10 +94,11 @@ func (db *qlDB) EventsForService(inst flux.InstanceID, service flux.ServiceID, b
 	return db.loadServiceIDs(events)
 }
 
-func (db *qlDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64) ([]history.Event, error) {
+func (db *qlDB) AllEvents(inst flux.InstanceID, before time.Time, limit int64, after time.Time) ([]history.Event, error) {
 	q := db.eventsQuery().
 		Where("instance_id = ?", string(inst)).
-		Where("started_at < ?", before)
+		Where("started_at < ?", before).
+		Where("started_at > ?", after)
 	if limit >= 0 {
 		q = q.Limit(uint64(limit))
 	}

--- a/history/sql/sql_test.go
+++ b/history/sql/sql_test.go
@@ -72,7 +72,7 @@ func TestHistoryLog(t *testing.T) {
 		Message:    "event 2",
 	}))
 
-	es, err := db.EventsForService(instance, flux.ServiceID("namespace/service"), time.Now().UTC(), -1)
+	es, err := db.EventsForService(instance, flux.ServiceID("namespace/service"), time.Now().UTC(), -1, time.Unix(0, 0))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestHistoryLog(t *testing.T) {
 	}
 	checkInDescOrder(t, es)
 
-	es, err = db.AllEvents(instance, time.Now().UTC(), -1)
+	es, err = db.AllEvents(instance, time.Now().UTC(), -1, time.Unix(0, 0))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -102,10 +102,13 @@ func (c *Client) LogEvent(_ flux.InstanceID, event history.Event) error {
 	return c.postWithBody("LogEvent", event)
 }
 
-func (c *Client) History(_ flux.InstanceID, s update.ServiceSpec, before time.Time, limit int64) ([]history.Entry, error) {
+func (c *Client) History(_ flux.InstanceID, s update.ServiceSpec, before time.Time, limit int64, after time.Time) ([]history.Entry, error) {
 	params := []string{"service", string(s)}
 	if !before.IsZero() {
 		params = append(params, "before", before.Format(time.RFC3339Nano))
+	}
+	if !after.IsZero() {
+		params = append(params, "after", after.Format(time.RFC3339Nano))
 	}
 	if limit >= 0 {
 		params = append(params, "limit", fmt.Sprint(limit))

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -249,6 +249,14 @@ func (s HTTPService) History(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
+	after := time.Unix(0, 0)
+	if r.FormValue("after") != "" {
+		after, err = time.Parse(time.RFC3339Nano, r.FormValue("after"))
+		if err != nil {
+			transport.ErrorResponse(w, r, err)
+			return
+		}
+	}
 	limit := int64(-1)
 	if r.FormValue("limit") != "" {
 		if _, err := fmt.Sscan(r.FormValue("limit"), &limit); err != nil {
@@ -257,7 +265,7 @@ func (s HTTPService) History(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	h, err := s.service.History(inst, spec, before, limit)
+	h, err := s.service.History(inst, spec, before, limit, after)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return

--- a/instance/events.go
+++ b/instance/events.go
@@ -16,12 +16,12 @@ func (rw EventReadWriter) LogEvent(e history.Event) error {
 	return rw.db.LogEvent(rw.inst, e)
 }
 
-func (rw EventReadWriter) AllEvents(before time.Time, limit int64) ([]history.Event, error) {
-	return rw.db.AllEvents(rw.inst, before, limit)
+func (rw EventReadWriter) AllEvents(before time.Time, limit int64, after time.Time) ([]history.Event, error) {
+	return rw.db.AllEvents(rw.inst, before, limit, after)
 }
 
-func (rw EventReadWriter) EventsForService(service flux.ServiceID, before time.Time, limit int64) ([]history.Event, error) {
-	return rw.db.EventsForService(rw.inst, service, before, limit)
+func (rw EventReadWriter) EventsForService(service flux.ServiceID, before time.Time, limit int64, after time.Time) ([]history.Event, error) {
+	return rw.db.EventsForService(rw.inst, service, before, limit, after)
 }
 
 func (rw EventReadWriter) GetEvent(id history.EventID) (history.Event, error) {

--- a/server/server.go
+++ b/server/server.go
@@ -166,7 +166,7 @@ func (s *Server) LogEvent(instID flux.InstanceID, e history.Event) error {
 	return nil
 }
 
-func (s *Server) History(inst flux.InstanceID, spec update.ServiceSpec, before time.Time, limit int64) (res []history.Entry, err error) {
+func (s *Server) History(inst flux.InstanceID, spec update.ServiceSpec, before time.Time, limit int64, after time.Time) (res []history.Entry, err error) {
 	helper, err := s.instancer.Get(inst)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance")
@@ -174,7 +174,7 @@ func (s *Server) History(inst flux.InstanceID, spec update.ServiceSpec, before t
 
 	var events []history.Event
 	if spec == update.ServiceSpecAll {
-		events, err = helper.AllEvents(before, limit)
+		events, err = helper.AllEvents(before, limit, after)
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching all history events")
 		}
@@ -184,7 +184,7 @@ func (s *Server) History(inst flux.InstanceID, spec update.ServiceSpec, before t
 			return nil, errors.Wrapf(err, "parsing service ID from spec %s", spec)
 		}
 
-		events, err = helper.EventsForService(id, before, limit)
+		events, err = helper.EventsForService(id, before, limit, after)
 		if err != nil {
 			return nil, errors.Wrapf(err, "fetching history events for %s", id)
 		}


### PR DESCRIPTION
I'm not sure this is the best way to add this parameter, I've simply followed 'before' through the code, and added 'after' wherever it complained. That probably breaks compatibility somewhere...

