### PR TITLE
Refactor kubernetes.go

### DIFF
--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -4,12 +4,13 @@ package kubernetes
 // adequate. Starting with Sync.
 
 import (
+	"encoding/base64"
 	"errors"
 	"reflect"
 	"testing"
 
 	"github.com/go-kit/kit/log"
-	discovery "k8s.io/client-go/1.5/discovery"
+	"k8s.io/client-go/1.5/discovery"
 	v1alpha1apps "k8s.io/client-go/1.5/kubernetes/typed/apps/v1alpha1"
 	v1beta1authentication "k8s.io/client-go/1.5/kubernetes/typed/authentication/v1beta1"
 	v1beta1authorization "k8s.io/client-go/1.5/kubernetes/typed/authorization/v1beta1"
@@ -21,8 +22,14 @@ import (
 	v1alpha1policy "k8s.io/client-go/1.5/kubernetes/typed/policy/v1alpha1"
 	v1alpha1rbac "k8s.io/client-go/1.5/kubernetes/typed/rbac/v1alpha1"
 	v1beta1storage "k8s.io/client-go/1.5/kubernetes/typed/storage/v1beta1"
+	"k8s.io/client-go/1.5/pkg/api/v1"
 
+	"fmt"
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/registry"
+	"k8s.io/client-go/1.5/pkg/apis/extensions/v1beta1"
+	"os"
 )
 
 type command struct {
@@ -112,7 +119,7 @@ metadata:
 func setup(t *testing.T) (*Cluster, *mockApplier) {
 	clientset := &mockClientset{}
 	applier := &mockApplier{}
-	kube, err := NewCluster(clientset, applier, nil, log.NewNopLogger())
+	kube, err := NewCluster(clientset, applier, nil, nil, nil, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -207,5 +214,345 @@ func TestSkipOnError(t *testing.T) {
 	}
 	if !reflect.DeepEqual(expected, mock.commands) {
 		t.Errorf("expected commands:\n%#v\ngot:\n%#v", expected, mock.commands)
+	}
+}
+
+const (
+	ns1      = "ns1"
+	ns2      = "ns2"
+	mysecret = "mysecret"
+)
+
+var (
+	svcName1 = "svcID1"
+	svcName2 = "svcID2"
+	svcName3 = "svcID3"
+	svcID1   = flux.ServiceID(ns1 + "/" + svcName1)
+	svcID2   = flux.ServiceID(ns1 + "/" + svcName2)
+	svcID3   = flux.ServiceID(ns2 + "/" + svcName3)
+	svc1     = cluster.Service{
+		ID: svcID1,
+		Containers: cluster.ContainersOrExcuse{
+			Containers: []cluster.Container{
+				{
+					Name:  "alpine",
+					Image: "alpine:3.6",
+				},
+			},
+		},
+	}
+	svc2 = cluster.Service{
+		ID: svcID2,
+		Containers: cluster.ContainersOrExcuse{
+			Containers: []cluster.Container{
+				{
+					Name:  "custom",
+					Image: "localhost:5000/my/image:latest",
+				},
+			},
+		},
+	}
+	svc3 = cluster.Service{
+		ID: svcID3,
+	}
+	host        = "hub.docker.io"
+	tmpl string = `
+    {
+        "auths": {
+            %q: {"auth": %q}
+        }
+    }`
+	okCreds                             string = base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	stringCreds                                = fmt.Sprintf(tmpl, host, okCreds)
+	testCredentials, testCredentialsErr        = registry.ParseCredentials([]byte(stringCreds))
+)
+
+type mockFluxAdapter struct {
+}
+
+func (*mockFluxAdapter) Services(namespace string) ([]cluster.Service, error) {
+	if namespace == ns1 {
+		return []cluster.Service{svc1, svc2}, nil
+	} else if namespace == ns2 {
+		return []cluster.Service{svc3}, nil
+	}
+	return []cluster.Service{svc1, svc2, svc3}, nil
+}
+
+func (*mockFluxAdapter) ImageCredentials(service cluster.Service) (registry.Credentials, error) {
+	switch service.ID.String() {
+	case svc1.ID.String():
+		return testCredentials, nil
+	default:
+		return registry.NoCredentials(), nil
+	}
+}
+
+type mockKubeAPI struct{}
+
+func (*mockKubeAPI) KubeServices(namespace string) (*v1.ServiceList, error) {
+	if namespace == ns1 {
+		return &v1.ServiceList{
+			Items: []v1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: ns1,
+						Name:      svcName1,
+					},
+				},
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: ns1,
+						Name:      svcName2,
+					},
+				},
+			},
+		}, nil
+	} else {
+		return &v1.ServiceList{
+			Items: []v1.Service{
+				{
+					ObjectMeta: v1.ObjectMeta{
+						Namespace: ns2,
+						Name:      svcName3,
+					},
+				},
+			},
+		}, nil
+	}
+}
+
+func (*mockKubeAPI) KubeService(ns, svc string) (*v1.Service, error) {
+	if ns == ns1 && svc == svcName1 {
+		return &v1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: ns1,
+				Name:      svcName1,
+			},
+		}, nil
+	}
+	return &v1.Service{}, errors.New("No service found")
+}
+
+func (*mockKubeAPI) KubeControllers(svc *v1.Service) ([]podController, error) {
+	if svc.Name == svcName1 {
+		return []podController{
+			{
+				Deployment: &v1beta1.Deployment{
+					Spec: v1beta1.DeploymentSpec{
+						Template: v1.PodTemplateSpec{
+							Spec: v1.PodSpec{
+								Containers: []v1.Container{
+									{
+										Name:  "test",
+										Image: "alpine:3.6",
+									},
+								},
+								ImagePullSecrets: []v1.LocalObjectReference{
+									{
+										Name: mysecret,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, nil
+	} else {
+		return []podController{}, nil
+	}
+}
+
+func (*mockKubeAPI) KubeSecrets(ns, secret string) (*v1.Secret, error) {
+	if ns == ns1 && secret == mysecret {
+		return &v1.Secret{
+			Type: v1.SecretTypeDockercfg,
+			Data: map[string][]byte{
+				v1.DockerConfigKey: []byte(stringCreds),
+			},
+		}, nil
+	}
+	return &v1.Secret{}, errors.New("Secret not found")
+}
+
+func (*mockKubeAPI) KubeNamespaces() (*v1.NamespaceList, error) {
+	return &v1.NamespaceList{
+		Items: []v1.Namespace{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: ns1,
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: ns2,
+				},
+			},
+		},
+	}, nil
+}
+
+func TestKubernetes_ImagesToFetch(t *testing.T) {
+	if testCredentialsErr != nil {
+		t.Fatal("Credentials weren't parsed properly", testCredentialsErr)
+	}
+	mock := mockFluxAdapter{}
+
+	f := NewImageFetcher(&mock, log.NewLogfmtLogger(os.Stderr))
+
+	// Call images to fetch
+	imageCreds := f.ImagesToFetch()
+
+	// Make sure it is what we expect
+	if len(imageCreds) != 2 {
+		t.Fatal("Incorrect number of image credentials", len(imageCreds))
+	}
+
+	// Find service with credentials
+	var credentials registry.Credentials
+	var image flux.ImageID
+	for k, imCred := range imageCreds {
+		if len(imCred.Hosts()) > 0 {
+			image = k
+			credentials = imCred
+			break
+		}
+	}
+
+	if len(credentials.Hosts()) != 1 {
+		t.Fatal("Wrong number of hosts returned", len(credentials.Hosts()))
+	} else if image.Image != "alpine" {
+		t.Fatal("Wrong image returned", image.Image)
+	} else if !reflect.DeepEqual(credentials.Hosts(), []string{host}) {
+		t.Fatal("Wrong credentials hosts returned", credentials.Hosts())
+	}
+}
+
+func TestKubernetes_FluxServiceCredentials(t *testing.T) {
+	mock := mockKubeAPI{}
+	sc := NewKubeFluxAdapter(&mock, log.NewLogfmtLogger(os.Stderr))
+
+	// All namespaces
+	svcs, err := sc.Services("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(svcs) != 3 {
+		t.Fatal("Expected three services. Got", len(svcs))
+	}
+	numNamespaces := make(map[string]string)
+	for _, v := range svcs {
+		ns, _ := v.ID.Components()
+		numNamespaces[ns] = ""
+	}
+	if len(numNamespaces) != 2 {
+		t.Fatal("Expecting services to live within two namespaces. Got", len(numNamespaces))
+	}
+
+	// Specific namespace
+	svcs, err = sc.Services(ns1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(svcs) != 2 {
+		t.Fatal("Expected three services. Got", len(svcs))
+	}
+	numNamespaces = make(map[string]string)
+	for _, v := range svcs {
+		ns, _ := v.ID.Components()
+		numNamespaces[ns] = ""
+	}
+	if len(numNamespaces) != 1 {
+		t.Fatal("Expecting services to live within two namespaces. Got", len(numNamespaces))
+	}
+
+	creds, err := sc.ImageCredentials(svc1)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if len(creds.Hosts()) != 1 {
+		t.Fatal("Expecting single host with credentials. Got", len(creds.Hosts()))
+	}
+	if creds.Hosts()[0] != host {
+		t.Fatal("Expected host of %q but got %q", host, creds.Hosts()[0])
+	}
+}
+
+func TestKubernetes_AllServices(t *testing.T) {
+	mock := mockFluxAdapter{}
+	c := Cluster{
+		fluxAdapter: &mock,
+	}
+	// All namespaces
+	svcs, err := c.AllServices("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(svcs) != 3 {
+		t.Fatal("Expected three services. Got", len(svcs))
+	}
+	numNamespaces := make(map[string]string)
+	for _, v := range svcs {
+		ns, _ := v.ID.Components()
+		numNamespaces[ns] = ""
+	}
+	if len(numNamespaces) != 2 {
+		t.Fatal("Expecting services to live within two namespaces. Got", len(numNamespaces))
+	}
+
+	// Specific namespace
+	svcs, err = c.AllServices(ns1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(svcs) != 2 {
+		t.Fatal("Expected three services. Got", len(svcs))
+	}
+	numNamespaces = make(map[string]string)
+	for _, v := range svcs {
+		ns, _ := v.ID.Components()
+		numNamespaces[ns] = ""
+	}
+	if len(numNamespaces) != 1 {
+		t.Fatal("Expecting services to live within two namespaces. Got", len(numNamespaces))
+	}
+}
+
+func TestKubernetes_SomeServices(t *testing.T) {
+	mock := mockFluxAdapter{}
+	c := Cluster{
+		fluxAdapter: &mock,
+	}
+	// One ID
+	svcs, err := c.SomeServices([]flux.ServiceID{svcID1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(svcs) != 1 {
+		t.Fatal("Expected three services. Got", len(svcs))
+	}
+	if svcs[0].ID.String() != svcID1.String() {
+		t.Fatal("Did not return expected service id", svcs[0].ID.String())
+	}
+	if len(svcs[0].Containers.Containers) == 0 {
+		t.Fatal("Service didn't return any containers, even though they are mocked")
+	}
+
+	// Multiple services
+	svcs, err = c.SomeServices([]flux.ServiceID{svcID1, svcID3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(svcs) != 2 {
+		t.Fatal("Expected three services. Got", len(svcs))
+	}
+	numNamespaces := make(map[string]string)
+	for _, v := range svcs {
+		ns, _ := v.ID.Components()
+		numNamespaces[ns] = ""
+	}
+	if len(numNamespaces) != 2 {
+		t.Fatal("Expecting services to live within two namespaces. Got", len(numNamespaces))
 	}
 }


### PR DESCRIPTION
The reason for this refactor is to allow testing k8s methods.
This is achieved by introducing two levels of interface. A low-level
KubeAPI, which encapsulates all the required kubernetes API calls and
a mid-level KubeFluxAdapter interface which signifies the change from
the kubernetes domain (v1.*) to the flux domain (flux.Service).

- Tests added by mocking out these interfaces
- Code moved around to make the interfaces more prominent
- Main altered to adhere to new interfaces
- AllServices and SomeServices (core api methods) have been altered
to use the new interfaces. Tests have been added.
- Sync, Export and Ping haven't been altered yet

A quick note on the SomeServices change. I decided to simply list all
services then filter for the ones requested to allow testing, simplify
the code and avoid adding more methods to the KubeAPI interface.
Previously it hit the raw k8s API to get each namespace, get a requested
service for that ns then find all `podController`s for the service. This
change results in a few more calls than necessary going to the k8s api,
but I deemed this acceptable to reduce the API and add tests.