### PR TITLE
Save locked user and message to annotations

### DIFF
--- a/cluster/kubernetes/resource/load.go
+++ b/cluster/kubernetes/resource/load.go
@@ -46,7 +46,7 @@ func Load(roots ...string) (map[string]resource.Resource, error) {
 	return objs, nil
 }
 
-// ParseManifests takes a dump of config (a multidoc YAML) and
+// ParseMultidoc takes a dump of config (a multidoc YAML) and
 // constructs an object set from the resources represented therein.
 func ParseMultidoc(multidoc []byte, source string) (map[string]resource.Resource, error) {
 	objs := map[string]resource.Resource{}

--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -51,8 +51,13 @@ func (o baseObject) ServiceIDs(all map[string]resource.Resource) []flux.ServiceI
 func (o baseObject) Policy() policy.Set {
 	set := policy.Set{}
 	for k, v := range o.Meta.Annotations {
-		if strings.HasPrefix(k, PolicyPrefix) && v == "true" {
-			set = set.Add(policy.Policy(strings.TrimPrefix(k, PolicyPrefix)))
+		if strings.HasPrefix(k, PolicyPrefix) {
+			p := strings.TrimPrefix(k, PolicyPrefix)
+			if v == "true" {
+				set = set.Add(policy.Policy(p))
+			} else {
+				set = set.Set(policy.Policy(p), v)
+			}
 		}
 	}
 	return set

--- a/cmd/fluxctl/lock_cmd.go
+++ b/cmd/fluxctl/lock_cmd.go
@@ -47,8 +47,16 @@ func (opts *serviceLockOpts) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	lockedPolicy := policy.Set{policy.Locked: "true"}
+	if opts.cause.User != "" {
+		lockedPolicy = lockedPolicy.Set(policy.LockedUser, opts.cause.User)
+	}
+	if opts.cause.Message != "" {
+		lockedPolicy = lockedPolicy.Set(policy.LockedMsg, opts.cause.Message)
+	}
+
 	jobID, err := opts.API.UpdatePolicies(noInstanceID, policy.Updates{
-		serviceID: policy.Update{Add: policy.Set{policy.Locked: "true"}},
+		serviceID: policy.Update{Add: lockedPolicy},
 	}, opts.cause)
 	if err != nil {
 		return err

--- a/cmd/fluxctl/unlock_cmd.go
+++ b/cmd/fluxctl/unlock_cmd.go
@@ -48,8 +48,11 @@ func (opts *serviceUnlockOpts) RunE(cmd *cobra.Command, args []string) error {
 	}
 
 	jobID, err := opts.API.UpdatePolicies(noInstanceID, policy.Updates{
-		serviceID: policy.Update{Remove: policy.Set{policy.Locked: "true"}},
-	}, opts.cause)
+		serviceID: policy.Update{Remove: policy.Set{
+			policy.Locked:     "true",
+			policy.LockedMsg:  "",
+			policy.LockedUser: "",
+		}}}, opts.cause)
 	if err != nil {
 		return err
 	}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -8,10 +8,12 @@ import (
 )
 
 const (
-	Ignore    = Policy("ignore")
-	Locked    = Policy("locked")
-	Automated = Policy("automated")
-	TagAll    = Policy("tag_all")
+	Ignore     = Policy("ignore")
+	Locked     = Policy("locked")
+	LockedUser = Policy("locked_user")
+	LockedMsg  = Policy("locked_msg")
+	Automated  = Policy("automated")
+	TagAll     = Policy("tag_all")
 )
 
 // Policy is an string, denoting the current deployment policy of a service,

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -7,12 +7,16 @@ import (
 )
 
 func TestJSON(t *testing.T) {
-	policy := Set{}
-	policy = policy.Add(Ignore)
-	policy = policy.Add(Locked)
+	boolPolicy := Set{}
+	boolPolicy = boolPolicy.Add(Ignore)
+	boolPolicy = boolPolicy.Add(Locked)
+	policy := boolPolicy.Set(LockedUser, "user@example.com")
 
 	if !(policy.Contains(Ignore) && policy.Contains(Locked)) {
 		t.Errorf("Policy did not include those added")
+	}
+	if val, ok := policy.Get(LockedUser); !ok || val != "user@example.com" {
+		t.Errorf("Policy did not include policy that was set")
 	}
 
 	bs, err := json.Marshal(policy)
@@ -37,7 +41,7 @@ func TestJSON(t *testing.T) {
 	if err = json.Unmarshal(bs, &policy2); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(policy, policy2) {
+	if !reflect.DeepEqual(boolPolicy, policy2) {
 		t.Errorf("Parsing equivalent list did not preserve policy. Expected:\n%#v\nGot:\n%#v\n", policy, policy2)
 	}
 }


### PR DESCRIPTION
 * add a policy for the user and message given when locking
 * set them in `fluxctl lock` and clear them in `fluxctl unlock`

They will appear in the annotations of the object, and in the result
of the list-services API call. (But not in the output of `fluxctl
list-services`)