### PR TITLE
Make test for tag safer

### DIFF
--- a/docker/image-tag
+++ b/docker/image-tag
@@ -11,7 +11,7 @@ fi
 
 # If a tagged version, just print that tag
 HEAD_TAGS=$(git tag --points-at HEAD)
-if [ ${HEAD_TAGS} ] ; then
+if [ -n "${HEAD_TAGS}" ] ; then
 	echo ${HEAD_TAGS}
 	exit 0
 fi


### PR DESCRIPTION
1. Quote the string so it's not interpreted as an expression
2. Use `[ -n "${string}" ]` so it's explicitly tested for being an non-empty string
