### PR TITLE
Support dockerconfigjson imagePullSecrets

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -93,7 +93,13 @@ func main() {
 
 		upstreamURL = fs.String("connect", "", "Connect to an upstream service e.g., Weave Cloud, at this base address")
 		token       = fs.String("token", "", "Authentication token for upstream service")
+
+		// Deprecated
+		_ = fs.String("docker-config", "", "path to a docker config to use for credentials")
 	)
+
+	fs.MarkDeprecated("docker-config", "credentials are taken from imagePullSecrets now")
+
 	fs.Parse(os.Args)
 
 	if version == "" {


### PR DESCRIPTION
You can create imagePullSecrets in either `.dockercfg` or `~/.docker/config.json` format. We use the latter ourselves, so it's important to support both.

(Also: deprecate the --docker-config argument, rather than removing it, since removing it will make existing deployments crashloop.)