### PR TITLE
Optimisation - reduce git note gets

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -176,7 +176,7 @@ func (d *Daemon) doSync(logger log.Logger) {
 		serviceIDs.Add(r.ServiceIDs(allResources))
 	}
 
-	notes, err := working.NoteRevList()
+	notes, err := working.NoteRevList(ctx)
 	if err != nil {
 		logger.Log("err", errors.Wrap(err, "loading notes from repo"))
 		return

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -176,6 +176,12 @@ func (d *Daemon) doSync(logger log.Logger) {
 		serviceIDs.Add(r.ServiceIDs(allResources))
 	}
 
+	notes, err := working.NoteRevList()
+	if err != nil {
+		logger.Log("err", errors.Wrap(err, "loading notes from repo"))
+		return
+	}
+
 	// Collect any events that come from notes attached to the commits
 	// we just synced. While we're doing this, keep track of what
 	// other things this sync includes e.g., releases and
@@ -187,6 +193,10 @@ func (d *Daemon) doSync(logger log.Logger) {
 
 		// Find notes in revisions.
 		for i := len(commits) - 1; i >= 0; i-- {
+			if ok := notes[commits[i].Revision]; !ok {
+				includes[history.NoneOfTheAbove] = true
+				continue
+			}
 			n, err := working.GetNote(ctx, commits[i].Revision)
 			if err != nil {
 				logger.Log("err", errors.Wrap(err, "loading notes from repo; possibly no notes"))

--- a/git/operations.go
+++ b/git/operations.go
@@ -123,9 +123,9 @@ func getNote(ctx context.Context, workingDir, notesRef, rev string) (*Note, erro
 // Get all revisions with a note (NB: DO NOT RELY ON THE ORDERING)
 // It appears to be ordered by ascending git object ref, not by time.
 // Return a map to make it easier to do "if in" type queries.
-func noteRevList(workingDir, notesRef string) (map[string]bool, error) {
+func noteRevList(ctx context.Context, workingDir, notesRef string) (map[string]bool, error) {
 	out := &bytes.Buffer{}
-	if err := execGitCmd(workingDir, nil, out, "notes", "--ref", notesRef, "list"); err != nil {
+	if err := execGitCmd(ctx, workingDir, nil, out, "notes", "--ref", notesRef, "list"); err != nil {
 		return nil, err
 	}
 	noteList := splitList(out.String())

--- a/git/operations.go
+++ b/git/operations.go
@@ -120,6 +120,25 @@ func getNote(ctx context.Context, workingDir, notesRef, rev string) (*Note, erro
 	return &note, nil
 }
 
+// Get all revisions with a note (NB: DO NOT RELY ON THE ORDERING)
+// It appears to be ordered by ascending git object ref, not by time.
+// Return a map to make it easier to do "if in" type queries.
+func noteRevList(workingDir, notesRef string) (map[string]bool, error) {
+	out := &bytes.Buffer{}
+	if err := execGitCmd(workingDir, nil, out, "notes", "--ref", notesRef, "list"); err != nil {
+		return nil, err
+	}
+	noteList := splitList(out.String())
+	result := make(map[string]bool, len(noteList))
+	for _, l := range noteList {
+		split := strings.Fields(l)
+		if len(split) > 0 {
+			result[split[1]] = true // First field contains the object ref (commit id in our case)
+		}
+	}
+	return result, nil
+}
+
 // Get the commit hash for a reference
 func refRevision(ctx context.Context, path, ref string) (string, error) {
 	out := &bytes.Buffer{}

--- a/git/operations.go
+++ b/git/operations.go
@@ -258,6 +258,8 @@ func findErrorMessage(output io.Reader) string {
 		switch {
 		case strings.HasPrefix(sc.Text(), "fatal: "):
 			return sc.Text()
+		case strings.HasPrefix(sc.Text(), "ERROR fatal: "): // Saw this error on ubuntu systems
+			return sc.Text()
 		case strings.HasPrefix(sc.Text(), "error:"):
 			return strings.Trim(sc.Text(), "error: ")
 		}

--- a/git/operations_test.go
+++ b/git/operations_test.go
@@ -1,8 +1,8 @@
 package git
 
 import (
-	"fmt"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os/exec"
 	"path"
@@ -39,7 +39,7 @@ func TestListNotes_2Notes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	notes, err := noteRevList(newDir, testNoteRef)
+	notes, err := noteRevList(context.Background(), newDir, testNoteRef)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestListNotes_2Notes(t *testing.T) {
 		t.Fatal("expected two notes")
 	}
 	for n := range notes {
-		note, err := getNote(newDir, testNoteRef, n)
+		note, err := getNote(context.Background(), newDir, testNoteRef, n)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -71,7 +71,7 @@ func TestListNotes_0Notes(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	notes, err := noteRevList(newDir, testNoteRef)
+	notes, err := noteRevList(context.Background(), newDir, testNoteRef)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -84,7 +84,7 @@ func TestListNotes_0Notes(t *testing.T) {
 func testNote(dir, rev string) (job.ID, error) {
 	id := job.ID(fmt.Sprintf("%v", noteIdCounter))
 	noteIdCounter += 1
-	err := addNote(dir, rev, testNoteRef, &Note{
+	err := addNote(context.Background(), dir, rev, testNoteRef, &Note{
 		id,
 		update.Spec{
 			update.Auto,
@@ -156,7 +156,7 @@ func createRepo(dir string, nestedDir string) error {
 	if err = execCommand("git", "-C", dir, "init"); err != nil {
 		return err
 	}
-	if err := config(dir, "operations_test_user", "example@example.com"); err != nil {
+	if err := config(context.Background(), dir, "operations_test_user", "example@example.com"); err != nil {
 		return err
 	}
 	if err := execCommand("mkdir", "-p", fullPath); err != nil {

--- a/git/repo.go
+++ b/git/repo.go
@@ -239,3 +239,9 @@ func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, erro
 	}
 	return list, err
 }
+
+func (c *Checkout) NoteRevList() (map[string]bool, error) {
+	c.Lock()
+	defer c.Unlock()
+	return noteRevList(c.Dir, c.SyncTag)
+}

--- a/git/repo.go
+++ b/git/repo.go
@@ -240,8 +240,8 @@ func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, erro
 	return list, err
 }
 
-func (c *Checkout) NoteRevList() (map[string]bool, error) {
+func (c *Checkout) NoteRevList(ctx context.Context) (map[string]bool, error) {
 	c.Lock()
 	defer c.Unlock()
-	return noteRevList(c.Dir, c.SyncTag)
+	return noteRevList(ctx, c.Dir, c.SyncTag)
 }


### PR DESCRIPTION
This is an optimisation to reduce the number of `gitExecCommand` calls due to repeated requests to see if a commit has a note.

First a method to get the notes was added and the results are placed in a map. I used a map to make it easier to do "is this commid id in the map" type queries later.

Next I added a check in the main loop to see if the current commit has a note. If not, continue.

An optimisation for #714.