### PR TITLE
Use Darwinic means to get a kernel version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,11 +54,11 @@ build/.flux-service.done: build/fluxsvc build/migrations.tar
 
 build/fluxd: $(FLUXD_DEPS)
 build/fluxd: cmd/fluxd/*.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" cmd/fluxd/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" ./cmd/fluxd
 
 build/fluxsvc: $(FLUXSVC_DEPS)
 build/fluxsvc: cmd/fluxsvc/*.go
-	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" cmd/fluxsvc/main.go
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o $@ $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" ./cmd/fluxsvc
 
 build/kubectl: cache/kubectl-$(KUBECTL_VERSION) docker/kubectl.version
 	cp cache/kubectl-$(KUBECTL_VERSION) $@

--- a/cmd/fluxd/checkpoint_darwin.go
+++ b/cmd/fluxd/checkpoint_darwin.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"syscall"
+)
+
+func getKernelVersion() string {
+	v, err := syscall.Sysctl("kern.osrelease")
+	if err != nil {
+		panic(err)
+	}
+	return "darwin-" + v
+}

--- a/cmd/fluxd/checkpoint_linux.go
+++ b/cmd/fluxd/checkpoint_linux.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"syscall"
+)
+
+func getKernelVersion() string {
+	var uts syscall.Utsname
+	syscall.Uname(&uts)
+	return cstringToString(uts.Release[:])
+}
+
+func cstringToString(c []int8) string {
+	s := make([]byte, len(c))
+	i := 0
+	for ; i < len(c); i++ {
+		if c[i] == 0 {
+			break
+		}
+		s[i] = uint8(c[i])
+	}
+	return string(s[:i])
+}

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -351,18 +351,6 @@ const (
 	versionCheckPeriod = 6 * time.Hour
 )
 
-func cstringToString(c []int8) string {
-	s := make([]byte, len(c))
-	i := 0
-	for ; i < len(c); i++ {
-		if c[i] == 0 {
-			break
-		}
-		s[i] = uint8(c[i])
-	}
-	return string(s[:i])
-}
-
 func checkForUpdates(clusterString string, gitString string, logger log.Logger) *checkpoint.Checker {
 	handleResponse := func(r *checkpoint.CheckResponse, err error) {
 		if err != nil {
@@ -376,11 +364,8 @@ func checkForUpdates(clusterString string, gitString string, logger log.Logger) 
 		logger.Log("msg", "up to date", "version", r.CurrentVersion)
 	}
 
-	var uts syscall.Utsname
-	syscall.Uname(&uts)
-	kernelVersion := cstringToString(uts.Release[:])
 	flags := map[string]string{
-		"kernel-version":  kernelVersion,
+		"kernel-version":  getKernelVersion(),
 		"cluster-version": clusterString,
 		"git-configured":  gitString,
 	}
@@ -390,5 +375,6 @@ func checkForUpdates(clusterString string, gitString string, logger log.Logger) 
 		SignatureFile: "",
 		Flags:         flags,
 	}
+
 	return checkpoint.CheckInterval(&params, versionCheckPeriod, handleResponse)
 }


### PR DESCRIPTION
`syscall.Uname` doesn't exist in BSD/Darwin; construct a kernel
version string by getting the OS release via `syscall.Sysctl(...)`
instead.

NB this only matters for `go install cmd/fluxd`, since the container
image binaries are always built for Linux.