### PR TITLE
Revert "Use official version of heroku registry client."

### DIFF
--- a/vendor/manifest
+++ b/vendor/manifest
@@ -478,10 +478,10 @@
 		},
 		{
 			"importpath": "github.com/heroku/docker-registry-client",
-			"repository": "https://github.com/heroku/docker-registry-client",
+			"repository": "https://github.com/paulbellamy/docker-registry-client",
 			"vcs": "git",
-			"revision": "95467b6cacee2a06f112a3cf7e47a70fad6000cf",
-			"branch": "master",
+			"revision": "2b1d4773467efc125a91237e10268631398de074",
+			"branch": "handle-relative-nextlinks",
 			"notests": true
 		},
 		{


### PR DESCRIPTION
This reverts commit 64625080acb0655da7cc5ef306a9cf20ea86b384.

We were using a forked version because the official version does not
cope with relative Link headers.