### PR TITLE
[WIP] An edgy test case with Istio example

### DIFF
--- a/cluster/kubernetes/files.go
+++ b/cluster/kubernetes/files.go
@@ -37,7 +37,7 @@ func (c *Manifests) FindDefinedServices(path string) (map[flux.ServiceID][]strin
 			for _, template := range templates {
 				if res.Meta.Namespace == template.namespace && matches(res, template.PodTemplate) {
 					sid := res.ServiceID()
-					result[sid] = append(result[sid], template.source)
+					result[sid] = appendIfMissing(result[sid], template.source)
 				}
 			}
 		case *resource.Deployment:
@@ -46,7 +46,7 @@ func (c *Manifests) FindDefinedServices(path string) (map[flux.ServiceID][]strin
 			for _, service := range services {
 				if res.Meta.Namespace == service.Meta.Namespace && matches(service, &res.Spec.Template) {
 					sid := service.ServiceID()
-					result[sid] = append(result[sid], source)
+					result[sid] = appendIfMissing(result[sid], source)
 				}
 			}
 		}
@@ -70,4 +70,13 @@ func matches(s *resource.Service, t *resource.PodTemplate) bool {
 		}
 	}
 	return true
+}
+
+func appendIfMissing(slice []string, i string) []string {
+	for _, v := range slice {
+		if v == i {
+			return slice
+		}
+	}
+	return append(slice, i)
 }

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -29,8 +29,7 @@ func TestParseEmpty(t *testing.T) {
 }
 
 func TestParseSome(t *testing.T) {
-	docs := `---
-kind: Service
+	docs := `kind: Service
 metadata:
   name: b-service
   namespace: b-namespace

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -77,8 +77,8 @@ func TestLoadSome(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// assume it's one per file for the minute
-	if len(objs) != len(testfiles.Files) {
-		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testfiles.Files), len(testfiles.Files), objs)
+	// assume it's at least one per file for the minute
+	if len(objs) < len(testfiles.Files) {
+		t.Errorf("expected at least %d objects from %d files, got %d object:\n%#v", len(testfiles.Files), len(testfiles.Files), len(objs), objs)
 	}
 }

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -45,6 +45,7 @@ func ServiceMap(dir string) map[flux.ServiceID][]string {
 		flux.ServiceID("default/helloworld"):     []string{filepath.Join(dir, "helloworld-deploy.yaml")},
 		flux.ServiceID("default/locked-service"): []string{filepath.Join(dir, "locked-service-deploy.yaml")},
 		flux.ServiceID("default/test-service"):   []string{filepath.Join(dir, "test-service-deploy.yaml")},
+		flux.ServiceID("default/reviews"):        []string{filepath.Join(dir, "istio-reviews-example.yaml")},
 	}
 }
 
@@ -146,5 +147,215 @@ spec:
     - port: 80
   selector:
     name: test-service
