### PR TITLE
Correct suggested format of tag

### DIFF
--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -9,7 +9,7 @@ This process will create a new tagged release of flux, push dockerfiles and uplo
 
 1. Alter and commit the /CHANGELOG.md file to signify what has changed in this version.
 2. Create a new release: https://github.com/weaveworks/flux/releases/new
-4. Fill in the version number for the name and tag. The version number should be semantic in the form `v1.2.3`.
+4. Fill in the version number for the name and tag. The version number should conform to [semver](semver.org); i.e., look like `1.2.3` (NB: no leading 'v'); optionally with a pre-release suffix, e.g., `1.0.0-beta`
 5. Fill in the Description field (possibly a copy paste from the CHANGELOG.md)
 6. Click "Publish release"
 


### PR DESCRIPTION
The CircleCI config is looking for tags matching
`/[0-9]+(\.[0-9]+)*(-[a-z]+)?/`, i.e., without a leading 'v'.