### PR TITLE
Distinguish automated release events

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -58,7 +58,7 @@ func (d *Daemon) PollImages(logger log.Logger) {
 		}
 	}
 
-	d.UpdateManifests(update.Spec{Type: update.Images, Spec: changes})
+	d.UpdateManifests(update.Spec{Type: update.Auto, Spec: changes})
 }
 
 func getTagPattern(services policy.ServiceMap, service flux.ServiceID, container string) string {

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -3,20 +3,19 @@ package notifications
 import (
 	"github.com/weaveworks/flux/history"
 	"github.com/weaveworks/flux/instance"
-	"github.com/weaveworks/flux/update"
 )
 
-// Release performs post-release notifications for an instance
-func Release(cfg instance.Config, r *history.ReleaseEventMetadata, releaseError string) error {
-	if r.Spec.Kind != update.ReleaseKindExecute {
-		return nil
-	}
-
-	// TODO: Use a config settings format which allows multiple notifiers to be
-	// configured.
-	var err error
+func Event(cfg instance.Config, e history.Event) error {
+	// If this is a release
 	if cfg.Settings.Slack.HookURL != "" {
-		err = slackNotifyRelease(cfg.Settings.Slack, r, releaseError)
+		switch e.Type {
+		case history.EventRelease:
+			r := e.Metadata.(*history.ReleaseEventMetadata)
+			return slackNotifyRelease(cfg.Settings.Slack, r, r.Error)
+		case history.EventAutoRelease:
+			r := e.Metadata.(*history.AutoReleaseEventMetadata)
+			return slackNotifyAutoRelease(cfg.Settings.Slack, r, r.Error)
+		}
 	}
-	return err
+	return nil
 }

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -26,15 +26,17 @@ func exampleRelease(t *testing.T) *history.ReleaseEventMetadata {
 			Kind:         update.ReleaseKindExecute,
 			Excludes:     nil,
 		},
-		Result: update.Result{
-			flux.ServiceID("default/helloworld"): {
-				Status: update.ReleaseStatusFailed,
-				Error:  "overall-release-error",
-				PerContainer: []update.ContainerUpdate{
-					update.ContainerUpdate{
-						Container: "container1",
-						Current:   img1a1,
-						Target:    img1a2,
+		ReleaseEventCommon: history.ReleaseEventCommon{
+			Result: update.Result{
+				flux.ServiceID("default/helloworld"): {
+					Status: update.ReleaseStatusFailed,
+					Error:  "overall-release-error",
+					PerContainer: []update.ContainerUpdate{
+						update.ContainerUpdate{
+							Container: "container1",
+							Current:   img1a1,
+							Target:    img1a2,
+						},
 					},
 				},
 			},
@@ -50,14 +52,15 @@ func TestRelease_DryRun(t *testing.T) {
 
 	// It should send releases to slack
 	r := exampleRelease(t)
+	ev := history.Event{Metadata: r}
 	r.Spec.Kind = update.ReleaseKindPlan
-	if err := Release(instance.Config{
+	if err := Event(instance.Config{
 		Settings: flux.UnsafeInstanceConfig{
 			Slack: flux.NotifierConfig{
 				HookURL: server.URL,
 			},
 		},
-	}, r, ""); err != nil {
+	}, ev); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/server/server.go
+++ b/server/server.go
@@ -143,17 +143,13 @@ func (s *Server) LogEvent(instID flux.InstanceID, e history.Event) error {
 		return errors.Wrapf(err, "logging event")
 	}
 
-	// If this is a release
-	if e.Type == history.EventRelease {
-		cfg, err := helper.Config.Get()
-		if err != nil {
-			return errors.Wrapf(err, "getting config")
-		}
-		releaseMeta := e.Metadata.(*history.ReleaseEventMetadata)
-		err = notifications.Release(cfg, releaseMeta, releaseMeta.Error)
-		if err != nil {
-			return errors.Wrapf(err, "notifying slack")
-		}
+	cfg, err := helper.Config.Get()
+	if err != nil {
+		return errors.Wrapf(err, "getting config")
+	}
+	err = notifications.Event(cfg, e)
+	if err != nil {
+		return errors.Wrapf(err, "notifying slack")
 	}
 	return nil
 }

--- a/update/automated.go
+++ b/update/automated.go
@@ -10,17 +10,17 @@ import (
 )
 
 type Automated struct {
-	changes []change
+	Changes []Change
 }
 
-type change struct {
-	service   flux.ServiceID
-	container cluster.Container
-	imageID   flux.ImageID
+type Change struct {
+	ServiceID flux.ServiceID
+	Container cluster.Container
+	ImageID   flux.ImageID
 }
 
 func (a *Automated) Add(service flux.ServiceID, container cluster.Container, image flux.ImageID) {
-	a.changes = append(a.changes, change{service, container, image})
+	a.Changes = append(a.Changes, Change{service, container, image})
 }
 
 func (a *Automated) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*ServiceUpdate, Result, error) {
@@ -54,16 +54,16 @@ func (a *Automated) ReleaseKind() ReleaseKind {
 
 func (a *Automated) CommitMessage() string {
 	var images []string
-	for _, image := range a.images() {
+	for _, image := range a.Images() {
 		images = append(images, image.String())
 	}
 	return fmt.Sprintf("Release %s to automated", strings.Join(images, ", "))
 }
 
-func (a *Automated) images() []flux.ImageID {
+func (a *Automated) Images() []flux.ImageID {
 	imageMap := map[flux.ImageID]struct{}{}
-	for _, change := range a.changes {
-		imageMap[change.imageID] = struct{}{}
+	for _, change := range a.Changes {
+		imageMap[change.ImageID] = struct{}{}
 	}
 	var images []flux.ImageID
 	for image, _ := range imageMap {
@@ -112,11 +112,11 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Servi
 			}
 
 			for _, change := range changes {
-				if change.container.Name != container.Name {
+				if change.Container.Name != container.Name {
 					continue
 				}
 
-				u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, change.imageID)
+				u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, change.ImageID)
 				if err != nil {
 					return nil, err
 				}
@@ -124,7 +124,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Servi
 				containerUpdates = append(containerUpdates, ContainerUpdate{
 					Container: container.Name,
 					Current:   currentImageID,
-					Target:    change.imageID,
+					Target:    change.ImageID,
 				})
 			}
 		}
@@ -147,10 +147,10 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Servi
 	return updates, nil
 }
 
-func (a *Automated) serviceMap() map[flux.ServiceID][]change {
-	set := map[flux.ServiceID][]change{}
-	for _, change := range a.changes {
-		set[change.service] = append(set[change.service], change)
+func (a *Automated) serviceMap() map[flux.ServiceID][]Change {
+	set := map[flux.ServiceID][]Change{}
+	for _, change := range a.Changes {
+		set[change.ServiceID] = append(set[change.ServiceID], change)
 	}
 	return set
 }

--- a/update/spec.go
+++ b/update/spec.go
@@ -10,6 +10,7 @@ import (
 const (
 	Images = "image"
 	Policy = "policy"
+	Auto   = "auto"
 )
 
 // How did this update get triggered?
@@ -47,6 +48,12 @@ func (spec *Spec) UnmarshalJSON(in []byte) error {
 		spec.Spec = update
 	case Images:
 		var update ReleaseSpec
+		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
+			return err
+		}
+		spec.Spec = update
+	case Auto:
+		var update Automated
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err
 		}


### PR DESCRIPTION
Previously when we ran automation the changes to be made were
collected into a set of releases of individual images. This was
largely to fit with the existing release mechanism.

The recent tag filtering implementation changed how releases could be
specified, allowing you to supply an implementation of
`update.Changes` which would then be used to calculate the changes to
manifests.

However, the commit notes and events still accommodate only the
original kind of release spec. The upshot: fields in commit notes were
empty, and notifications missing.

One quick fix would be to finesse automated release specs to look like
the original kind. However, since the former can mention multiple
images, it is easier said than done. Instead I decided to bite the
bullet and create a new kind of event (and hook it into notification).

Also removes the custom Slack template, which we didn't use.

(Heads-up: this creates a new kind of Event with the type "autorelease", which will need a view in the UI.)

Fixes #641.