### PR TITLE
Add methods to receive Github push notifications

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -38,7 +38,13 @@ type DaemonService interface {
 	LogEvent(service.InstanceID, history.Event) error
 }
 
+// API for other services connecting to the service
+type ServiceService interface {
+	SyncNotifyGit(url, branch string) error
+}
+
 type FluxService interface {
 	ClientService
 	DaemonService
+	ServiceService
 }

--- a/integrations/github/hashing.go
+++ b/integrations/github/hashing.go
@@ -1,0 +1,23 @@
+package github
+
+import (
+	"crypto/sha256"
+	"fmt"
+
+	"github.com/weaveworks/flux/remote"
+)
+
+func MakeGitSubject(platform remote.Platform) (string, error) {
+	repoConfig, err := platform.GitRepoConfig(false)
+	if err != nil {
+		return "", err
+	}
+	r := repoConfig.Remote
+	return GitConfigHash(r.URL, r.Branch), nil
+}
+
+func GitConfigHash(url, branch string) string {
+	s := fmt.Sprintf("%s:%s", url, branch)
+	hash := sha256.Sum256([]byte(s))
+	return fmt.Sprintf("%x", hash)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -21,13 +21,12 @@ import (
 )
 
 type Server struct {
-	version     string
-	instancer   instance.Instancer
-	config      instance.DB
-	messageBus  bus.MessageBus
-	logger      log.Logger
-	maxPlatform chan struct{} // semaphore for concurrent calls to the platform
-	connected   int32
+	version    string
+	instancer  instance.Instancer
+	config     instance.DB
+	messageBus bus.MessageBus
+	logger     log.Logger
+	connected  int32
 }
 
 func New(
@@ -39,12 +38,11 @@ func New(
 ) *Server {
 	connectedDaemons.Set(0)
 	return &Server{
-		version:     version,
-		instancer:   instancer,
-		config:      config,
-		messageBus:  messageBus,
-		logger:      logger,
-		maxPlatform: make(chan struct{}, 8),
+		version:    version,
+		instancer:  instancer,
+		config:     config,
+		messageBus: messageBus,
+		logger:     logger,
 	}
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -343,3 +343,11 @@ func (s *Server) instrumentPlatform(instID service.InstanceID, p remote.Platform
 func (s *Server) IsDaemonConnected(instID service.InstanceID) error {
 	return s.messageBus.Ping(instID)
 }
+
+func (s *Server) SyncNotifyGit(url, branch string) error {
+	p, err := s.messageBus.ConnectWithGitConfig(url, branch)
+	if err != nil {
+		return err
+	}
+	return p.SyncNotify()
+}

--- a/service/bus/bus.go
+++ b/service/bus/bus.go
@@ -14,6 +14,8 @@ type Connecter interface {
 	// with the underlying mechanism (i.e., not if the platform is
 	// simply not known to be connected at this time).
 	Connect(inst service.InstanceID) (remote.Platform, error)
+
+	ConnectWithGitConfig(url, branch string) (remote.Platform, error)
 }
 
 // MessageBus handles routing messages to/from the matching platform.


### PR DESCRIPTION
This change adds a new subject to the message bus which is generated by hashing the (giturl, branch) pair for each connecting fluxd, and adds methods to notify those fluxds to sync when notified by Github.