### PR TITLE
Add timeout to git command

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -19,6 +19,7 @@ import (
 	k8sclient "k8s.io/client-go/1.5/kubernetes"
 	"k8s.io/client-go/1.5/rest"
 
+	"context"
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/cluster/kubernetes"
@@ -328,7 +329,9 @@ func main() {
 		}
 
 		for checkout == nil {
-			working, err := repo.Clone(gitConfig)
+			ctx, cancel := context.WithTimeout(context.Background(), git.DefaultCloneTimeout)
+			working, err := repo.Clone(ctx, gitConfig)
+			cancel()
 			if err != nil {
 				if checker == nil {
 					checker = checkForUpdates(clusterVersion, "false", updateCheckLogger)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"context"
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
@@ -338,7 +339,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), *cluster.Mock, history.EventRead
 		SyncTag:   "flux-test",
 		NotesRef:  "fluxtest",
 	}
-	checkout, err := repo.Clone(params)
+	checkout, err := repo.Clone(context.Background(), params)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"context"
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 	"github.com/weaveworks/flux/git"
@@ -58,7 +59,7 @@ func Checkout(t *testing.T) (*git.Checkout, func()) {
 		SyncTag:   "flux-test",
 		NotesRef:  "fluxtest",
 	}
-	co, err := repo.Clone(config)
+	co, err := repo.Clone(context.Background(), config)
 	if err != nil {
 		cleanup()
 		t.Fatal(err)

--- a/git/operations_test.go
+++ b/git/operations_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"context"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 	"io/ioutil"
 	"os/exec"
@@ -19,7 +20,7 @@ func TestChangedFiles_SlashPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = changedFiles(newDir, nestedDir, "HEAD")
+	_, err = changedFiles(context.Background(), newDir, nestedDir, "HEAD")
 	if err == nil {
 		t.Fatal("Should have errored")
 	}
@@ -36,7 +37,7 @@ func TestChangedFiles_UnslashPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = changedFiles(newDir, nestedDir, "HEAD")
+	_, err = changedFiles(context.Background(), newDir, nestedDir, "HEAD")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -53,7 +54,7 @@ func TestChangedFiles_NoPath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = changedFiles(newDir, nestedDir, "HEAD")
+	_, err = changedFiles(context.Background(), newDir, nestedDir, "HEAD")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/kit/log"
 
 	//	"github.com/weaveworks/flux"
+	"context"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/cluster/kubernetes"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
@@ -47,7 +48,7 @@ func TestSync(t *testing.T) {
 		if err := execCommand("rm", filepath.Join(checkout.ManifestDir(), file)); err != nil {
 			t.Fatal(err)
 		}
-		if err := checkout.CommitAndPush("deleted "+file, nil); err != nil {
+		if err := checkout.CommitAndPush(context.Background(), "deleted "+file, nil); err != nil {
 			t.Fatal(err)
 		}
 		break
@@ -77,7 +78,7 @@ func setup(t *testing.T) (*git.Checkout, func()) {
 	repo, cleanupRepo := gittest.Repo(t)
 
 	// Clone the repo so we can mess with the files
-	working, err := repo.Clone(gitconf)
+	working, err := repo.Clone(context.Background(), gitconf)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
To mitigate against any low level execution problems, add a context timeout to git commands so that if they fail, it won't cause subsequent requests to back up. This mitigates against #714.