### PR TITLE
Wait for platform presence in fluxsvc test

### DIFF
--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -114,7 +114,10 @@ func setup(t *testing.T) {
 		},
 	}
 	done := make(chan error)
-	messageBus.Subscribe(id, mockPlatform, done) // For ListService
+	messageBus.Subscribe(id, mockPlatform, done)
+	if err := messageBus.AwaitPresence(id, 5*time.Second); err != nil {
+		t.Errorf("Timed out waiting for presence of mockPlatform")
+	}
 
 	// History
 	hDb, _ := historysql.NewSQL(dbDriver, databaseSource)
@@ -346,7 +349,7 @@ func TestFluxsvc_Ping(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Fatal("Request should have been ok but got %q, body:\n%v", resp.Status, body)
+		t.Fatal("Request should have been ok but got %q, body:\n%q", resp.Status, string(body))
 	}
 }
 
@@ -371,6 +374,6 @@ func TestFluxsvc_Register(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.Fatal("Request should have been ok but got %q, body:\n%v", resp.Status, body)
+		t.Fatal("Request should have been ok but got %q, body:\n%q", resp.Status, string(body))
 	}
 }


### PR DESCRIPTION
One source of flakes appears to be the race between the platform being registered and seeing if the platform is registered (both `TestFluxsvc_Register` and `TestFluxsvc_Ping`).

This change forces those tests to block until the platform has demonstrably subscribed, or fail if it does not happen within five seconds.

I've run this a few times in circleci, and although you never know with flakes, it appears to improve the situation. Still a bit of a shot in dim light.