### PR TITLE
Export sync and jobs metrics

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -135,9 +135,11 @@ type DaemonJobFunc func(ctx context.Context, jobID job.ID, working *git.Checkout
 // Must cancel the context once this job is complete
 func (d *Daemon) queueJob(do DaemonJobFunc) job.ID {
 	id := job.ID(guid.New())
+	enqueuedAt := time.Now()
 	d.Jobs.Enqueue(&job.Job{
 		ID: id,
 		Do: func(logger log.Logger) error {
+			queueDuration.Observe(time.Since(enqueuedAt).Seconds())
 			started := time.Now().UTC()
 			ctx, cancel := context.WithTimeout(context.Background(), defaultJobTimeout)
 			defer cancel()
@@ -176,6 +178,7 @@ func (d *Daemon) queueJob(do DaemonJobFunc) job.ID {
 			return nil
 		},
 	})
+	queueLength.Set(float64(d.Jobs.Len()))
 	d.JobStatusCache.SetStatus(id, job.Status{StatusString: job.StatusQueued})
 	return id
 }

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -85,6 +85,7 @@ func (d *Daemon) GitPollLoop(stop chan struct{}, wg *sync.WaitGroup, logger log.
 			// about to do that)
 			d.askForSync()
 		case job := <-d.Jobs.Ready():
+			queueLength.Set(float64(d.Jobs.Len()))
 			jobLogger := log.NewContext(logger).With("jobID", job.ID)
 			jobLogger.Log("state", "in-progress")
 			// It's assumed that (successful) jobs will push commits

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -14,7 +14,7 @@ var (
 		Namespace: "flux",
 		Subsystem: "daemon",
 		Name:      "sync_duration_seconds",
-		Help:      "Duration of git-to-cluster syncs, in seconds.",
+		Help:      "Duration of git-to-cluster synchronisation, in seconds.",
 		Buckets:   []float64{0.5, 5, 10, 20, 30, 40, 50, 60, 75, 90, 120, 240},
 	}, []string{fluxmetrics.LabelSuccess})
 
@@ -24,7 +24,24 @@ var (
 		Namespace: "flux",
 		Subsystem: "daemon",
 		Name:      "job_duration_seconds",
-		Help:      "Duration of jobs, in seconds.",
+		Help:      "Duration of job execution, in seconds.",
 		Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 15, 20, 30, 45, 60, 120},
 	}, []string{fluxmetrics.LabelSuccess})
+
+	// Same buckets as above (on the rough and ready assumption that
+	// jobs will wait for some small multiple of job execution times)
+	queueDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "queue_duration_seconds",
+		Help:      "Duration of time spent in the job queue before execution, in seconds.",
+		Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 15, 20, 30, 45, 60, 120},
+	}, []string{})
+
+	queueLength = prometheus.NewGaugeFrom(stdprometheus.GaugeOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "queue_length_count",
+		Help:      "Count of jobs waiting in the queue to be run.",
+	}, []string{})
 )

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -1,0 +1,18 @@
+package daemon
+
+import (
+	"github.com/go-kit/kit/metrics/prometheus"
+	stdprometheus "github.com/prometheus/client_golang/prometheus"
+
+	fluxmetrics "github.com/weaveworks/flux/metrics"
+)
+
+var (
+	syncDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "sync_duration_seconds",
+		Help:      "Duration of git-to-cluster syncs, in seconds.",
+		Buckets:   stdprometheus.ExponentialBuckets(0.2, 3, 8), // top bucket ~= 21 minutes
+	}, []string{fluxmetrics.LabelSuccess})
+)

--- a/daemon/metrics.go
+++ b/daemon/metrics.go
@@ -8,11 +8,23 @@ import (
 )
 
 var (
+	// For us, syncs (of about 100 resources) take about thirty
+	// seconds to a minute. Most short-lived (<1s) syncs will be failures.
 	syncDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
 		Namespace: "flux",
 		Subsystem: "daemon",
 		Name:      "sync_duration_seconds",
 		Help:      "Duration of git-to-cluster syncs, in seconds.",
-		Buckets:   stdprometheus.ExponentialBuckets(0.2, 3, 8), // top bucket ~= 21 minutes
+		Buckets:   []float64{0.5, 5, 10, 20, 30, 40, 50, 60, 75, 90, 120, 240},
+	}, []string{fluxmetrics.LabelSuccess})
+
+	// For most jobs, the majority of the time will be spent pushing
+	// changes (git objects and refs) upstream.
+	jobDuration = prometheus.NewHistogramFrom(stdprometheus.HistogramOpts{
+		Namespace: "flux",
+		Subsystem: "daemon",
+		Name:      "job_duration_seconds",
+		Help:      "Duration of jobs, in seconds.",
+		Buckets:   []float64{0.1, 0.5, 1, 2, 5, 10, 15, 20, 30, 45, 60, 120},
 	}, []string{fluxmetrics.LabelSuccess})
 )


### PR DESCRIPTION
Adds metrics for the sync/job loop:

 * histogram of duration of syncs
 * histogram of duration of job execution
 * histogram of duration in job queue (waiting to be executed)
 * gauge of queue length

The histograms have custom buckets, since the default buckets are suitable for network calls but not things that involve tens of operations (e.g., syncing).