### PR TITLE
Push context deadlines inside jobs and sync ops

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"context"
 	"github.com/go-kit/kit/log"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/cluster/kubernetes"
@@ -304,7 +305,7 @@ func TestDaemon_JobStatusWithNoCache(t *testing.T) {
 }
 
 func mockDaemon(t *testing.T) (*Daemon, func(), *cluster.Mock, history.EventReadWriter) {
-	logger := log.NewLogfmtLogger(os.Stdout)
+	logger := log.NewNopLogger()
 
 	singleService := cluster.Service{
 		ID: flux.ServiceID(svc),
@@ -500,6 +501,7 @@ func updatePolicy(t *testing.T, d *Daemon) job.ID {
 		},
 	})
 }
+
 func updateManifest(t *testing.T, d *Daemon, spec update.Spec) job.ID {
 	id, err := d.UpdateManifests(spec)
 	if err != nil {

--- a/git/operations.go
+++ b/git/operations.go
@@ -123,17 +123,17 @@ func getNote(ctx context.Context, workingDir, notesRef, rev string) (*Note, erro
 // Get all revisions with a note (NB: DO NOT RELY ON THE ORDERING)
 // It appears to be ordered by ascending git object ref, not by time.
 // Return a map to make it easier to do "if in" type queries.
-func noteRevList(ctx context.Context, workingDir, notesRef string) (map[string]bool, error) {
+func noteRevList(ctx context.Context, workingDir, notesRef string) (map[string]struct{}, error) {
 	out := &bytes.Buffer{}
 	if err := execGitCmd(ctx, workingDir, nil, out, "notes", "--ref", notesRef, "list"); err != nil {
 		return nil, err
 	}
 	noteList := splitList(out.String())
-	result := make(map[string]bool, len(noteList))
+	result := make(map[string]struct{}, len(noteList))
 	for _, l := range noteList {
 		split := strings.Fields(l)
 		if len(split) > 0 {
-			result[split[1]] = true // First field contains the object ref (commit id in our case)
+			result[split[1]] = struct{}{} // First field contains the object ref (commit id in our case)
 		}
 	}
 	return result, nil

--- a/git/repo.go
+++ b/git/repo.go
@@ -169,7 +169,7 @@ func (c *Checkout) CommitAndPush(ctx context.Context, commitMessage string, note
 	return nil
 }
 
-// GetNote gets a note for the revision specified, or "" if there is no such note.
+// GetNote gets a note for the revision specified, or nil if there is no such note.
 func (c *Checkout) GetNote(ctx context.Context, rev string) (*Note, error) {
 	c.RLock()
 	defer c.RUnlock()
@@ -240,8 +240,8 @@ func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, erro
 	return list, err
 }
 
-func (c *Checkout) NoteRevList(ctx context.Context) (map[string]bool, error) {
+func (c *Checkout) NoteRevList(ctx context.Context) (map[string]struct{}, error) {
 	c.Lock()
 	defer c.Unlock()
-	return noteRevList(ctx, c.Dir, c.SyncTag)
+	return noteRevList(ctx, c.Dir, c.realNotesRef)
 }


### PR DESCRIPTION
Synchronising with the cluster can easily take tens of seconds, so it is better to have timeouts for individual operations or small batches of operations, rather than the whole thing.

Similarly, jobs can wait in the job queue for e.g., syncs to happen, so it is necessary to time them from when they _start_, not when they are requested.

Lastly, fix and use `git.Repo.NoteRevList` when answering JobStatus from commit notes, since that is exactly the expensive batch of git operations that motivated it.