### PR TITLE
Notify on sync

### DIFF
--- a/history/event.go
+++ b/history/event.go
@@ -239,6 +239,20 @@ func (e *Event) UnmarshalJSON(in []byte) error {
 		}
 		e.Metadata = &metadata
 		break
+	case EventCommit:
+		var metadata CommitEventMetadata
+		if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
+			return err
+		}
+		e.Metadata = &metadata
+		break
+	case EventSync:
+		var metadata SyncEventMetadata
+		if err := json.Unmarshal(wireEvent.MetadataBytes, &metadata); err != nil {
+			return err
+		}
+		e.Metadata = &metadata
+		break
 	default:
 		if len(wireEvent.MetadataBytes) > 0 {
 			var metadata UnknownEventMetadata

--- a/history/event_test.go
+++ b/history/event_test.go
@@ -2,9 +2,9 @@ package history
 
 import (
 	"encoding/json"
-	"fmt"
-	"github.com/weaveworks/flux/update"
 	"testing"
+
+	"github.com/weaveworks/flux/update"
 )
 
 var (
@@ -41,31 +41,6 @@ func TestEvent_ParseReleaseMetaData(t *testing.T) {
 		}
 	default:
 		t.Fatal("Wrong event type unmarshalled")
-	}
-}
-
-func TestEvent_ParseNormalMetadata(t *testing.T) {
-	origEvent := Event{
-		Type: EventSync,
-		Metadata: &SyncEventMetadata{
-			Revisions: []string{"1"},
-		},
-	}
-
-	bytes, _ := json.Marshal(origEvent)
-
-	e := Event{}
-	err := e.UnmarshalJSON(bytes)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if e.Metadata == nil {
-		t.Fatal("Hasn't been unmarshalled properly")
-
-	}
-	fmt.Println(e.Metadata)
-	if fmt.Sprint(e.Metadata) != "map[revisions:[1]]" {
-		t.Fatal("Expected metadata")
 	}
 }
 

--- a/notifications/notifications.go
+++ b/notifications/notifications.go
@@ -15,6 +15,8 @@ func Event(cfg instance.Config, e history.Event) error {
 		case history.EventAutoRelease:
 			r := e.Metadata.(*history.AutoReleaseEventMetadata)
 			return slackNotifyAutoRelease(cfg.Settings.Slack, r, r.Error)
+		case history.EventSync:
+			return slackNotifySync(cfg.Settings.Slack, &e)
 		}
 	}
 	return nil

--- a/server/server.go
+++ b/server/server.go
@@ -153,6 +153,7 @@ func (s *Server) SyncStatus(instID service.InstanceID, ref string) (res []string
 // LogEvent receives events from fluxd and pushes events to the history
 // db and a slack notification
 func (s *Server) LogEvent(instID service.InstanceID, e history.Event) error {
+	s.logger.Log("method", "LogEvent", "instance", instID, "event", e)
 	helper, err := s.instancer.Get(instID)
 	if err != nil {
 		return errors.Wrapf(err, "getting instance")
@@ -170,7 +171,7 @@ func (s *Server) LogEvent(instID service.InstanceID, e history.Event) error {
 	}
 	err = notifications.Event(cfg, e)
 	if err != nil {
-		return errors.Wrapf(err, "notifying slack")
+		return errors.Wrapf(err, "sending notifications")
 	}
 	return nil
 }

--- a/service/config.go
+++ b/service/config.go
@@ -8,6 +8,10 @@ type NotifierConfig struct {
 	HookURL         string `json:"hookURL" yaml:"hookURL"`
 	Username        string `json:"username" yaml:"username"`
 	ReleaseTemplate string `json:"releaseTemplate" yaml:"releaseTemplate"`
+	// NotifyEvents should be a list of e.g. ["release", "sync"]. default, if
+	// unset, is ["release"].
+	// TODO Implement this.
+	NotifyEvents []string `json:"notifyEvents,omitempty" yaml:"notifyEvents,omitempty"`
 }
 
 type InstanceConfig struct {


### PR DESCRIPTION
~Don't merge!~ (EDIT(squaremo): can be merged)

Support notifying slack about "sync" events, as well as "release" events. So that you can see when your config changes have been applied.