### PR TITLE
Tag filter CLI

### DIFF
--- a/cmd/fluxctl/automate_cmd.go
+++ b/cmd/fluxctl/automate_cmd.go
@@ -9,14 +9,14 @@ import (
 )
 
 type serviceAutomateOpts struct {
-	*serviceOpts
+	*rootOpts
 	service string
 	outputOpts
 	cause update.Cause
 }
 
-func newServiceAutomate(parent *serviceOpts) *serviceAutomateOpts {
-	return &serviceAutomateOpts{serviceOpts: parent}
+func newServiceAutomate(parent *rootOpts) *serviceAutomateOpts {
+	return &serviceAutomateOpts{rootOpts: parent}
 }
 
 func (opts *serviceAutomateOpts) Command() *cobra.Command {

--- a/cmd/fluxctl/deautomate_cmd.go
+++ b/cmd/fluxctl/deautomate_cmd.go
@@ -9,14 +9,14 @@ import (
 )
 
 type serviceDeautomateOpts struct {
-	*serviceOpts
+	*rootOpts
 	service string
 	outputOpts
 	cause update.Cause
 }
 
-func newServiceDeautomate(parent *serviceOpts) *serviceDeautomateOpts {
-	return &serviceDeautomateOpts{serviceOpts: parent}
+func newServiceDeautomate(parent *rootOpts) *serviceDeautomateOpts {
+	return &serviceDeautomateOpts{rootOpts: parent}
 }
 
 func (opts *serviceDeautomateOpts) Command() *cobra.Command {

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -11,13 +11,13 @@ import (
 )
 
 type serviceShowOpts struct {
-	*serviceOpts
+	*rootOpts
 	service string
 	limit   int
 }
 
-func newServiceShow(parent *serviceOpts) *serviceShowOpts {
-	return &serviceShowOpts{serviceOpts: parent}
+func newServiceShow(parent *rootOpts) *serviceShowOpts {
+	return &serviceShowOpts{rootOpts: parent}
 }
 
 func (opts *serviceShowOpts) Command() *cobra.Command {

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -12,12 +12,12 @@ import (
 )
 
 type serviceListOpts struct {
-	*serviceOpts
+	*rootOpts
 	namespace string
 }
 
-func newServiceList(parent *serviceOpts) *serviceListOpts {
-	return &serviceListOpts{serviceOpts: parent}
+func newServiceList(parent *rootOpts) *serviceListOpts {
+	return &serviceListOpts{rootOpts: parent}
 }
 
 func (opts *serviceListOpts) Command() *cobra.Command {

--- a/cmd/fluxctl/lock_cmd.go
+++ b/cmd/fluxctl/lock_cmd.go
@@ -9,14 +9,14 @@ import (
 )
 
 type serviceLockOpts struct {
-	*serviceOpts
+	*rootOpts
 	service string
 	outputOpts
 	cause update.Cause
 }
 
-func newServiceLock(parent *serviceOpts) *serviceLockOpts {
-	return &serviceLockOpts{serviceOpts: parent}
+func newServiceLock(parent *rootOpts) *serviceLockOpts {
+	return &serviceLockOpts{rootOpts: parent}
 }
 
 func (opts *serviceLockOpts) Command() *cobra.Command {

--- a/cmd/fluxctl/main_test.go
+++ b/cmd/fluxctl/main_test.go
@@ -17,15 +17,13 @@ import (
 	"github.com/weaveworks/flux/job"
 )
 
-func mockServiceOpts(trip *genericMockRoundTripper) *serviceOpts {
+func mockServiceOpts(trip *genericMockRoundTripper) *rootOpts {
 	c := http.Client{
 		Transport: trip,
 	}
 	mockAPI := client.New(&c, transport.NewAPIRouter(), "", "")
-	return &serviceOpts{
-		rootOpts: &rootOpts{
-			API: mockAPI,
-		},
+	return &rootOpts{
+		API: mockAPI,
 	}
 }
 

--- a/cmd/fluxctl/policy.go
+++ b/cmd/fluxctl/policy.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/policy"
+	"github.com/weaveworks/flux/update"
+)
+
+type servicePolicyOpts struct {
+	*rootOpts
+	outputOpts
+	service   string
+	container string
+	tag       string
+
+	automate, deautomate bool
+	lock, unlock         bool
+
+	cause update.Cause
+}
+
+func newServicePolicy(parent *rootOpts) *servicePolicyOpts {
+	return &servicePolicyOpts{rootOpts: parent}
+}
+
+func (opts *servicePolicyOpts) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "policy",
+		Short: "Manage policies for a service.",
+		Example: makeExample(
+			"fluxctl policy --service=foo --automate",
+			"fluxctl policy --service=foo --lock",
+			"fluxctl policy --service=foo --container=bar --tag=1.2.*",
+		),
+		RunE: opts.RunE,
+	}
+
+	AddOutputFlags(cmd, &opts.outputOpts)
+	AddCauseFlags(cmd, &opts.cause)
+	flags := cmd.Flags()
+	flags.StringVarP(&opts.service, "service", "s", "", "Service to modify")
+	flags.StringVar(&opts.container, "container", "", "Container to set tag filter")
+	flags.StringVar(&opts.tag, "tag", "", "Tag filter pattern")
+	flags.BoolVar(&opts.automate, "automate", false, "Automate service")
+	flags.BoolVar(&opts.deautomate, "deautomate", false, "Deautomate for service")
+	flags.BoolVar(&opts.lock, "lock", false, "Lock service")
+	flags.BoolVar(&opts.unlock, "unlock", false, "Unlock service")
+
+	return cmd
+}
+
+func (opts *servicePolicyOpts) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return errorWantedNoArgs
+	}
+	if opts.service == "" {
+		return newUsageError("-s, --service is required")
+	}
+	if opts.automate && opts.deautomate {
+		return newUsageError("automate and deautomate both specified")
+	}
+	if opts.lock && opts.unlock {
+		return newUsageError("lock and unlock both specified")
+	}
+	if opts.container != "" && opts.tag == "" {
+		return newUsageError("container specified without a tag pattern")
+	}
+	if opts.tag != "" && opts.container == "" {
+		return newUsageError("tag pattern specified without a container")
+	}
+
+	serviceID, err := flux.ParseServiceID(opts.service)
+	if err != nil {
+		return err
+	}
+
+	update := calculatePolicyChanges(opts)
+	jobID, err := opts.API.UpdatePolicies(noInstanceID, policy.Updates{
+		serviceID: update,
+	}, opts.cause)
+	if err != nil {
+		return err
+	}
+	return await(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, false, opts.verbose)
+}
+
+func calculatePolicyChanges(opts *servicePolicyOpts) policy.Update {
+	add := policy.Set{}
+	if opts.automate {
+		add = add.Add(policy.Automated)
+	}
+	if opts.lock {
+		add = add.Add(policy.Locked)
+	}
+	if opts.tag != "" && opts.tag != "*" {
+		add = add.Set(policy.TagPrefix(opts.container), "glob:"+opts.tag)
+	}
+
+	remove := policy.Set{}
+	if opts.deautomate {
+		remove = remove.Add(policy.Automated)
+	}
+	if opts.unlock {
+		remove = remove.Add(policy.Locked)
+	}
+	if opts.tag == "*" {
+		remove = remove.Add(policy.TagPrefix(opts.container))
+	}
+
+	update := policy.Update{}
+	if len(add) > 0 {
+		update.Add = add
+	}
+	if len(remove) > 0 {
+		update.Remove = remove
+	}
+
+	return update
+}

--- a/cmd/fluxctl/policy.go
+++ b/cmd/fluxctl/policy.go
@@ -32,6 +32,16 @@ func (opts *servicePolicyOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "policy",
 		Short: "Manage policies for a service.",
+		Long: `
+Manage policies for a service.
+
+Tag filter patterns must be specified as 'container=pattern', such as 'foo=1.*'
+where an asterisk means 'match anything'.
+Surrounding these with single-quotes are recommended to avoid shell expansion.
+
+If both --tag-all and --tag are specified, --tag-all will apply to all
+containers which aren't explicitly named.
+        `,
 		Example: makeExample(
 			"fluxctl policy --service=foo --automate",
 			"fluxctl policy --service=foo --lock",
@@ -110,7 +120,7 @@ func calculatePolicyChanges(opts *servicePolicyOpts) (policy.Update, error) {
 	for _, tagPair := range opts.tags {
 		parts := strings.Split(tagPair, "=")
 		if len(parts) != 2 {
-			return policy.Update{}, fmt.Errorf("invalid container/tag pair: %q", tagPair)
+			return policy.Update{}, fmt.Errorf("invalid container/tag pair: %q. Expected format is 'container=filter'", tagPair)
 		}
 
 		container, tag := parts[0], parts[1]

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -10,7 +10,7 @@ import (
 )
 
 type serviceReleaseOpts struct {
-	*serviceOpts
+	*rootOpts
 	services    []string
 	allServices bool
 	image       string
@@ -21,8 +21,8 @@ type serviceReleaseOpts struct {
 	cause update.Cause
 }
 
-func newServiceRelease(parent *serviceOpts) *serviceReleaseOpts {
-	return &serviceReleaseOpts{serviceOpts: parent}
+func newServiceRelease(parent *rootOpts) *serviceReleaseOpts {
+	return &serviceReleaseOpts{rootOpts: parent}
 }
 
 func (opts *serviceReleaseOpts) Command() *cobra.Command {

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -69,6 +69,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		newServiceDeautomate(opts).Command(),
 		newServiceLock(opts).Command(),
 		newServiceUnlock(opts).Command(),
+		newServicePolicy(opts).Command(),
 		newSave(opts).Command(),
 		newIdentity(opts).Command(),
 	)

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -28,14 +28,6 @@ type rootOpts struct {
 // optionally gets populated by an intermediating authfe from the token.
 const noInstanceID = service.InstanceID("")
 
-type serviceOpts struct {
-	*rootOpts
-}
-
-func newService(parent *rootOpts) *serviceOpts {
-	return &serviceOpts{rootOpts: parent}
-}
-
 func newRoot() *rootOpts {
 	return &rootOpts{}
 }
@@ -68,17 +60,15 @@ func (opts *rootOpts) Command() *cobra.Command {
 	cmd.PersistentFlags().StringVarP(&opts.Token, "token", "t", "",
 		fmt.Sprintf("Weave Cloud service token; you can also set the environment variable %s or %s", envVariableCloudToken, envVariableToken))
 
-	svcopts := newService(opts)
-
 	cmd.AddCommand(
 		newVersionCommand(),
-		newServiceShow(svcopts).Command(),
-		newServiceList(svcopts).Command(),
-		newServiceRelease(svcopts).Command(),
-		newServiceAutomate(svcopts).Command(),
-		newServiceDeautomate(svcopts).Command(),
-		newServiceLock(svcopts).Command(),
-		newServiceUnlock(svcopts).Command(),
+		newServiceShow(opts).Command(),
+		newServiceList(opts).Command(),
+		newServiceRelease(opts).Command(),
+		newServiceAutomate(opts).Command(),
+		newServiceDeautomate(opts).Command(),
+		newServiceLock(opts).Command(),
+		newServiceUnlock(opts).Command(),
 		newSave(opts).Command(),
 		newIdentity(opts).Command(),
 	)

--- a/cmd/fluxctl/unlock_cmd.go
+++ b/cmd/fluxctl/unlock_cmd.go
@@ -9,14 +9,14 @@ import (
 )
 
 type serviceUnlockOpts struct {
-	*serviceOpts
+	*rootOpts
 	service string
 	outputOpts
 	cause update.Cause
 }
 
-func newServiceUnlock(parent *serviceOpts) *serviceUnlockOpts {
-	return &serviceUnlockOpts{serviceOpts: parent}
+func newServiceUnlock(parent *rootOpts) *serviceUnlockOpts {
+	return &serviceUnlockOpts{rootOpts: parent}
 }
 
 func (opts *serviceUnlockOpts) Command() *cobra.Command {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -455,20 +455,24 @@ func policyCommitMessage(us policy.Updates, cause update.Cause) string {
 func policyEventTypes(u policy.Update) []string {
 	types := map[string]struct{}{}
 	for p, _ := range u.Add {
-		switch p {
-		case policy.Automated:
+		switch {
+		case p == policy.Automated:
 			types[history.EventAutomate] = struct{}{}
-		case policy.Locked:
+		case p == policy.Locked:
 			types[history.EventLock] = struct{}{}
+		case policy.Tag(p):
+			types[history.EventUpdateTag] = struct{}{}
 		}
 	}
 
 	for p, _ := range u.Remove {
-		switch p {
-		case policy.Automated:
+		switch {
+		case p == policy.Automated:
 			types[history.EventDeautomate] = struct{}{}
-		case policy.Locked:
+		case p == policy.Locked:
 			types[history.EventUnlock] = struct{}{}
+		case policy.Tag(p):
+			types[history.EventUpdateTag] = struct{}{}
 		}
 	}
 	var result []string

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -407,6 +407,26 @@ func containersWithAvailable(service cluster.Service, images update.ImageMap) (r
 	return res
 }
 
+func policyCommitMessage(us policy.Updates, cause update.Cause) string {
+	// shortcut, since we want roughly the same information
+	events := policyEvents(us, time.Now())
+	commitMsg := &bytes.Buffer{}
+	prefix := "- "
+	switch {
+	case cause.Message != "":
+		fmt.Fprintf(commitMsg, "%s\n\n", cause.Message)
+	case len(events) > 1:
+		fmt.Fprintf(commitMsg, "Updated service policies\n\n")
+	default:
+		prefix = ""
+	}
+
+	for _, event := range events {
+		fmt.Fprintf(commitMsg, "%s%v\n", prefix, event)
+	}
+	return commitMsg.String()
+}
+
 // policyEvents builds a map of events (by type), for all the events in this set of
 // updates. There will be one event per type, containing all service ids
 // affected by that event. e.g. all automated services will share an event.
@@ -431,26 +451,6 @@ func policyEvents(us policy.Updates, now time.Time) map[string]history.Event {
 	return eventsByType
 }
 
-func policyCommitMessage(us policy.Updates, cause update.Cause) string {
-	// shortcut, since we want roughly the same information
-	events := policyEvents(us, time.Now())
-	commitMsg := &bytes.Buffer{}
-	prefix := "- "
-	switch {
-	case cause.Message != "":
-		fmt.Fprintf(commitMsg, "%s\n\n", cause.Message)
-	case len(events) > 1:
-		fmt.Fprintf(commitMsg, "Updated service policies\n\n")
-	default:
-		prefix = ""
-	}
-
-	for _, event := range events {
-		fmt.Fprintf(commitMsg, "%s%v\n", prefix, event)
-	}
-	return commitMsg.String()
-}
-
 // policyEventTypes is a deduped list of all event types this update contains
 func policyEventTypes(u policy.Update) []string {
 	types := map[string]struct{}{}
@@ -460,8 +460,8 @@ func policyEventTypes(u policy.Update) []string {
 			types[history.EventAutomate] = struct{}{}
 		case p == policy.Locked:
 			types[history.EventLock] = struct{}{}
-		case policy.Tag(p):
-			types[history.EventUpdateTag] = struct{}{}
+		default:
+			types[history.EventUpdatePolicy] = struct{}{}
 		}
 	}
 
@@ -471,8 +471,8 @@ func policyEventTypes(u policy.Update) []string {
 			types[history.EventDeautomate] = struct{}{}
 		case p == policy.Locked:
 			types[history.EventUnlock] = struct{}{}
-		case policy.Tag(p):
-			types[history.EventUpdateTag] = struct{}{}
+		default:
+			types[history.EventUpdatePolicy] = struct{}{}
 		}
 	}
 	var result []string

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -63,7 +63,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 
 func getTagPattern(services policy.ServiceMap, service flux.ServiceID, container string) string {
 	policies := services[service]
-	if pattern, ok := policies.Get(policy.Policy("tag." + container)); ok {
+	if pattern, ok := policies.Get(policy.TagPrefix(container)); ok {
 		return strings.TrimPrefix(pattern, "glob:")
 	}
 	return "*"

--- a/history/event.go
+++ b/history/event.go
@@ -23,6 +23,7 @@ const (
 	EventDeautomate  = "deautomate"
 	EventLock        = "lock"
 	EventUnlock      = "unlock"
+	EventUpdateTag   = "update_tag"
 
 	LogLevelDebug = "debug"
 	LogLevelInfo  = "info"

--- a/history/event.go
+++ b/history/event.go
@@ -15,15 +15,15 @@ import (
 
 // These are all the types of events.
 const (
-	EventCommit      = "commit"
-	EventSync        = "sync"
-	EventRelease     = "release"
-	EventAutoRelease = "autorelease"
-	EventAutomate    = "automate"
-	EventDeautomate  = "deautomate"
-	EventLock        = "lock"
-	EventUnlock      = "unlock"
-	EventUpdateTag   = "update_tag"
+	EventCommit       = "commit"
+	EventSync         = "sync"
+	EventRelease      = "release"
+	EventAutoRelease  = "autorelease"
+	EventAutomate     = "automate"
+	EventDeautomate   = "deautomate"
+	EventLock         = "lock"
+	EventUnlock       = "unlock"
+	EventUpdatePolicy = "update_policy"
 
 	LogLevelDebug = "debug"
 	LogLevelInfo  = "info"

--- a/history/event.go
+++ b/history/event.go
@@ -153,6 +153,8 @@ func (e Event) String() string {
 		return fmt.Sprintf("Locked: %s", strings.Join(strServiceIDs, ", "))
 	case EventUnlock:
 		return fmt.Sprintf("Unlocked: %s", strings.Join(strServiceIDs, ", "))
+	case EventUpdatePolicy:
+		return fmt.Sprintf("Updated policies: %s", strings.Join(strServiceIDs, ", "))
 	default:
 		return fmt.Sprintf("Unknown event: %s", e.Type)
 	}
@@ -173,10 +175,7 @@ type CommitEventMetadata struct {
 }
 
 func (c CommitEventMetadata) ShortRevision() string {
-	if len(c.Revision) <= 7 {
-		return c.Revision
-	}
-	return c.Revision[:7]
+	return shortRevision(c.Revision)
 }
 
 // SyncEventMetadata is the metadata for when new a commit is synced to the cluster

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -26,6 +26,14 @@ func Boolean(policy Policy) bool {
 	return false
 }
 
+func TagPrefix(container string) Policy {
+	return Policy("tag." + container)
+}
+
+func Tag(policy Policy) bool {
+	return strings.HasPrefix(string(policy), "tag.")
+}
+
 type Updates map[flux.ServiceID]Update
 
 type Update struct {

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -12,6 +12,7 @@ const (
 	Ignore    = Policy("ignore")
 	Locked    = Policy("locked")
 	Automated = Policy("automated")
+	TagAll    = Policy("tag_all")
 )
 
 // Policy is an string, denoting the current deployment policy of a service,


### PR DESCRIPTION
Currently working towards implementing this command:

```
$ fluxctl policy --service=foo \
    [--(de)automate] \
    [--(un)lock] \
    [--container=bar --tag=master-*]
```

Progress:

- [x] `--(de)automate`
- [x] `--(un)lock`
- [x] `--container --tag` (with arbitrarily many pairs of these)
- [x] commit messages must make sense
- [x] history