### PR TITLE
Prefix ssh keygen tmpdir with ..weave-

### DIFF
--- a/ssh/keygen.go
+++ b/ssh/keygen.go
@@ -82,7 +82,7 @@ func (ktv *KeyTypeValue) Specified() bool {
 // subdirectory of tmpfsPath, which should point to a tmpfs mount as the
 // private key is not encrypted.
 func KeyGen(keyBits, keyType OptionalValue, tmpfsPath string) (privateKeyPath string, privateKey []byte, publicKey PublicKey, err error) {
-	tempDir, err := ioutil.TempDir(tmpfsPath, "keygen")
+	tempDir, err := ioutil.TempDir(tmpfsPath, "..weave-keygen")
 	if err != nil {
 		return "", nil, PublicKey{}, err
 	}


### PR DESCRIPTION
The 'AtomicWriter' used by k8s to project secrets into a tmpfs volume
periodically removes any files whose names do not match existing keys in
the secret, unfortunately including the temporary directories into which
we generate keys. This can be avoided by prefixing our temporary
directories with '..', effectively placing them in the namespace
reserved by the AtomicWriter for non-user-visible files; since we are
intruding into this namespace, we also include 'weave-' in the prefix in
an attempt to avoid collisions.