### PR TITLE
Parse docker credentials from imagePullRequests (not .dockerconfig)

### DIFF
--- a/image.go
+++ b/image.go
@@ -41,6 +41,9 @@ func ParseImageID(s string) (ImageID, error) {
 	case 2:
 		img.Tag = parts[1]
 		s = parts[0]
+	case 3: // There might be three parts if there is a host with a custom port
+		img.Tag = parts[2]
+		s = s[:strings.LastIndex(s, ":")]
 	default:
 		return ImageID{}, ErrMalformedImageID
 	}

--- a/image_test.go
+++ b/image_test.go
@@ -26,6 +26,8 @@ func TestImageID_ParseImageID(t *testing.T) {
 		{"quay.io/library/alpine", "quay.io/library/alpine:latest"},
 		{"quay.io/library/alpine:latest", "quay.io/library/alpine:latest"},
 		{"quay.io/library/alpine:mytag", "quay.io/library/alpine:mytag"},
+		{"localhost:5000/library/alpine:mytag", "localhost:5000/library/alpine:mytag"},
+		{"kube-registry.kube-system.svc.cluster.local:31000/secret/repo:latest", "kube-registry.kube-system.svc.cluster.local:31000/secret/repo:latest"},
 	} {
 		i, err := ParseImageID(x.test)
 		if err != nil {
@@ -43,8 +45,6 @@ func TestImageID_ParseImageIDErrorCases(t *testing.T) {
 	}{
 		{""},
 		{":tag"},
-		{"alpine::"},
-		{"alpine:invalid:"},
 		{"/too/many/slashes/"},
 	} {
 		_, err := ParseImageID(x.test)

--- a/registry/integration_test.go
+++ b/registry/integration_test.go
@@ -71,11 +71,10 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 	}()
 
 	shutdownWg.Add(1)
-	go w.Loop(shutdown, shutdownWg, func() []ImageCreds {
-		return []ImageCreds{{
-			ID:    id,
-			Creds: NoCredentials(),
-		}}
+	go w.Loop(shutdown, shutdownWg, func() ImageCreds {
+		return ImageCreds{
+			id: NoCredentials(),
+		}
 	})
 
 	timeout := time.NewTicker(10 * time.Second)    // Shouldn't take longer than 10s

--- a/registry/integration_test.go
+++ b/registry/integration_test.go
@@ -37,13 +37,11 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 	logger := log.NewContext(log.NewLogfmtLogger(os.Stderr))
 
 	remote := NewRemoteClientFactory(
-		NoCredentials(),
 		logger.With("component", "client"),
 		middleware.RateLimiterConfig{200, 10},
 	)
 
 	cache := NewCacheClientFactory(
-		NoCredentials(),
 		logger.With("component", "cache"),
 		mc,
 		time.Hour,
@@ -73,8 +71,11 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 	}()
 
 	shutdownWg.Add(1)
-	go w.Loop(shutdown, shutdownWg, func() []flux.ImageID {
-		return []flux.ImageID{id}
+	go w.Loop(shutdown, shutdownWg, func() []ImageCreds {
+		return []ImageCreds{{
+			ID:    id,
+			Creds: NoCredentials(),
+		}}
 	})
 
 	timeout := time.NewTicker(10 * time.Second)    // Shouldn't take longer than 10s

--- a/registry/mock.go
+++ b/registry/mock.go
@@ -55,7 +55,7 @@ func NewMockClientFactory(c Client, err error) ClientFactory {
 	}
 }
 
-func (m *mockRemoteFactory) ClientFor(repository string) (Client, error) {
+func (m *mockRemoteFactory) ClientFor(repository string, creds Credentials) (Client, error) {
 	return m.c, m.err
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -37,7 +37,7 @@ type registry struct {
 	connections int
 }
 
-// NewClient creates a new registry registry, to use when fetching repositories.
+// NewRegistry creates a new registry, to use when fetching repositories.
 // Behind the scenes the registry will call ClientFactory.ClientFor(...)
 // when requesting an image. This will generate a Client to access the
 // backend.
@@ -58,7 +58,7 @@ func NewRegistry(c ClientFactory, l log.Logger, connections int) Registry {
 //   quay.io/foo/helloworld -> quay.io/foo/helloworld
 //
 func (reg *registry) GetRepository(id flux.ImageID) ([]flux.Image, error) {
-	client, err := reg.factory.ClientFor(id.Host)
+	client, err := reg.factory.ClientFor(id.Host, Credentials{})
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (reg *registry) GetRepository(id flux.ImageID) ([]flux.Image, error) {
 
 // Get a single Image from the registry if it exists
 func (reg *registry) GetImage(id flux.ImageID) (flux.Image, error) {
-	client, err := reg.factory.ClientFor(id.Host)
+	client, err := reg.factory.ClientFor(id.Host, Credentials{})
 	if err != nil {
 		return flux.Image{}, err
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -87,14 +87,14 @@ func TestRegistry_GetRepositoryManifestError(t *testing.T) {
 // It will fail if there is not internet connection
 func TestRemoteFactory_RawClient(t *testing.T) {
 	// No credentials required for public Image
-	fact := NewRemoteClientFactory(Credentials{}, log.NewNopLogger(), middleware.RateLimiterConfig{
+	fact := NewRemoteClientFactory(log.NewNopLogger(), middleware.RateLimiterConfig{
 		RPS:   200,
 		Burst: 1,
 	})
 
 	// Refresh tags first
 	var tags []string
-	client, err := fact.ClientFor(id.Host)
+	client, err := fact.ClientFor(id.Host, Credentials{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -108,7 +108,7 @@ func TestRemoteFactory_RawClient(t *testing.T) {
 		t.Fatal("Should have some tags")
 	}
 
-	client, err = fact.ClientFor(id.Host)
+	client, err = fact.ClientFor(id.Host, Credentials{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,12 +127,12 @@ func TestRemoteFactory_RawClient(t *testing.T) {
 }
 
 func TestRemoteFactory_InvalidHost(t *testing.T) {
-	fact := NewRemoteClientFactory(Credentials{}, log.NewNopLogger(), middleware.RateLimiterConfig{})
+	fact := NewRemoteClientFactory(log.NewNopLogger(), middleware.RateLimiterConfig{})
 	invalidId, err := flux.ParseImageID("invalid.host/library/alpine:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, err := fact.ClientFor(invalidId.Host)
+	client, err := fact.ClientFor(invalidId.Host, Credentials{})
 	if err != nil {
 		return
 	}

--- a/registry/warming.go
+++ b/registry/warming.go
@@ -28,9 +28,14 @@ type Warmer struct {
 	Burst         int
 }
 
+type ImageCreds struct {
+	ID    flux.ImageID
+	Creds Credentials
+}
+
 // Continuously get the images to populate the cache with, and
 // populate the cache with them.
-func (w *Warmer) Loop(stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFunc func() []flux.ImageID) {
+func (w *Warmer) Loop(stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFunc func() []ImageCreds) {
 	defer wg.Done()
 
 	if w.Logger == nil || w.ClientFactory == nil || w.Expiry == 0 || w.Writer == nil || w.Reader == nil {
@@ -55,8 +60,9 @@ func (w *Warmer) Loop(stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFun
 	}
 }
 
-func (w *Warmer) warm(id flux.ImageID) {
-	client, err := w.ClientFactory.ClientFor(id.Host)
+func (w *Warmer) warm(img ImageCreds) {
+	id := img.ID
+	client, err := w.ClientFactory.ClientFor(id.Host, img.Creds)
 	if err != nil {
 		w.Logger.Log("err", err.Error())
 		return

--- a/site/faq.md
+++ b/site/faq.md
@@ -67,3 +67,11 @@ Now restart fluxd to re-read the k8s secret (if it is running):
 
 `kubectl delete $(kubectl get pod -o name -l name=flux)`
 
+### How do I use a private docker registry?
+
+Create a Kubernetes Secret with your docker credentials then add the
+name of this secret to your Pod manifest under the `imagePullSecrets`
+setting. Flux will read this value and parse the Kubernetes secret.
+
+For a guide showing how to do this, see the
+[Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).

--- a/site/standalone/setup.md
+++ b/site/standalone/setup.md
@@ -106,9 +106,3 @@ arguments (examples with defaults): `--k8s-secret-name=flux-git-deploy`,
 Using an SSH key allows you to maintain control of the repository. You
 can revoke permission for `flux` to access the repository at any time
 by removing the deploy key.
-
-## Using a Private Registry
-
-Simply mount the registry credentials into the container. The location
-of the credentials can be customised with the argument (example with
-default): `--docker-config=~/.docker/config.json`


### PR DESCRIPTION
This PR moves the method that returns a list of images to warm into
the kubernetes package. This is because the method is specific to k8s
anyway and the new code to parse the secrets needed access to the k8s
cluster.

ImageCreds is a new struct to colocate the ImageID and the credentials
required to pull them.

Credentials are now added to the client via the client factory for each
new client. This is because each image might have different credentials.

Minor fix to ImageID parsing because it wasn't able to parse id's in the format: `localhost:5000/my/image:tag`

GCR support was implemented in #663

# Testing

Push an image to a private repository. For example:

```
docker pull quay.io/weaveworks/helloworld:master-9a16ff945b9e
docker tag quay.io/weaveworks/helloworld:master-9a16ff945b9e quay.io/weaveworks/helloyou:master-9a16ff945b9e
docker login quay.io
docker push quay.io/weaveworks/helloyou:master-9a16ff945b9e
```

Create a secret on your cluster that provides your login credentials:

```
kubectl create secret docker-registry myregistrykey --docker-server=quay.io --docker-username=myuser --docker-password=mypass --docker-email=foo@bar.com
```

And finally edit your k8s deployment manifest to include the private image, and the secret in an `imagePullSecret`. For example:

```yaml
apiVersion: extensions/v1beta1
kind: Deployment
metadata:
  name: helloworld
spec:
  minReadySeconds: 5
  replicas: 1
  template:
    metadata:
      labels:
        name: helloworld
    spec:
      containers:
      - name: helloworld
        image: quay.io/weaveworks/helloyou:master-9a16ff945b9e
        args:
        - -msg=Ahoy
        ports:
        - containerPort: 80
      - name: sidecar
        image: quay.io/weaveworks/sidecar:master-a000002
        args:
        - -addr=:8080
        ports:
        - containerPort: 8080
      imagePullSecrets:
        - name: myregistrykey
```