### PR TITLE
Make fluxd restarts more graceful

### DIFF
--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -5,6 +5,8 @@ metadata:
   name: flux
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:

--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -115,9 +115,8 @@ func (a *Upstream) loop() {
 					// We have logged the deprecation error, now crashloop to garner attention
 					os.Exit(1)
 				}
-				time.Sleep(backoff)
-				continue
 			}
+			time.Sleep(backoff)
 		case <-a.quit:
 			return
 		}


### PR DESCRIPTION
When flux is itself restarted (e.g., by applying a new deployment
config, perhaps from a release), the new pod will get in a kicking war
with the old pod while the latter winds down.

To mitigate this, two measures.

1. Always wait before reconnecting, rather than waiting only if there
was an error. When being kicked, the connection is shut cleanly;
previously, it would try to reconnect immediately, prompting another
kick, and so on.

2. Use the rollout strategy `Recreate` (in the example deployment
yamel). `Recreate` does what we want: stop the previous pod, start the
new one.

(NB: if you update your own fluxd deployment, you'll need to delete it then apply the new one.)