### PR TITLE
More accurately report changed services

### DIFF
--- a/cluster/kubernetes/resource/deployment.go
+++ b/cluster/kubernetes/resource/deployment.go
@@ -17,7 +17,7 @@ func (o Deployment) ServiceIDs(all map[string]resource.Resource) []flux.ServiceI
 	// Look through all for any matching services
 	for _, r := range all {
 		s, ok := r.(*Service)
-		if ok && s.Matches(labels.Set(o.Spec.Template.Metadata.Labels)) {
+		if ok && s.Meta.Namespace == o.Meta.Namespace && s.Matches(labels.Set(o.Spec.Template.Metadata.Labels)) {
 			found.Add(s.ServiceIDs(all))
 		}
 	}

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -124,12 +124,6 @@ func (d *LoopVars) askForImagePoll() {
 func (d *Daemon) doSync(logger log.Logger) {
 	started := time.Now().UTC()
 
-	// Pull for new commits
-	if err := d.Checkout.Pull(); err != nil {
-		logger.Log("err", err)
-		return
-	}
-
 	// checkout a working clone so we can mess around with tags later
 	working, err := d.Checkout.WorkingClone()
 	if err != nil {


### PR DESCRIPTION
The motivation for this is to fix #632, and that's done in the change to `cluster/kubernetes/resource/deployment.go`. There's a couple of other changes, _en passant_, in the first two commits.