### PR TITLE
Parse serialisations of []Policy as policy.Set

### DIFF
--- a/policy/policy.go
+++ b/policy/policy.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/weaveworks/flux"
@@ -33,6 +34,21 @@ type Update struct {
 }
 
 type Set map[Policy]string
+
+// We used to specify a set of policies as []Policy, and in some places
+// it may be so serialised.
+func (s *Set) UnmarshalJSON(in []byte) error {
+	type set Set
+	if err := json.Unmarshal(in, (*set)(s)); err != nil {
+		var list []Policy
+		if err = json.Unmarshal(in, &list); err != nil {
+			return err
+		}
+		var s1 = Set{}
+		*s = s1.Add(list...)
+	}
+	return nil
+}
 
 func (s Set) String() string {
 	var ps []string

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -1,0 +1,43 @@
+package policy
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestJSON(t *testing.T) {
+	policy := Set{}
+	policy = policy.Add(Ignore)
+	policy = policy.Add(Locked)
+
+	if !(policy.Contains(Ignore) && policy.Contains(Locked)) {
+		t.Errorf("Policy did not include those added")
+	}
+
+	bs, err := json.Marshal(policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var policy2 Set
+	if err = json.Unmarshal(bs, &policy2); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(policy, policy2) {
+		t.Errorf("Roundtrip did not preserve policy. Expected:\n%#v\nGot:\n%#v\n", policy, policy2)
+	}
+
+	listyPols := []Policy{Ignore, Locked}
+	bs, err = json.Marshal(listyPols)
+	if err != nil {
+		t.Fatal(err)
+	}
+	policy2 = Set{}
+	if err = json.Unmarshal(bs, &policy2); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(policy, policy2) {
+		t.Errorf("Parsing equivalent list did not preserve policy. Expected:\n%#v\nGot:\n%#v\n", policy, policy2)
+	}
+}


### PR DESCRIPTION
When extending policy to include tag filters, the type representing a
set of policies changed from `[]Policy` (a slice of policies to
consider as "on") to `map[Policy]string` (since policies may now have
values other than on and .. absent).

For most purposes this is internal, however it appears in public APIs in two places:

 1. when calling `UpdatePolicy` you provide a policy.Updates
 2. historical events and commit notes include a `update.Spec` which
 can contain `policy.Updates`

.. and `policy.Updates` has fields of the kind described above.

To smooth this over, adapt []Policy to map[Policy]string when
deserialising.