### PR TITLE
Decode and stringify autorelease events from DB

### DIFF
--- a/history/event.go
+++ b/history/event.go
@@ -110,6 +110,16 @@ func (e Event) String() string {
 			user,
 			msg,
 		)
+	case EventAutoRelease:
+		metadata := e.Metadata.(*AutoReleaseEventMetadata)
+		strImageIDs := metadata.Result.ImageIDs()
+		if len(strImageIDs) == 0 {
+			strImageIDs = []string{"no image changes"}
+		}
+		return fmt.Sprintf(
+			"Automated release of %s",
+			strings.Join(strImageIDs, ", "),
+		)
 	case EventCommit:
 		metadata := e.Metadata.(*CommitEventMetadata)
 		svcStr := "<no changes>"

--- a/history/sql/pg.go
+++ b/history/sql/pg.go
@@ -77,6 +77,12 @@ func (db *pgDB) scanEvents(query squirrel.Sqlizer) ([]history.Event, error) {
 					return nil, err
 				}
 				h.Metadata = &m
+			case history.EventAutoRelease:
+				var m history.AutoReleaseEventMetadata
+				if err := json.Unmarshal(metadataBytes, &m); err != nil {
+					return nil, err
+				}
+				h.Metadata = &m
 			}
 		}
 		events = append(events, h)

--- a/history/sql/ql.go
+++ b/history/sql/ql.go
@@ -71,6 +71,12 @@ func (db *qlDB) scanEvents(query squirrel.Sqlizer) ([]history.Event, error) {
 					return nil, err
 				}
 				h.Metadata = &m
+			case history.EventAutoRelease:
+				var m history.AutoReleaseEventMetadata
+				if err := json.Unmarshal(metadataBytes, &m); err != nil {
+					return nil, err
+				}
+				h.Metadata = &m
 			}
 		}
 		events = append(events, h)


### PR DESCRIPTION
PR #642 added an event for automated releases (as distinct to releases) so that notifications work again.

This PR makes sure they are rehydrated from the database properly, so that the UI can show them sensibly.