### PR TITLE
Fix fluxctl identity command

### DIFF
--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -215,7 +215,7 @@ func (s HTTPServer) GetPublicSSHKey(w http.ResponseWriter, r *http.Request) {
 		transport.ErrorResponse(w, r, err)
 		return
 	}
-	transport.JSONResponse(w, r, res)
+	transport.JSONResponse(w, r, res.PublicSSHKey)
 }
 
 func (s HTTPServer) RegeneratePublicSSHKey(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
This bug was caused by attempting to unmarshal `flux.GitConfig` JSON into `ssh.PublicKey`.

Fixes #723 