### PR TITLE
Include pre-releases in tags that trigger an upload

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -72,7 +72,7 @@ deployment:
           echo Pushing $IMAGE_TAG
           docker push "$IMAGE_TAG"
   release:
-    tag: /[0-9]+(\.[0-9]+)*/
+    tag: /[0-9]+(\.[0-9]+)*(-[a-z]+)?/
     commands:
       - make release-bins
       - bin/upload-binaries


### PR DESCRIPTION
E.g., `1.0.0-beta`.