### PR TITLE
Bump all API to v6

### DIFF
--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -91,7 +91,7 @@ func (opts *rootOpts) PersistentPreRunE(cmd *cobra.Command, _ []string) error {
 		return errors.Wrapf(err, "parsing URL")
 	}
 	opts.Token = getFromEnvIfNotSet(cmd.Flags(), "token", opts.Token, envVariableToken, envVariableCloudToken)
-	opts.API = client.New(http.DefaultClient, transport.NewServiceRouter(), opts.URL, flux.Token(opts.Token))
+	opts.API = client.New(http.DefaultClient, transport.NewAPIRouter(), opts.URL, flux.Token(opts.Token))
 	return nil
 }
 

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -222,7 +222,7 @@ func main() {
 				&http.Client{Timeout: 10 * time.Second},
 				fmt.Sprintf("fluxd/%v", version),
 				flux.Token(*token),
-				transport.NewServiceRouter(), // TODO should be NewUpstreamRouter, since it only needs the registration endpoint
+				transport.NewUpstreamRouter(),
 				*upstreamURL,
 				&remote.ErrorLoggingPlatform{daemonRef, upstreamLogger},
 				upstreamLogger,

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -130,7 +130,7 @@ func setup() {
 
 	// Server
 	apiServer := server.New(ver, instancer, instanceDB, messageBus, log.NewNopLogger())
-	router = transport.NewServiceRouter()
+	router = httpserver.NewServiceRouter()
 	handler := httpserver.NewHandler(apiServer, router, log.NewNopLogger())
 	ts = httptest.NewServer(handler)
 	apiClient = client.New(http.DefaultClient, router, ts.URL, "")

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/weaveworks/flux/db"
 	"github.com/weaveworks/flux/history"
 	historysql "github.com/weaveworks/flux/history/sql"
-	transport "github.com/weaveworks/flux/http"
 	httpserver "github.com/weaveworks/flux/http/server"
 	"github.com/weaveworks/flux/instance"
 	instancedb "github.com/weaveworks/flux/instance/sql"
@@ -147,7 +146,7 @@ func main() {
 		logger.Log("addr", *listenAddr)
 		mux := http.NewServeMux()
 		mux.Handle("/metrics", promhttp.Handler())
-		handler := httpserver.NewHandler(server, transport.NewServiceRouter(), logger)
+		handler := httpserver.NewHandler(server, httpserver.NewServiceRouter(), logger)
 		mux.Handle("/", handler)
 		mux.Handle("/api/flux/", http.StripPrefix("/api/flux", handler))
 		errc <- http.ListenAndServe(*listenAddr, mux)

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -30,6 +30,9 @@ var (
 // An API server for the daemon
 func NewRouter() *mux.Router {
 	r := transport.NewAPIRouter()
+	// All old versions are deprecated in the daemon. Use an up to
+	// date client!
+	transport.DeprecateVersions(r, "v1", "v2", "v3", "v4", "v5")
 	// We assume every request that doesn't match a route is a client
 	// calling an old or hitherto unsupported API.
 	r.NewRoute().Name("NotFound").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -52,7 +52,7 @@ func NewUpstream(client *http.Client, ua string, t flux.Token, router *mux.Route
 		return nil, errors.Wrap(err, "inferring WS/HTTP endpoints")
 	}
 
-	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemonV6")
+	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemon")
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
 	}

--- a/http/server/server.go
+++ b/http/server/server.go
@@ -35,30 +35,77 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
+func NewServiceRouter() *mux.Router {
+	r := transport.NewAPIRouter()
+
+	transport.DeprecateVersions(r, "v1", "v2")
+	transport.UpstreamRoutes(r)
+
+	// Backwards compatibility: we only expect the web UI to use these
+	// routes, until it is updated to use v6.
+	r.NewRoute().Name("ListServicesV3").Methods("GET").Path("/v3/services").Queries("namespace", "{namespace}") // optional namespace!
+	r.NewRoute().Name("ListImagesV3").Methods("GET").Path("/v3/images").Queries("service", "{service}")
+	r.NewRoute().Name("UpdatePoliciesV4").Methods("PATCH").Path("/v4/policies")
+	r.NewRoute().Name("HistoryV3").Methods("GET").Path("/v3/history").Queries("service", "{service}")
+	r.NewRoute().Name("StatusV3").Methods("GET").Path("/v3/status")
+	r.NewRoute().Name("GetConfigV4").Methods("GET").Path("/v4/config")
+	r.NewRoute().Name("SetConfigV4").Methods("POST").Path("/v4/config")
+	r.NewRoute().Name("PatchConfigV4").Methods("PATCH").Path("/v4/config")
+	r.NewRoute().Name("ExportV5").Methods("HEAD", "GET").Path("/v5/export")
+	r.NewRoute().Name("PostIntegrationsGithubV5").Methods("POST").Path("/v5/integrations/github").Queries("owner", "{owner}", "repository", "{repository}")
+	r.NewRoute().Name("IsConnectedV4").Methods("HEAD", "GET").Path("/v4/ping")
+
+	// V6 service routes
+	r.NewRoute().Name("History").Methods("GET").Path("/v6/history").Queries("service", "{service}")
+	r.NewRoute().Name("Status").Methods("GET").Path("/v6/status")
+	r.NewRoute().Name("GetConfig").Methods("GET").Path("/v6/config")
+	r.NewRoute().Name("SetConfig").Methods("POST").Path("/v6/config")
+	r.NewRoute().Name("PatchConfig").Methods("PATCH").Path("/v6/config")
+	r.NewRoute().Name("PostIntegrationsGithub").Methods("POST").Path("/v6/integrations/github").Queries("owner", "{owner}", "repository", "{repository}")
+	r.NewRoute().Name("IsConnected").Methods("HEAD", "GET").Path("/v6/ping")
+
+	// We assume every request that doesn't match a route is a client
+	// calling an old or hitherto unsupported API.
+	r.NewRoute().Name("NotFound").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		transport.WriteError(w, r, http.StatusNotFound, transport.MakeAPINotFound(r.URL.Path))
+	})
+
+	return r
+}
+
 func NewHandler(s api.FluxService, r *mux.Router, logger log.Logger) http.Handler {
 	handle := HTTPService{s}
 	for method, handlerMethod := range map[string]http.HandlerFunc{
-		"ListServices":           handle.ListServices,
-		"ListImages":             handle.ListImages,
-		"UpdateImages":           handle.UpdateImages,
-		"UpdatePolicies":         handle.UpdatePolicies,
-		"LogEvent":               handle.LogEvent,
-		"History":                handle.History,
-		"Status":                 handle.Status,
-		"GetConfig":              handle.GetConfig,
-		"SetConfig":              handle.SetConfig,
-		"PatchConfig":            handle.PatchConfig,
-		"PostIntegrationsGithub": handle.PostIntegrationsGithub,
-		"RegisterDaemonV4":       handle.RegisterV4,
-		"RegisterDaemonV5":       handle.RegisterV5,
-		"RegisterDaemonV6":       handle.RegisterV6,
-		"IsConnected":            handle.IsConnected,
-		"Export":                 handle.Export,
-		"SyncNotify":             handle.SyncNotify,
-		"JobStatus":              handle.JobStatus,
-		"SyncStatus":             handle.SyncStatus,
-		"GetPublicSSHKey":        handle.GetPublicSSHKey,
-		"RegeneratePublicSSHKey": handle.RegeneratePublicSSHKey,
+		"ListServices":             handle.ListServices,
+		"ListServicesV3":           handle.ListServices,
+		"ListImages":               handle.ListImages,
+		"ListImagesV3":             handle.ListImages,
+		"UpdateImages":             handle.UpdateImages,
+		"UpdatePolicies":           handle.UpdatePolicies,
+		"UpdatePoliciesV4":         handle.UpdatePolicies,
+		"LogEvent":                 handle.LogEvent,
+		"History":                  handle.History,
+		"HistoryV3":                handle.History,
+		"Status":                   handle.Status,
+		"StatusV3":                 handle.Status,
+		"GetConfigV4":              handle.GetConfig,
+		"GetConfig":                handle.GetConfig,
+		"SetConfig":                handle.SetConfig,
+		"SetConfigV4":              handle.SetConfig,
+		"PatchConfig":              handle.PatchConfig,
+		"PatchConfigV4":            handle.PatchConfig,
+		"PostIntegrationsGithub":   handle.PostIntegrationsGithub,
+		"PostIntegrationsGithubV5": handle.PostIntegrationsGithub,
+		"Export":                   handle.Export,
+		"ExportV5":                 handle.Export,
+		"RegisterDaemon":           handle.RegisterV6,
+		"IsConnected":              handle.IsConnected,
+		"IsConnectedV4":            handle.IsConnected,
+		"SyncNotify":               handle.SyncNotify,
+		"JobStatus":                handle.JobStatus,
+		"SyncStatus":               handle.SyncStatus,
+		"GetPublicSSHKey":          handle.GetPublicSSHKey,
+		"RegeneratePublicSSHKey":   handle.RegeneratePublicSSHKey,
 	} {
 		handler := logging(handlerMethod, log.NewContext(logger).With("method", method))
 		r.Get(method).Handler(handler)
@@ -394,18 +441,6 @@ func (s HTTPService) Status(w http.ResponseWriter, r *http.Request) {
 	}
 
 	transport.JSONResponse(w, r, status)
-}
-
-func (s HTTPService) RegisterV4(w http.ResponseWriter, r *http.Request) {
-	s.doRegister(w, r, func(conn io.ReadWriteCloser) platformCloser {
-		return rpc.NewClientV4(conn)
-	})
-}
-
-func (s HTTPService) RegisterV5(w http.ResponseWriter, r *http.Request) {
-	s.doRegister(w, r, func(conn io.ReadWriteCloser) platformCloser {
-		return rpc.NewClientV5(conn)
-	})
 }
 
 func (s HTTPService) RegisterV6(w http.ResponseWriter, r *http.Request) {

--- a/http/transport.go
+++ b/http/transport.go
@@ -13,67 +13,45 @@ import (
 	"github.com/weaveworks/flux"
 )
 
-func NewAPIRouter() *mux.Router {
-	r := mux.NewRouter()
-	// Any versions not represented in the routes below are
-	// deprecated. They are done separately so we can see them as
-	// different methods in metrics and logging.
+func DeprecateVersions(r *mux.Router, versions ...string) {
 	var deprecated http.HandlerFunc = func(w http.ResponseWriter, r *http.Request) {
 		WriteError(w, r, http.StatusGone, ErrorDeprecated)
 	}
 
-	for _, version := range []string{"v1", "v2"} {
+	// Any versions not represented in the routes below should be
+	// deprecated. They are done separately so we can see them as
+	// different methods in metrics and logging.
+	for _, version := range versions {
 		r.NewRoute().Name("Deprecated:" + version).PathPrefix("/" + version + "/").HandlerFunc(deprecated)
 	}
+}
 
-	// These API endpoints are specifically deprecated
-	for name, path := range map[string]string{
-		"PostOrGetRelease":   "/v4/release",            // deprecated because UpdateImages and Sync{Cluster,Status} supercede them, and we cannot support both
-		"GenerateDeployKeys": "/v5/config/deploy-keys", // replaced by PublicSSHKey
-	} {
-		r.NewRoute().Name("Deprecated:" + name).Path(path).HandlerFunc(deprecated)
-	}
+func NewAPIRouter() *mux.Router {
+	r := mux.NewRouter()
 
-	r.NewRoute().Name("ListServices").Methods("GET").Path("/v3/services").Queries("namespace", "{namespace}") // optional namespace!
-	r.NewRoute().Name("ListImages").Methods("GET").Path("/v3/images").Queries("service", "{service}")
+	r.NewRoute().Name("ListServices").Methods("GET").Path("/v6/services").Queries("namespace", "{namespace}") // optional namespace!
+	r.NewRoute().Name("ListImages").Methods("GET").Path("/v6/images").Queries("service", "{service}")
 
 	r.NewRoute().Name("UpdateImages").Methods("POST").Path("/v6/update-images").Queries("service", "{service}", "image", "{image}", "kind", "{kind}")
-	r.NewRoute().Name("UpdatePolicies").Methods("PATCH").Path("/v4/policies")
+	r.NewRoute().Name("UpdatePolicies").Methods("PATCH").Path("/v6/policies")
 	r.NewRoute().Name("SyncNotify").Methods("POST").Path("/v6/sync")
 	r.NewRoute().Name("JobStatus").Methods("GET").Path("/v6/jobs").Queries("id", "{id}")
 	r.NewRoute().Name("SyncStatus").Methods("GET").Path("/v6/sync").Queries("ref", "{ref}")
-	r.NewRoute().Name("Export").Methods("HEAD", "GET").Path("/v5/export")
+	r.NewRoute().Name("Export").Methods("HEAD", "GET").Path("/v6/export")
 	r.NewRoute().Name("GetPublicSSHKey").Methods("GET").Path("/v6/identity.pub")
 	r.NewRoute().Name("RegeneratePublicSSHKey").Methods("POST").Path("/v6/identity.pub")
 
 	return r // TODO 404 though?
 }
 
-func NewServiceRouter() *mux.Router {
-	r := NewAPIRouter()
+func UpstreamRoutes(r *mux.Router) {
+	r.NewRoute().Name("RegisterDaemon").Methods("GET").Path("/v6/daemon")
+	r.NewRoute().Name("LogEvent").Methods("POST").Path("/v6/events")
+}
 
-	r.NewRoute().Name("Automate").Methods("POST").Path("/v3/automate").Queries("service", "{service}")
-	r.NewRoute().Name("Deautomate").Methods("POST").Path("/v3/deautomate").Queries("service", "{service}")
-	r.NewRoute().Name("Lock").Methods("POST").Path("/v3/lock").Queries("service", "{service}")
-	r.NewRoute().Name("Unlock").Methods("POST").Path("/v3/unlock").Queries("service", "{service}")
-	r.NewRoute().Name("History").Methods("GET").Path("/v3/history").Queries("service", "{service}")
-	r.NewRoute().Name("Status").Methods("GET").Path("/v3/status")
-	r.NewRoute().Name("GetConfig").Methods("GET").Path("/v4/config")
-	r.NewRoute().Name("SetConfig").Methods("POST").Path("/v4/config")
-	r.NewRoute().Name("PatchConfig").Methods("PATCH").Path("/v4/config")
-	r.NewRoute().Name("PostIntegrationsGithub").Methods("POST").Path("/v5/integrations/github").Queries("owner", "{owner}", "repository", "{repository}")
-	r.NewRoute().Name("RegisterDaemonV4").Methods("GET").Path("/v4/daemon")
-	r.NewRoute().Name("RegisterDaemonV5").Methods("GET").Path("/v5/daemon")
-	r.NewRoute().Name("RegisterDaemonV6").Methods("GET").Path("/v6/daemon")
-	r.NewRoute().Name("IsConnected").Methods("HEAD", "GET").Path("/v4/ping")
-	r.NewRoute().Name("LogEvent").Methods("POST").Path("/v4/events")
-
-	// We assume every request that doesn't match a route is a client
-	// calling an old or hitherto unsupported API.
-	r.NewRoute().Name("NotFound").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		WriteError(w, r, http.StatusNotFound, MakeAPINotFound(r.URL.Path))
-	})
-
+func NewUpstreamRouter() *mux.Router {
+	r := mux.NewRouter()
+	UpstreamRoutes(r)
 	return r
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -18,14 +18,6 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-const (
-	serviceAutomated   = "Automation enabled."
-	serviceDeautomated = "Automation disabled."
-
-	serviceLocked   = "Service locked."
-	serviceUnlocked = "Service unlocked."
-)
-
 type Server struct {
 	version     string
 	instancer   instance.Instancer


### PR DESCRIPTION
This bumps the API up to v6, so we can reroute requests to it vs older versions. The service retains the old routes, so that it can handle requests with or without such rerouting. The daemon only serves the new version, since it never handled the old one.
