### PR TITLE
Merge the image and git loops (again)

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -341,8 +341,6 @@ func main() {
 
 	shutdownWg.Add(1)
 	go daemon.GitPollLoop(shutdown, shutdownWg, log.NewContext(logger).With("component", "sync-loop"))
-	shutdownWg.Add(1)
-	go daemon.ImagePollLoop(shutdown, shutdownWg, log.NewContext(logger).With("component", "image-poll-loop"))
 
 	// Update daemonRef so that upstream and handlers point to fully working daemon
 	daemonRef.UpdatePlatform(daemon)


### PR DESCRIPTION
To accomplish #591 it is a lot easier if the image polling and git
polling run in the same loop.

When they are in different loops, is it tricky to synchronise them
such that a service being automated will result in the new commit
being pulled _then_ the images examined. If they happen in the other
order, the commit showing the newly automated service won't be present
and that service will be passed over.

This adds a bit more fuss in the one loop but is simpler to
understand, I reckon.