+`,
+	"istio-reviews-example.yaml": `# Copyright 2017 Istio Authors
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+##################################################################################################
+# Reviews service
+##################################################################################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: reviews
+  labels:
+    app: reviews
+spec:
+  ports:
+  - port: 9080
+    name: http
+  selector:
+    app: reviews
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: reviews-v1
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: injected
+        alpha.istio.io/version: jenkins@ubuntu-16-04-build-12ac793f80be71-0.1.6-dab2033
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"istio/init:0.1","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}},{"args":["-c","sysctl
+          -w kernel.core_pattern=/tmp/core.%e.%p.%t \u0026\u0026 ulimit -c unlimited"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
+      creationTimestamp: null
+      labels:
+        app: reviews
+        version: v1
+    spec:
+      containers:
+      - image: istio/examples-bookinfo-reviews-v1
+        imagePullPolicy: IfNotPresent
+        name: reviews
+        ports:
+        - containerPort: 9080
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - -v
+        - "2"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: istio/proxy_debug:0.1
+        imagePullPolicy: Always
+        name: proxy
+        resources: {}
+        securityContext:
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/certs
+          name: istio-certs
+          readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.default
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: reviews-v2
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: injected
+        alpha.istio.io/version: jenkins@ubuntu-16-04-build-12ac793f80be71-0.1.6-dab2033
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"istio/init:0.1","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}},{"args":["-c","sysctl
+          -w kernel.core_pattern=/tmp/core.%e.%p.%t \u0026\u0026 ulimit -c unlimited"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
+      creationTimestamp: null
+      labels:
+        app: reviews
+        version: v2
+    spec:
+      containers:
+      - image: istio/examples-bookinfo-reviews-v2
+        imagePullPolicy: IfNotPresent
+        name: reviews
+        ports:
+        - containerPort: 9080
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - -v
+        - "2"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: istio/proxy_debug:0.1
+        imagePullPolicy: Always
+        name: proxy
+        resources: {}
+        securityContext:
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/certs
+          name: istio-certs
+          readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.default
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  name: reviews-v3
+spec:
+  replicas: 1
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        alpha.istio.io/sidecar: injected
+        alpha.istio.io/version: jenkins@ubuntu-16-04-build-12ac793f80be71-0.1.6-dab2033
+        pod.beta.kubernetes.io/init-containers: '[{"args":["-p","15001","-u","1337"],"image":"istio/init:0.1","imagePullPolicy":"Always","name":"init","securityContext":{"capabilities":{"add":["NET_ADMIN"]}}},{"args":["-c","sysctl
+          -w kernel.core_pattern=/tmp/core.%e.%p.%t \u0026\u0026 ulimit -c unlimited"],"command":["/bin/sh"],"image":"alpine","imagePullPolicy":"Always","name":"enable-core-dump","securityContext":{"privileged":true}}]'
+      creationTimestamp: null
+      labels:
+        app: reviews
+        version: v3
+    spec:
+      containers:
+      - image: istio/examples-bookinfo-reviews-v3
+        imagePullPolicy: IfNotPresent
+        name: reviews
+        ports:
+        - containerPort: 9080
+        resources: {}
+      - args:
+        - proxy
+        - sidecar
+        - -v
+        - "2"
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        image: istio/proxy_debug:0.1
+        imagePullPolicy: Always
+        name: proxy
+        resources: {}
+        securityContext:
+          runAsUser: 1337
+        volumeMounts:
+        - mountPath: /etc/certs
+          name: istio-certs
+          readOnly: true
+      volumes:
+      - name: istio-certs
+        secret:
+          secretName: istio.default
 `,
 }

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -89,7 +89,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ServiceIDs{"default/locked-service", "default/test-service", "default/helloworld"}
+	expectedServiceIDs := flux.ServiceIDs{"default/locked-service", "default/test-service", "default/helloworld", "default/reviews"}
 	expectedServiceIDs.Sort()
 	k8s.SyncFunc = func(def cluster.SyncDef) error {
 		syncCalled++
@@ -144,7 +144,7 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ServiceIDs{"default/locked-service", "default/test-service", "default/helloworld"}
+	expectedServiceIDs := flux.ServiceIDs{"default/locked-service", "default/test-service", "default/helloworld", "default/reviews"}
 	expectedServiceIDs.Sort()
 	k8s.SyncFunc = func(def cluster.SyncDef) error {
 		syncCalled++
@@ -215,7 +215,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ServiceIDs{"default/locked-service", "default/test-service", "default/helloworld"}
+	expectedServiceIDs := flux.ServiceIDs{"default/locked-service", "default/test-service", "default/helloworld", "default/reviews"}
 	expectedServiceIDs.Sort()
 	k8s.SyncFunc = func(def cluster.SyncDef) error {
 		syncCalled++

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -149,6 +149,7 @@ func checkClusterMatchesFiles(t *testing.T, m cluster.Manifests, c cluster.Clust
 	}
 	resources, err := m.ParseManifests(conf)
 	if err != nil {
+		fmt.Printf("--- # begin contents:\n%s\n--- # end contents", conf)
 		t.Fatal(err)
 	}
 	files, err := m.LoadManifests(dir)

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -149,7 +149,7 @@ func checkClusterMatchesFiles(t *testing.T, m cluster.Manifests, c cluster.Clust
 	}
 	resources, err := m.ParseManifests(conf)
 	if err != nil {
-		fmt.Printf("--- # begin contents:\n%s\n--- # end contents", conf)
+		fmt.Printf("--- # begin bad conf\n%s\n--- # end bad conf\n", conf)
 		t.Fatal(err)
 	}
 	files, err := m.LoadManifests(dir)


### PR DESCRIPTION
While playing with Istio, I've encotered an issue with Flux failing to parse a manifest that contains 1 service and 3 deployments.

The reviews service is defind as part of a larger [multi-doc manifest]( https://github.com/istio/istio/blob/release-0.1/samples/apps/bookinfo/bookinfo.yaml#L85-L156). In order to enable it with Istion sidecars, one has to use `istioctl kube-inject`, and only after that it becomes consumable by Flux. I've checked in the output of `istioctl kube-inject` into a repo of my own and split the app into smaller [multi-docs](https://github.com/errordeveloper/istio-gitops/blob/bc1f39c739c9b5676cf252eeada9f79042a727bd/app/reviews.yaml), and hooked it up to Flux (using v1.0.0-beta).

Flux tripped over this with an obscure error message:
```
ts=2017-08-09T14:58:11Z caller=loop.go:132 component=sync-loop err="Service default/reviews: running kubectl: error: error validating \"STDIN\": error validating data: field spec.template.spec.containers[0].name for v1.Container is required; if you choose to ignore these errors, turn validation off with --validate=false; Deployment default/reviews-v1: yaml: line 1: mapping values are not allowed in this context"
```
I've test the manifest using `kubectl apply` and it worked just fine.

I then broke the manifest into 4 (1 for the service, and one for each of the deployments), and that worked fine with Flux (see [`reviews*.yaml`](https://github.com/errordeveloper/istio-gitops/tree/9890d9a666a0e9061f9888e2bd0ece02f0b0bd3a/app)).
I've then combined deployments into one file, and that gave me a new error:
```
ts=2017-08-09T16:34:53Z caller=loop.go:132 component=sync-loop err="Deployment default/reviews-v1: running kubectl: The Deployment \"reviews-v3\" is invalid: \n* spec.template.metadata.labels: Invalid value: map[string]string(nil): `selector` does not match template `labels`\n* spec.template.spec.containers: Required value"
```
So I realised something must be a litte odd here.

In this PR I've added a test case with large multi-doc and after I've made some trivial updates in the tests, I've discovered that we end-up with a bit of a mess:

- [a fragment of `PodSpec` for one of the `review-v?` deployments](https://gist.github.com/errordeveloper/e8851a23e87951e26ddbb0692f6a7ae2#file-flux-istio-example-test-L95-L130)
- [a top fragment of `reviews-3` deployment](https://gist.github.com/errordeveloper/e8851a23e87951e26ddbb0692f6a7ae2#file-flux-istio-example-test-L132-L154) (there is also separate [full-copy of it](https://gist.github.com/errordeveloper/e8851a23e87951e26ddbb0692f6a7ae2#file-flux-istio-example-test-L217-L276))
- [a top fragment of `reviews-2` deployment](https://gist.github.com/errordeveloper/e8851a23e87951e26ddbb0692f6a7ae2#file-flux-istio-example-test-L310-L332)