### PR TITLE
Get rid of instance IDs in the API, and use `context.Context`

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -342,13 +342,7 @@
 
 [[projects]]
   name = "github.com/nats-io/go-nats"
-  packages = ["encoders/builtin","util"]
-  revision = "29f9728a183bf3fa7e809e14edac00b33be72088"
-  version = "v1.3.0"
-
-[[projects]]
-  name = "github.com/nats-io/nats"
-  packages = ["."]
+  packages = [".","encoders/builtin","util"]
   revision = "29f9728a183bf3fa7e809e14edac00b33be72088"
   version = "v1.3.0"
 
@@ -510,6 +504,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4f967ec3520cdba630e9a1273e761aa560583cb7c4c7c1b44f3edc99c3614330"
+  inputs-digest = "024a7b8ff1fe11667a508d388ed8055d62a53dacbf9173463aeeddf87b7b586a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/api/api.go
+++ b/api/api.go
@@ -1,44 +1,33 @@
 package api
 
 import (
-	"time"
+	"context"
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/history"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/remote"
-	"github.com/weaveworks/flux/service"
 	"github.com/weaveworks/flux/ssh"
 	"github.com/weaveworks/flux/update"
 )
 
-// API for clients connecting to the service.
-type ClientService interface {
-	Status(inst service.InstanceID) (service.Status, error)
-	ListServices(inst service.InstanceID, namespace string) ([]flux.ServiceStatus, error)
-	ListImages(service.InstanceID, update.ServiceSpec) ([]flux.ImageStatus, error)
-	UpdateImages(service.InstanceID, update.ReleaseSpec, update.Cause) (job.ID, error)
-	SyncNotify(service.InstanceID) error
-	JobStatus(service.InstanceID, job.ID) (job.Status, error)
-	SyncStatus(service.InstanceID, string) ([]string, error)
-	UpdatePolicies(service.InstanceID, policy.Updates, update.Cause) (job.ID, error)
-	History(service.InstanceID, update.ServiceSpec, time.Time, int64, time.Time) ([]history.Entry, error)
-	GetConfig(_ service.InstanceID, fingerprint string) (service.InstanceConfig, error)
-	SetConfig(service.InstanceID, service.InstanceConfig) error
-	PatchConfig(service.InstanceID, service.ConfigPatch) error
-	Export(inst service.InstanceID) ([]byte, error)
-	PublicSSHKey(inst service.InstanceID, regenerate bool) (ssh.PublicKey, error)
+// API for clients connecting to the service
+type Client interface {
+	ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error)
+	ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error)
+	UpdateImages(context.Context, update.ReleaseSpec, update.Cause) (job.ID, error)
+	SyncNotify(context.Context) error
+	JobStatus(context.Context, job.ID) (job.Status, error)
+	SyncStatus(ctx context.Context, ref string) ([]string, error)
+	UpdatePolicies(context.Context, policy.Updates, update.Cause) (job.ID, error)
+	Export(context.Context) ([]byte, error)
+	PublicSSHKey(ctx context.Context, regenerate bool) (ssh.PublicKey, error)
 }
 
-// API for daemons connecting to the service
-type DaemonService interface {
-	RegisterDaemon(service.InstanceID, remote.Platform) error
-	IsDaemonConnected(service.InstanceID) error
-	LogEvent(service.InstanceID, history.Event) error
-}
-
-type FluxService interface {
-	ClientService
-	DaemonService
+// API for daemons connecting to an upstream service
+type Upstream interface {
+	RegisterDaemon(context.Context, remote.Platform) error
+	IsDaemonConnected(context.Context) error
+	LogEvent(context.Context, history.Event) error
 }

--- a/api/service.go
+++ b/api/service.go
@@ -1,0 +1,21 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	"github.com/weaveworks/flux/history"
+	"github.com/weaveworks/flux/service"
+	"github.com/weaveworks/flux/update"
+)
+
+type Service interface {
+	Client
+	Upstream
+
+	Status(context.Context) (service.Status, error)
+	History(context.Context, update.ServiceSpec, time.Time, int64, time.Time) ([]history.Entry, error)
+	GetConfig(ctx context.Context, fingerprint string) (service.InstanceConfig, error)
+	SetConfig(context.Context, service.InstanceConfig) error
+	PatchConfig(context.Context, service.ConfigPatch) error
+}

--- a/cmd/fluxctl/identity_cmd.go
+++ b/cmd/fluxctl/identity_cmd.go
@@ -35,7 +35,9 @@ func (opts *identityOpts) RunE(_ *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	publicSSHKey, err := opts.API.PublicSSHKey(context.TODO(), opts.regenerate)
+	ctx := context.Background()
+
+	publicSSHKey, err := opts.API.PublicSSHKey(ctx, opts.regenerate)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/identity_cmd.go
+++ b/cmd/fluxctl/identity_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ func (opts *identityOpts) RunE(_ *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	publicSSHKey, err := opts.API.PublicSSHKey(noInstanceID, opts.regenerate)
+	publicSSHKey, err := opts.API.PublicSSHKey(context.TODO(), opts.regenerate)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -43,7 +43,9 @@ func (opts *serviceShowOpts) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	services, err := opts.API.ListImages(context.TODO(), service)
+	ctx := context.Background()
+
+	services, err := opts.API.ListImages(ctx, service)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -42,7 +43,7 @@ func (opts *serviceShowOpts) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	services, err := opts.API.ListImages(noInstanceID, service)
+	services, err := opts.API.ListImages(context.TODO(), service)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -36,7 +37,7 @@ func (opts *serviceListOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	services, err := opts.API.ListServices(noInstanceID, opts.namespace)
+	services, err := opts.API.ListServices(context.TODO(), opts.namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -37,7 +37,9 @@ func (opts *serviceListOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	services, err := opts.API.ListServices(context.TODO(), opts.namespace)
+	ctx := context.Background()
+
+	services, err := opts.API.ListServices(ctx, opts.namespace)
 	if err != nil {
 		return err
 	}

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -89,13 +89,16 @@ func (opts *servicePolicyOpts) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	jobID, err := opts.API.UpdatePolicies(context.TODO(), policy.Updates{
+
+	ctx := context.Background()
+
+	jobID, err := opts.API.UpdatePolicies(ctx, policy.Updates{
 		serviceID: update,
 	}, opts.cause)
 	if err != nil {
 		return err
 	}
-	return await(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, false, opts.verbose)
+	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, false, opts.verbose)
 }
 
 func calculatePolicyChanges(opts *servicePolicyOpts) (policy.Update, error) {

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -88,7 +89,7 @@ func (opts *servicePolicyOpts) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	jobID, err := opts.API.UpdatePolicies(noInstanceID, policy.Updates{
+	jobID, err := opts.API.UpdatePolicies(context.TODO(), policy.Updates{
 		serviceID: update,
 	}, opts.cause)
 	if err != nil {

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -108,7 +108,9 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStderr(), "Submitting release ...\n")
 	}
 
-	jobID, err := opts.API.UpdateImages(context.TODO(), update.ReleaseSpec{
+	ctx := context.Background()
+
+	jobID, err := opts.API.UpdateImages(ctx, update.ReleaseSpec{
 		ServiceSpecs: services,
 		ImageSpec:    image,
 		Kind:         kind,
@@ -118,5 +120,5 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return await(cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbose)
+	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbose)
 }

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -107,7 +108,7 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStderr(), "Submitting release ...\n")
 	}
 
-	jobID, err := opts.API.UpdateImages(noInstanceID, update.ReleaseSpec{
+	jobID, err := opts.API.UpdateImages(context.TODO(), update.ReleaseSpec{
 		ServiceSpecs: services,
 		ImageSpec:    image,
 		Kind:         kind,

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -15,18 +15,13 @@ import (
 	"github.com/weaveworks/flux/api"
 	transport "github.com/weaveworks/flux/http"
 	"github.com/weaveworks/flux/http/client"
-	"github.com/weaveworks/flux/service"
 )
 
 type rootOpts struct {
 	URL   string
 	Token string
-	API   api.ClientService
+	API   api.Client
 }
-
-// fluxctl never sends an instance ID directly; it's always blank, and
-// optionally gets populated by an intermediating authfe from the token.
-const noInstanceID = service.InstanceID("")
 
 func newRoot() *rootOpts {
 	return &rootOpts{}

--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -55,7 +56,7 @@ func (opts *saveOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	config, err := opts.API.Export(noInstanceID)
+	config, err := opts.API.Export(context.TODO())
 	if err != nil {
 		return errors.Wrap(err, "exporting config")
 	}

--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -56,7 +56,9 @@ func (opts *saveOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	config, err := opts.API.Export(context.TODO())
+	ctx := context.Background()
+
+	config, err := opts.API.Export(ctx)
 	if err != nil {
 		return errors.Wrap(err, "exporting config")
 	}

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"strings"
 
 	"github.com/go-kit/kit/log"
@@ -13,6 +14,9 @@ import (
 
 func (d *Daemon) pollForNewImages(logger log.Logger) {
 	logger.Log("msg", "polling images")
+
+	// One day we may use this for operations other than the call at the end
+	ctx := context.Background()
 
 	candidateServices, err := d.unlockedAutomatedServices()
 	if err != nil {
@@ -59,7 +63,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 	}
 
 	if len(changes.Changes) > 0 {
-		d.UpdateManifests(update.Spec{Type: update.Auto, Spec: changes})
+		d.UpdateManifests(ctx, update.Spec{Type: update.Auto, Spec: changes})
 	}
 }
 

--- a/daemon/notready.go
+++ b/daemon/notready.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"sync"
 
 	"github.com/weaveworks/flux"
@@ -42,44 +43,44 @@ func (nrd *NotReadyDaemon) UpdateReason(reason error) {
 
 // 'Not ready' platform implementation
 
-func (nrd *NotReadyDaemon) Ping() error {
+func (nrd *NotReadyDaemon) Ping(ctx context.Context) error {
 	return nrd.cluster.Ping()
 }
 
-func (nrd *NotReadyDaemon) Version() (string, error) {
+func (nrd *NotReadyDaemon) Version(ctx context.Context) (string, error) {
 	return nrd.version, nil
 }
 
-func (nrd *NotReadyDaemon) Export() ([]byte, error) {
+func (nrd *NotReadyDaemon) Export(ctx context.Context) ([]byte, error) {
 	return nrd.cluster.Export()
 }
 
-func (nrd *NotReadyDaemon) ListServices(namespace string) ([]flux.ServiceStatus, error) {
+func (nrd *NotReadyDaemon) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
 	return nil, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) ListImages(update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (nrd *NotReadyDaemon) ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error) {
 	return nil, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) UpdateManifests(update.Spec) (job.ID, error) {
+func (nrd *NotReadyDaemon) UpdateManifests(context.Context, update.Spec) (job.ID, error) {
 	var id job.ID
 	return id, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) SyncNotify() error {
+func (nrd *NotReadyDaemon) SyncNotify(context.Context) error {
 	return nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) JobStatus(id job.ID) (job.Status, error) {
+func (nrd *NotReadyDaemon) JobStatus(context.Context, job.ID) (job.Status, error) {
 	return job.Status{}, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) SyncStatus(string) ([]string, error) {
+func (nrd *NotReadyDaemon) SyncStatus(context.Context, string) ([]string, error) {
 	return nil, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) GitRepoConfig(regenerate bool) (flux.GitConfig, error) {
+func (nrd *NotReadyDaemon) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error) {
 	publicSSHKey, err := nrd.cluster.PublicSSHKey(regenerate)
 	if err != nil {
 		return flux.GitConfig{}, err

--- a/daemon/ref.go
+++ b/daemon/ref.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"sync"
 
 	"github.com/weaveworks/flux"
@@ -33,42 +34,42 @@ func (pr *Ref) UpdatePlatform(platform remote.Platform) {
 // remote.Platform implementation so clients don't need to be refactored around
 // Platform() API
 
-func (pr *Ref) Ping() error {
-	return pr.Platform().Ping()
+func (pr *Ref) Ping(ctx context.Context) error {
+	return pr.Platform().Ping(ctx)
 }
 
-func (pr *Ref) Version() (string, error) {
-	return pr.Platform().Version()
+func (pr *Ref) Version(ctx context.Context) (string, error) {
+	return pr.Platform().Version(ctx)
 }
 
-func (pr *Ref) Export() ([]byte, error) {
-	return pr.Platform().Export()
+func (pr *Ref) Export(ctx context.Context) ([]byte, error) {
+	return pr.Platform().Export(ctx)
 }
 
-func (pr *Ref) ListServices(namespace string) ([]flux.ServiceStatus, error) {
-	return pr.Platform().ListServices(namespace)
+func (pr *Ref) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
+	return pr.Platform().ListServices(ctx, namespace)
 }
 
-func (pr *Ref) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, error) {
-	return pr.Platform().ListImages(spec)
+func (pr *Ref) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+	return pr.Platform().ListImages(ctx, spec)
 }
 
-func (pr *Ref) UpdateManifests(spec update.Spec) (job.ID, error) {
-	return pr.Platform().UpdateManifests(spec)
+func (pr *Ref) UpdateManifests(ctx context.Context, spec update.Spec) (job.ID, error) {
+	return pr.Platform().UpdateManifests(ctx, spec)
 }
 
-func (pr *Ref) SyncNotify() error {
-	return pr.Platform().SyncNotify()
+func (pr *Ref) SyncNotify(ctx context.Context) error {
+	return pr.Platform().SyncNotify(ctx)
 }
 
-func (pr *Ref) JobStatus(id job.ID) (job.Status, error) {
-	return pr.Platform().JobStatus(id)
+func (pr *Ref) JobStatus(ctx context.Context, id job.ID) (job.Status, error) {
+	return pr.Platform().JobStatus(ctx, id)
 }
 
-func (pr *Ref) SyncStatus(ref string) ([]string, error) {
-	return pr.Platform().SyncStatus(ref)
+func (pr *Ref) SyncStatus(ctx context.Context, ref string) ([]string, error) {
+	return pr.Platform().SyncStatus(ctx, ref)
 }
 
-func (pr *Ref) GitRepoConfig(regenerate bool) (flux.GitConfig, error) {
-	return pr.Platform().GitRepoConfig(regenerate)
+func (pr *Ref) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error) {
+	return pr.Platform().GitRepoConfig(ctx, regenerate)
 }

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -66,7 +66,7 @@ type HTTPServer struct {
 }
 
 func (s HTTPServer) SyncNotify(w http.ResponseWriter, r *http.Request) {
-	err := s.daemon.SyncNotify()
+	err := s.daemon.SyncNotify(r.Context())
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -76,7 +76,7 @@ func (s HTTPServer) SyncNotify(w http.ResponseWriter, r *http.Request) {
 
 func (s HTTPServer) JobStatus(w http.ResponseWriter, r *http.Request) {
 	id := job.ID(mux.Vars(r)["id"])
-	status, err := s.daemon.JobStatus(id)
+	status, err := s.daemon.JobStatus(r.Context(), id)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -86,7 +86,7 @@ func (s HTTPServer) JobStatus(w http.ResponseWriter, r *http.Request) {
 
 func (s HTTPServer) SyncStatus(w http.ResponseWriter, r *http.Request) {
 	ref := mux.Vars(r)["ref"]
-	commits, err := s.daemon.SyncStatus(ref)
+	commits, err := s.daemon.SyncStatus(r.Context(), ref)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -102,7 +102,7 @@ func (s HTTPServer) ListImages(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	d, err := s.daemon.ListImages(spec)
+	d, err := s.daemon.ListImages(r.Context(), spec)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -160,7 +160,7 @@ func (s HTTPServer) UpdateImages(w http.ResponseWriter, r *http.Request) {
 		User:    r.FormValue("user"),
 		Message: r.FormValue("message"),
 	}
-	result, err := s.daemon.UpdateManifests(update.Spec{Type: update.Images, Cause: cause, Spec: spec})
+	result, err := s.daemon.UpdateManifests(r.Context(), update.Spec{Type: update.Images, Cause: cause, Spec: spec})
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -180,7 +180,7 @@ func (s HTTPServer) UpdatePolicies(w http.ResponseWriter, r *http.Request) {
 		Message: r.FormValue("message"),
 	}
 
-	jobID, err := s.daemon.UpdateManifests(update.Spec{Type: update.Policy, Cause: cause, Spec: updates})
+	jobID, err := s.daemon.UpdateManifests(r.Context(), update.Spec{Type: update.Policy, Cause: cause, Spec: updates})
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -191,7 +191,7 @@ func (s HTTPServer) UpdatePolicies(w http.ResponseWriter, r *http.Request) {
 
 func (s HTTPServer) ListServices(w http.ResponseWriter, r *http.Request) {
 	namespace := mux.Vars(r)["namespace"]
-	res, err := s.daemon.ListServices(namespace)
+	res, err := s.daemon.ListServices(r.Context(), namespace)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -200,7 +200,7 @@ func (s HTTPServer) ListServices(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s HTTPServer) Export(w http.ResponseWriter, r *http.Request) {
-	status, err := s.daemon.Export()
+	status, err := s.daemon.Export(r.Context())
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -210,7 +210,7 @@ func (s HTTPServer) Export(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s HTTPServer) GetPublicSSHKey(w http.ResponseWriter, r *http.Request) {
-	res, err := s.daemon.GitRepoConfig(false)
+	res, err := s.daemon.GitRepoConfig(r.Context(), false)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return
@@ -219,7 +219,7 @@ func (s HTTPServer) GetPublicSSHKey(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s HTTPServer) RegeneratePublicSSHKey(w http.ResponseWriter, r *http.Request) {
-	_, err := s.daemon.GitRepoConfig(true)
+	_, err := s.daemon.GitRepoConfig(r.Context(), true)
 	if err != nil {
 		transport.ErrorResponse(w, r, err)
 		return

--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"os"
@@ -19,7 +20,6 @@ import (
 	"github.com/weaveworks/flux/http/websocket"
 	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/remote/rpc"
-	"github.com/weaveworks/flux/service"
 )
 
 // Upstream handles communication from the daemon to a service
@@ -177,7 +177,7 @@ func (a *Upstream) setConnectionDuration(duration float64) {
 
 func (a *Upstream) LogEvent(event history.Event) error {
 	// Instance ID is set via token here, so we can leave it blank.
-	return a.apiClient.LogEvent(service.InstanceID(""), event)
+	return a.apiClient.LogEvent(context.TODO(), event)
 }
 
 // Close closes the connection to the service

--- a/remote/logging.go
+++ b/remote/logging.go
@@ -1,6 +1,8 @@
 package remote
 
 import (
+	"context"
+
 	"github.com/go-kit/kit/log"
 
 	"github.com/weaveworks/flux"
@@ -13,93 +15,93 @@ type ErrorLoggingPlatform struct {
 	Logger   log.Logger
 }
 
-func (p *ErrorLoggingPlatform) Ping() (err error) {
+func (p *ErrorLoggingPlatform) Ping(ctx context.Context) (err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "Ping", "error", err)
 		}
 	}()
-	return p.Platform.Ping()
+	return p.Platform.Ping(ctx)
 }
 
-func (p *ErrorLoggingPlatform) Version() (v string, err error) {
+func (p *ErrorLoggingPlatform) Version(ctx context.Context) (v string, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "Version", "error", err, "version", v)
 		}
 	}()
-	return p.Platform.Version()
+	return p.Platform.Version(ctx)
 }
 
-func (p *ErrorLoggingPlatform) Export() (config []byte, err error) {
+func (p *ErrorLoggingPlatform) Export(ctx context.Context) (config []byte, err error) {
 	defer func() {
 		if err != nil {
 			// Omit config as it could be large
 			p.Logger.Log("method", "Export", "error", err)
 		}
 	}()
-	return p.Platform.Export()
+	return p.Platform.Export(ctx)
 }
 
-func (p *ErrorLoggingPlatform) ListServices(maybeNamespace string) (_ []flux.ServiceStatus, err error) {
+func (p *ErrorLoggingPlatform) ListServices(ctx context.Context, maybeNamespace string) (_ []flux.ServiceStatus, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "ListServices", "error", err)
 		}
 	}()
-	return p.Platform.ListServices(maybeNamespace)
+	return p.Platform.ListServices(ctx, maybeNamespace)
 }
 
-func (p *ErrorLoggingPlatform) ListImages(spec update.ServiceSpec) (_ []flux.ImageStatus, err error) {
+func (p *ErrorLoggingPlatform) ListImages(ctx context.Context, spec update.ServiceSpec) (_ []flux.ImageStatus, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "ListImages", "error", err)
 		}
 	}()
-	return p.Platform.ListImages(spec)
+	return p.Platform.ListImages(ctx, spec)
 }
 
-func (p *ErrorLoggingPlatform) SyncNotify() (err error) {
+func (p *ErrorLoggingPlatform) SyncNotify(ctx context.Context) (err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "SyncNotify", "error", err)
 		}
 	}()
-	return p.Platform.SyncNotify()
+	return p.Platform.SyncNotify(ctx)
 }
 
-func (p *ErrorLoggingPlatform) JobStatus(jobID job.ID) (_ job.Status, err error) {
+func (p *ErrorLoggingPlatform) JobStatus(ctx context.Context, jobID job.ID) (_ job.Status, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "JobStatus", "error", err)
 		}
 	}()
-	return p.Platform.JobStatus(jobID)
+	return p.Platform.JobStatus(ctx, jobID)
 }
 
-func (p *ErrorLoggingPlatform) SyncStatus(rev string) (_ []string, err error) {
+func (p *ErrorLoggingPlatform) SyncStatus(ctx context.Context, ref string) (_ []string, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "SyncStatus", "error", err)
 		}
 	}()
-	return p.Platform.SyncStatus(rev)
+	return p.Platform.SyncStatus(ctx, ref)
 }
 
-func (p *ErrorLoggingPlatform) UpdateManifests(u update.Spec) (_ job.ID, err error) {
+func (p *ErrorLoggingPlatform) UpdateManifests(ctx context.Context, u update.Spec) (_ job.ID, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "UpdateManifests", "error", err)
 		}
 	}()
-	return p.Platform.UpdateManifests(u)
+	return p.Platform.UpdateManifests(ctx, u)
 }
 
-func (p *ErrorLoggingPlatform) GitRepoConfig(regenerate bool) (_ flux.GitConfig, err error) {
+func (p *ErrorLoggingPlatform) GitRepoConfig(ctx context.Context, regenerate bool) (_ flux.GitConfig, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "GitRepoConfig", "error", err)
 		}
 	}()
-	return p.Platform.GitRepoConfig(regenerate)
+	return p.Platform.GitRepoConfig(ctx, regenerate)
 }

--- a/remote/metrics.go
+++ b/remote/metrics.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -31,102 +32,102 @@ func Instrument(p Platform) Platform {
 	return &instrumentedPlatform{p}
 }
 
-func (i *instrumentedPlatform) Ping() (err error) {
+func (i *instrumentedPlatform) Ping(ctx context.Context) (err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "Ping",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.Ping()
+	return i.p.Ping(ctx)
 }
 
-func (i *instrumentedPlatform) Version() (v string, err error) {
+func (i *instrumentedPlatform) Version(ctx context.Context) (v string, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "Version",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.Version()
+	return i.p.Version(ctx)
 }
 
-func (i *instrumentedPlatform) Export() (config []byte, err error) {
+func (i *instrumentedPlatform) Export(ctx context.Context) (config []byte, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "Export",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.Export()
+	return i.p.Export(ctx)
 }
 
-func (i *instrumentedPlatform) ListServices(namespace string) (_ []flux.ServiceStatus, err error) {
+func (i *instrumentedPlatform) ListServices(ctx context.Context, namespace string) (_ []flux.ServiceStatus, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "ListServices",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.ListServices(namespace)
+	return i.p.ListServices(ctx, namespace)
 }
 
-func (i *instrumentedPlatform) ListImages(spec update.ServiceSpec) (_ []flux.ImageStatus, err error) {
+func (i *instrumentedPlatform) ListImages(ctx context.Context, spec update.ServiceSpec) (_ []flux.ImageStatus, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "ListImages",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.ListImages(spec)
+	return i.p.ListImages(ctx, spec)
 }
 
-func (i *instrumentedPlatform) UpdateManifests(spec update.Spec) (_ job.ID, err error) {
+func (i *instrumentedPlatform) UpdateManifests(ctx context.Context, spec update.Spec) (_ job.ID, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "UpdateManifests",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.UpdateManifests(spec)
+	return i.p.UpdateManifests(ctx, spec)
 }
 
-func (i *instrumentedPlatform) SyncNotify() (err error) {
+func (i *instrumentedPlatform) SyncNotify(ctx context.Context) (err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "SyncNotify",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.SyncNotify()
+	return i.p.SyncNotify(ctx)
 }
 
-func (i *instrumentedPlatform) JobStatus(id job.ID) (_ job.Status, err error) {
+func (i *instrumentedPlatform) JobStatus(ctx context.Context, id job.ID) (_ job.Status, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "JobStatus",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.JobStatus(id)
+	return i.p.JobStatus(ctx, id)
 }
 
-func (i *instrumentedPlatform) SyncStatus(cursor string) (_ []string, err error) {
+func (i *instrumentedPlatform) SyncStatus(ctx context.Context, cursor string) (_ []string, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "SyncStatus",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.SyncStatus(cursor)
+	return i.p.SyncStatus(ctx, cursor)
 }
 
-func (i *instrumentedPlatform) GitRepoConfig(regenerate bool) (_ flux.GitConfig, err error) {
+func (i *instrumentedPlatform) GitRepoConfig(ctx context.Context, regenerate bool) (_ flux.GitConfig, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "GitRepoConfig",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.GitRepoConfig(regenerate)
+	return i.p.GitRepoConfig(ctx, regenerate)
 }

--- a/remote/platform.go
+++ b/remote/platform.go
@@ -3,6 +3,8 @@
 package remote
 
 import (
+	"context"
+
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/update"
@@ -12,8 +14,8 @@ import (
 // `Platform`.
 
 type PlatformV4 interface {
-	Ping() error
-	Version() (string, error)
+	Ping(context.Context) error
+	Version(context.Context) (string, error)
 	// Deprecated
 	//	AllServices(maybeNamespace string, ignored flux.ServiceIDSet) ([]Service, error)
 	//	SomeServices([]flux.ServiceID) ([]Service, error)
@@ -25,7 +27,7 @@ type PlatformV5 interface {
 	// We still support this, for bootstrapping; but it might
 	// reasonably be moved to the daemon interface, or removed in
 	// favour of letting people use their cluster-specific tooling.
-	Export() ([]byte, error)
+	Export(context.Context) ([]byte, error)
 	// Deprecated
 	//	Sync(SyncDef) error
 }
@@ -37,18 +39,18 @@ type PlatformV5 interface {
 type PlatformV6 interface {
 	PlatformV5
 	// These are new, or newly moved to this interface
-	ListServices(namespace string) ([]flux.ServiceStatus, error)
-	ListImages(update.ServiceSpec) ([]flux.ImageStatus, error)
+	ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error)
+	ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error)
 	// Send a spec for updating config to the daemon
-	UpdateManifests(update.Spec) (job.ID, error)
+	UpdateManifests(context.Context, update.Spec) (job.ID, error)
 	// Poke the daemon to sync with git
-	SyncNotify() error
+	SyncNotify(context.Context) error
 	// Ask the daemon where it's up to with syncing
-	SyncStatus(string) ([]string, error)
+	SyncStatus(ctx context.Context, ref string) ([]string, error)
 	// Ask the daemon where it's up to with job processing
-	JobStatus(job.ID) (job.Status, error)
+	JobStatus(context.Context, job.ID) (job.Status, error)
 	// Get the daemon's public SSH key
-	GitRepoConfig(regenerate bool) (flux.GitConfig, error)
+	GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error)
 }
 
 // Platform is the SPI for the daemon; i.e., it's all the things we

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -1,6 +1,8 @@
 package rpc
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
@@ -13,43 +15,43 @@ type baseClient struct{}
 
 var _ remote.Platform = baseClient{}
 
-func (bc baseClient) Version() (string, error) {
+func (bc baseClient) Version(context.Context) (string, error) {
 	return "", remote.UpgradeNeededError(errors.New("Version method not implemented"))
 }
 
-func (bc baseClient) Ping() error {
+func (bc baseClient) Ping(context.Context) error {
 	return remote.UpgradeNeededError(errors.New("Ping method not implemented"))
 }
 
-func (bc baseClient) Export() ([]byte, error) {
+func (bc baseClient) Export(context.Context) ([]byte, error) {
 	return nil, remote.UpgradeNeededError(errors.New("Export method not implemented"))
 }
 
-func (bc baseClient) ListServices(string) ([]flux.ServiceStatus, error) {
+func (bc baseClient) ListServices(context.Context, string) ([]flux.ServiceStatus, error) {
 	return nil, remote.UpgradeNeededError(errors.New("ListServices method not implemented"))
 }
 
-func (bc baseClient) ListImages(update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (bc baseClient) ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error) {
 	return nil, remote.UpgradeNeededError(errors.New("ListImages method not implemented"))
 }
 
-func (bc baseClient) UpdateManifests(update.Spec) (job.ID, error) {
+func (bc baseClient) UpdateManifests(context.Context, update.Spec) (job.ID, error) {
 	var id job.ID
 	return id, remote.UpgradeNeededError(errors.New("UpdateManifests method not implemented"))
 }
 
-func (bc baseClient) SyncNotify() error {
+func (bc baseClient) SyncNotify(context.Context) error {
 	return remote.UpgradeNeededError(errors.New("SyncNotify method not implemented"))
 }
 
-func (bc baseClient) JobStatus(job.ID) (job.Status, error) {
+func (bc baseClient) JobStatus(context.Context, job.ID) (job.Status, error) {
 	return job.Status{}, remote.UpgradeNeededError(errors.New("JobStatus method not implemented"))
 }
 
-func (bc baseClient) SyncStatus(string) ([]string, error) {
+func (bc baseClient) SyncStatus(context.Context, string) ([]string, error) {
 	return nil, remote.UpgradeNeededError(errors.New("SyncStatus method not implemented"))
 }
 
-func (bc baseClient) GitRepoConfig(bool) (flux.GitConfig, error) {
+func (bc baseClient) GitRepoConfig(context.Context, bool) (flux.GitConfig, error) {
 	return flux.GitConfig{}, remote.UpgradeNeededError(errors.New("GitRepoConfig method not implemented"))
 }

--- a/remote/rpc/clientV4.go
+++ b/remote/rpc/clientV4.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"io"
 	"net/rpc"
 	"net/rpc/jsonrpc"
@@ -23,7 +24,7 @@ func NewClientV4(conn io.ReadWriteCloser) *RPCClientV4 {
 }
 
 // Ping is used to check if the remote platform is available.
-func (p *RPCClientV4) Ping() error {
+func (p *RPCClientV4) Ping(ctx context.Context) error {
 	err := p.client.Call("RPCServer.Ping", struct{}{}, nil)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
 		return remote.FatalError{err}
@@ -32,7 +33,7 @@ func (p *RPCClientV4) Ping() error {
 }
 
 // Version is used to check if the remote platform is available
-func (p *RPCClientV4) Version() (string, error) {
+func (p *RPCClientV4) Version(ctx context.Context) (string, error) {
 	var version string
 	err := p.client.Call("RPCServer.Version", struct{}{}, &version)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {

--- a/remote/rpc/clientV5.go
+++ b/remote/rpc/clientV5.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"io"
 	"net/rpc"
 
@@ -21,7 +22,7 @@ func NewClientV5(conn io.ReadWriteCloser) *RPCClientV5 {
 }
 
 // Export is used to get service configuration in platform-specific format
-func (p *RPCClientV5) Export() ([]byte, error) {
+func (p *RPCClientV5) Export(ctx context.Context) ([]byte, error) {
 	var config []byte
 	err := p.client.Call("RPCServer.Export", struct{}{}, &config)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"io"
 	"net/rpc"
 
@@ -44,7 +45,7 @@ func NewClientV6(conn io.ReadWriteCloser) *RPCClientV6 {
 }
 
 // Export is used to get service configuration in platform-specific format
-func (p *RPCClientV6) Export() ([]byte, error) {
+func (p *RPCClientV6) Export(ctx context.Context) ([]byte, error) {
 	var config []byte
 	err := p.client.Call("RPCServer.Export", struct{}{}, &config)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
@@ -57,7 +58,7 @@ func (p *RPCClientV6) Export() ([]byte, error) {
 }
 
 // Export is used to get service configuration in platform-specific format
-func (p *RPCClientV6) ListServices(namespace string) ([]flux.ServiceStatus, error) {
+func (p *RPCClientV6) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
 	var services []flux.ServiceStatus
 	err := p.client.Call("RPCServer.ListServices", namespace, &services)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
@@ -69,7 +70,7 @@ func (p *RPCClientV6) ListServices(namespace string) ([]flux.ServiceStatus, erro
 	return services, err
 }
 
-func (p *RPCClientV6) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (p *RPCClientV6) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
 	var images []flux.ImageStatus
 	if err := requireServiceSpecKinds(spec, supportedKindsV6); err != nil {
 		return images, remote.UpgradeNeededError(err)
@@ -85,7 +86,7 @@ func (p *RPCClientV6) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, e
 	return images, err
 }
 
-func (p *RPCClientV6) UpdateManifests(u update.Spec) (job.ID, error) {
+func (p *RPCClientV6) UpdateManifests(ctx context.Context, u update.Spec) (job.ID, error) {
 	var result job.ID
 	if err := requireSpecKinds(u, supportedKindsV6); err != nil {
 		return result, remote.UpgradeNeededError(err)
@@ -101,7 +102,7 @@ func (p *RPCClientV6) UpdateManifests(u update.Spec) (job.ID, error) {
 	return result, err
 }
 
-func (p *RPCClientV6) SyncNotify() error {
+func (p *RPCClientV6) SyncNotify(ctx context.Context) error {
 	var result struct{}
 	err := p.client.Call("RPCServer.SyncNotify", struct{}{}, &result)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
@@ -113,7 +114,7 @@ func (p *RPCClientV6) SyncNotify() error {
 	return err
 }
 
-func (p *RPCClientV6) JobStatus(jobID job.ID) (job.Status, error) {
+func (p *RPCClientV6) JobStatus(ctx context.Context, jobID job.ID) (job.Status, error) {
 	var result job.Status
 	err := p.client.Call("RPCServer.JobStatus", jobID, &result)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
@@ -125,7 +126,7 @@ func (p *RPCClientV6) JobStatus(jobID job.ID) (job.Status, error) {
 	return result, err
 }
 
-func (p *RPCClientV6) SyncStatus(ref string) ([]string, error) {
+func (p *RPCClientV6) SyncStatus(ctx context.Context, ref string) ([]string, error) {
 	var result []string
 	err := p.client.Call("RPCServer.SyncStatus", ref, &result)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
@@ -137,7 +138,7 @@ func (p *RPCClientV6) SyncStatus(ref string) ([]string, error) {
 	return result, err
 }
 
-func (p *RPCClientV6) GitRepoConfig(regenerate bool) (flux.GitConfig, error) {
+func (p *RPCClientV6) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error) {
 	var result flux.GitConfig
 	err := p.client.Call("RPCServer.GitRepoConfig", regenerate, &result)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"io"
 	"net/rpc"
 
@@ -28,7 +29,7 @@ func NewClientV7(conn io.ReadWriteCloser) *RPCClientV7 {
 }
 
 // Export is used to get service configuration in platform-specific format
-func (p *RPCClientV7) Export() ([]byte, error) {
+func (p *RPCClientV7) Export(ctx context.Context) ([]byte, error) {
 	var resp ExportResponse
 	err := p.client.Call("RPCServer.Export", struct{}{}, &resp)
 	if err != nil {
@@ -41,7 +42,7 @@ func (p *RPCClientV7) Export() ([]byte, error) {
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) ListServices(namespace string) ([]flux.ServiceStatus, error) {
+func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
 	var resp ListServicesResponse
 	err := p.client.Call("RPCServer.ListServices", namespace, &resp)
 	if err != nil {
@@ -55,7 +56,7 @@ func (p *RPCClientV7) ListServices(namespace string) ([]flux.ServiceStatus, erro
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (p *RPCClientV7) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
 	var resp ListImagesResponse
 	if err := requireServiceSpecKinds(spec, supportedKindsV7); err != nil {
 		return resp.Result, remote.UpgradeNeededError(err)
@@ -72,7 +73,7 @@ func (p *RPCClientV7) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, e
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) UpdateManifests(u update.Spec) (job.ID, error) {
+func (p *RPCClientV7) UpdateManifests(ctx context.Context, u update.Spec) (job.ID, error) {
 	var resp UpdateManifestsResponse
 	if err := requireSpecKinds(u, supportedKindsV7); err != nil {
 		return resp.Result, remote.UpgradeNeededError(err)
@@ -88,7 +89,7 @@ func (p *RPCClientV7) UpdateManifests(u update.Spec) (job.ID, error) {
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) SyncNotify() error {
+func (p *RPCClientV7) SyncNotify(ctx context.Context) error {
 	var resp SyncNotifyResponse
 	err := p.client.Call("RPCServer.SyncNotify", struct{}{}, &resp)
 	if err != nil {
@@ -101,7 +102,7 @@ func (p *RPCClientV7) SyncNotify() error {
 	return err
 }
 
-func (p *RPCClientV7) JobStatus(jobID job.ID) (job.Status, error) {
+func (p *RPCClientV7) JobStatus(ctx context.Context, jobID job.ID) (job.Status, error) {
 	var resp JobStatusResponse
 	err := p.client.Call("RPCServer.JobStatus", jobID, &resp)
 	if err != nil {
@@ -114,7 +115,7 @@ func (p *RPCClientV7) JobStatus(jobID job.ID) (job.Status, error) {
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) SyncStatus(ref string) ([]string, error) {
+func (p *RPCClientV7) SyncStatus(ctx context.Context, ref string) ([]string, error) {
 	var resp SyncStatusResponse
 	err := p.client.Call("RPCServer.SyncStatus", ref, &resp)
 	if err != nil {
@@ -127,7 +128,7 @@ func (p *RPCClientV7) SyncStatus(ref string) ([]string, error) {
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) GitRepoConfig(regenerate bool) (flux.GitConfig, error) {
+func (p *RPCClientV7) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error) {
 	var resp GitRepoConfigResponse
 	err := p.client.Call("RPCServer.GitRepoConfig", regenerate, &resp)
 	if err != nil {

--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"io"
 	"net/rpc"
 
@@ -26,7 +27,7 @@ func NewClientV8(conn io.ReadWriteCloser) *RPCClientV8 {
 	return &RPCClientV8{NewClientV7(conn)}
 }
 
-func (p *RPCClientV8) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (p *RPCClientV8) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
 	var resp ListImagesResponse
 	if err := requireServiceSpecKinds(spec, supportedKindsV8); err != nil {
 		return resp.Result, remote.UnsupportedResourceKind(err)
@@ -43,7 +44,7 @@ func (p *RPCClientV8) ListImages(spec update.ServiceSpec) ([]flux.ImageStatus, e
 	return resp.Result, err
 }
 
-func (p *RPCClientV8) UpdateManifests(u update.Spec) (job.ID, error) {
+func (p *RPCClientV8) UpdateManifests(ctx context.Context, u update.Spec) (job.ID, error) {
 	var resp UpdateManifestsResponse
 	if err := requireSpecKinds(u, supportedKindsV8); err != nil {
 		return resp.Result, remote.UnsupportedResourceKind(err)

--- a/remote/rpc/doc.go
+++ b/remote/rpc/doc.go
@@ -41,4 +41,10 @@ server code always implements just the most recent version.
 For backwards-incompatible changes, we must bump the protocol version
 (and create a new `RegisterDaemon` endpoint).
 
+On contexts:
+
+Sadly, `net/rpc` does not support context.Context, and never will. So
+we must ignore the contexts passed in. If we change the RPC mechanism,
+we may be able to address this.
+
 */

--- a/remote/rpc/rpc_test.go
+++ b/remote/rpc/rpc_test.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"errors"
 	"io"
 	"reflect"
@@ -56,6 +57,7 @@ func faultyPipes() (io.ReadWriteCloser, io.ReadWriteCloser) {
 }
 
 func TestBadRPC(t *testing.T) {
+	ctx := context.Background()
 	mock := &remote.MockPlatform{}
 	clientConn, serverConn := faultyPipes()
 	server, err := NewServer(mock)
@@ -65,7 +67,7 @@ func TestBadRPC(t *testing.T) {
 	go server.ServeConn(serverConn)
 
 	client := NewClientV6(clientConn)
-	if err = client.Ping(); err == nil {
+	if err = client.Ping(ctx); err == nil {
 		t.Error("expected error from RPC system, got nil")
 	}
 	if _, ok := err.(remote.FatalError); !ok {

--- a/remote/rpc/server.go
+++ b/remote/rpc/server.go
@@ -1,6 +1,7 @@
 package rpc
 
 import (
+	"context"
 	"io"
 	"net/rpc"
 	"net/rpc/jsonrpc"
@@ -39,11 +40,11 @@ type RPCServer struct {
 }
 
 func (p *RPCServer) Ping(_ struct{}, _ *struct{}) error {
-	return p.p.Ping()
+	return p.p.Ping(context.Background())
 }
 
 func (p *RPCServer) Version(_ struct{}, resp *string) error {
-	v, err := p.p.Version()
+	v, err := p.p.Version(context.Background())
 	*resp = v
 	return err
 }
@@ -54,7 +55,7 @@ type ExportResponse struct {
 }
 
 func (p *RPCServer) Export(_ struct{}, resp *ExportResponse) error {
-	v, err := p.p.Export()
+	v, err := p.p.Export(context.Background())
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
@@ -71,7 +72,7 @@ type ListServicesResponse struct {
 }
 
 func (p *RPCServer) ListServices(namespace string, resp *ListServicesResponse) error {
-	v, err := p.p.ListServices(namespace)
+	v, err := p.p.ListServices(context.Background(), namespace)
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
@@ -88,7 +89,7 @@ type ListImagesResponse struct {
 }
 
 func (p *RPCServer) ListImages(spec update.ServiceSpec, resp *ListImagesResponse) error {
-	v, err := p.p.ListImages(spec)
+	v, err := p.p.ListImages(context.Background(), spec)
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
@@ -105,7 +106,7 @@ type UpdateManifestsResponse struct {
 }
 
 func (p *RPCServer) UpdateManifests(spec update.Spec, resp *UpdateManifestsResponse) error {
-	v, err := p.p.UpdateManifests(spec)
+	v, err := p.p.UpdateManifests(context.Background(), spec)
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
@@ -121,7 +122,7 @@ type SyncNotifyResponse struct {
 }
 
 func (p *RPCServer) SyncNotify(_ struct{}, resp *SyncNotifyResponse) error {
-	err := p.p.SyncNotify()
+	err := p.p.SyncNotify(context.Background())
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
 			resp.ApplicationError = err
@@ -137,7 +138,7 @@ type JobStatusResponse struct {
 }
 
 func (p *RPCServer) JobStatus(jobID job.ID, resp *JobStatusResponse) error {
-	v, err := p.p.JobStatus(jobID)
+	v, err := p.p.JobStatus(context.Background(), jobID)
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
@@ -153,8 +154,8 @@ type SyncStatusResponse struct {
 	ApplicationError *fluxerr.Error
 }
 
-func (p *RPCServer) SyncStatus(cursor string, resp *SyncStatusResponse) error {
-	v, err := p.p.SyncStatus(cursor)
+func (p *RPCServer) SyncStatus(ref string, resp *SyncStatusResponse) error {
+	v, err := p.p.SyncStatus(context.Background(), ref)
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
@@ -171,7 +172,7 @@ type GitRepoConfigResponse struct {
 }
 
 func (p *RPCServer) GitRepoConfig(regenerate bool, resp *GitRepoConfigResponse) error {
-	v, err := p.p.GitRepoConfig(regenerate)
+	v, err := p.p.GitRepoConfig(context.Background(), regenerate)
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {

--- a/service/bus/bus.go
+++ b/service/bus/bus.go
@@ -1,6 +1,8 @@
 package bus
 
 import (
+	"context"
+
 	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/service"
 )
@@ -21,9 +23,9 @@ type MessageBus interface {
 	Connecter
 	// Subscribe registers a platform as the daemon for the instance
 	// specified.
-	Subscribe(inst service.InstanceID, p remote.Platform, done chan<- error)
+	Subscribe(ctx context.Context, inst service.InstanceID, p remote.Platform, done chan<- error)
 	// Ping returns nil if the daemon for the instance given is known
 	// to be connected, or ErrPlatformNotAvailable otherwise. NB this
 	// differs from the semantics of `Connecter.Connect`.
-	Ping(inst service.InstanceID) error
+	Ping(ctx context.Context, inst service.InstanceID) error
 }

--- a/service/server/server.go
+++ b/service/server/server.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -48,7 +49,24 @@ func New(
 	}
 }
 
-func (s *Server) Status(instID service.InstanceID) (res service.Status, err error) {
+var (
+	ErrNoInstanceID = errors.New("No instance ID supplied in request")
+)
+
+// Get the InstanceID from the context, or fail with an error
+func getInstanceID(ctx context.Context) (service.InstanceID, error) {
+	id, ok := ctx.Value(service.InstanceIDKey).(service.InstanceID)
+	if ok {
+		return id, nil
+	}
+	return "", ErrNoInstanceID
+}
+
+func (s *Server) Status(ctx context.Context) (res service.Status, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return res, errors.Wrapf(err, "getting instance")
@@ -62,7 +80,7 @@ func (s *Server) Status(instID service.InstanceID) (res service.Status, err erro
 	}
 
 	res.Fluxd.Last = config.Connection.Last
-	// DOn't bother trying to get information from the daemon if we
+	// Don't bother trying to get information from the daemon if we
 	// haven't recorded it as connected
 	if config.Connection.Connected {
 		res.Fluxd.Connected = true
@@ -87,7 +105,12 @@ func (s *Server) Status(instID service.InstanceID) (res service.Status, err erro
 	return res, nil
 }
 
-func (s *Server) ListServices(instID service.InstanceID, namespace string) (res []flux.ServiceStatus, err error) {
+func (s *Server) ListServices(ctx context.Context, namespace string) (res []flux.ServiceStatus, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
+
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance")
@@ -100,7 +123,12 @@ func (s *Server) ListServices(instID service.InstanceID, namespace string) (res 
 	return services, nil
 }
 
-func (s *Server) ListImages(instID service.InstanceID, spec update.ServiceSpec) (res []flux.ImageStatus, err error) {
+func (s *Server) ListImages(ctx context.Context, spec update.ServiceSpec) (res []flux.ImageStatus, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
+
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance "+string(instID))
@@ -108,7 +136,12 @@ func (s *Server) ListImages(instID service.InstanceID, spec update.ServiceSpec) 
 	return inst.Platform.ListImages(spec)
 }
 
-func (s *Server) UpdateImages(instID service.InstanceID, spec update.ReleaseSpec, cause update.Cause) (job.ID, error) {
+func (s *Server) UpdateImages(ctx context.Context, spec update.ReleaseSpec, cause update.Cause) (job.ID, error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return "", err
+	}
+
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return "", errors.Wrapf(err, "getting instance "+string(instID))
@@ -116,7 +149,11 @@ func (s *Server) UpdateImages(instID service.InstanceID, spec update.ReleaseSpec
 	return inst.Platform.UpdateManifests(update.Spec{Type: update.Images, Cause: cause, Spec: spec})
 }
 
-func (s *Server) UpdatePolicies(instID service.InstanceID, updates policy.Updates, cause update.Cause) (job.ID, error) {
+func (s *Server) UpdatePolicies(ctx context.Context, updates policy.Updates, cause update.Cause) (job.ID, error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return "", err
+	}
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return "", errors.Wrapf(err, "getting instance "+string(instID))
@@ -125,7 +162,11 @@ func (s *Server) UpdatePolicies(instID service.InstanceID, updates policy.Update
 	return inst.Platform.UpdateManifests(update.Spec{Type: update.Policy, Cause: cause, Spec: updates})
 }
 
-func (s *Server) SyncNotify(instID service.InstanceID) (err error) {
+func (s *Server) SyncNotify(ctx context.Context) (err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return err
+	}
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return errors.Wrapf(err, "getting instance "+string(instID))
@@ -133,7 +174,11 @@ func (s *Server) SyncNotify(instID service.InstanceID) (err error) {
 	return inst.Platform.SyncNotify()
 }
 
-func (s *Server) JobStatus(instID service.InstanceID, jobID job.ID) (res job.Status, err error) {
+func (s *Server) JobStatus(ctx context.Context, jobID job.ID) (res job.Status, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return job.Status{}, errors.Wrapf(err, "getting instance "+string(instID))
@@ -142,7 +187,11 @@ func (s *Server) JobStatus(instID service.InstanceID, jobID job.ID) (res job.Sta
 	return inst.Platform.JobStatus(jobID)
 }
 
-func (s *Server) SyncStatus(instID service.InstanceID, ref string) (res []string, err error) {
+func (s *Server) SyncStatus(ctx context.Context, ref string) (res []string, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance "+string(instID))
@@ -153,13 +202,18 @@ func (s *Server) SyncStatus(instID service.InstanceID, ref string) (res []string
 
 // LogEvent receives events from fluxd and pushes events to the history
 // db and a slack notification
-func (s *Server) LogEvent(instID service.InstanceID, e history.Event) error {
-	s.logger.Log("method", "LogEvent", "instance", instID, "event", e)
+func (s *Server) LogEvent(ctx context.Context, e history.Event) error {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return err
+	}
+
 	helper, err := s.instancer.Get(instID)
 	if err != nil {
 		return errors.Wrapf(err, "getting instance")
 	}
 
+	s.logger.Log("method", "LogEvent", "instance", instID, "event", e)
 	// Log event in history first. This is less likely to fail
 	err = helper.LogEvent(e)
 	if err != nil {
@@ -177,8 +231,13 @@ func (s *Server) LogEvent(instID service.InstanceID, e history.Event) error {
 	return nil
 }
 
-func (s *Server) History(inst service.InstanceID, spec update.ServiceSpec, before time.Time, limit int64, after time.Time) (res []history.Entry, err error) {
-	helper, err := s.instancer.Get(inst)
+func (s *Server) History(ctx context.Context, spec update.ServiceSpec, before time.Time, limit int64, after time.Time) (res []history.Entry, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
+
+	helper, err := s.instancer.Get(instID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting instance")
 	}
@@ -214,7 +273,12 @@ func (s *Server) History(inst service.InstanceID, spec update.ServiceSpec, befor
 	return res, nil
 }
 
-func (s *Server) GetConfig(instID service.InstanceID, fingerprint string) (service.InstanceConfig, error) {
+func (s *Server) GetConfig(ctx context.Context, fingerprint string) (service.InstanceConfig, error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return service.InstanceConfig{}, err
+	}
+
 	fullConfig, err := s.config.GetConfig(instID)
 	if err != nil {
 		return service.InstanceConfig{}, err
@@ -234,11 +298,20 @@ func (s *Server) GetConfig(instID service.InstanceID, fingerprint string) (servi
 	return config, nil
 }
 
-func (s *Server) SetConfig(instID service.InstanceID, updates service.InstanceConfig) error {
+func (s *Server) SetConfig(ctx context.Context, updates service.InstanceConfig) error {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return err
+	}
 	return s.config.UpdateConfig(instID, applyConfigUpdates(updates))
 }
 
-func (s *Server) PatchConfig(instID service.InstanceID, patch service.ConfigPatch) error {
+func (s *Server) PatchConfig(ctx context.Context, patch service.ConfigPatch) error {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return err
+	}
+
 	fullConfig, err := s.config.GetConfig(instID)
 	if err != nil {
 		return errors.Wrap(err, "unable to get config")
@@ -259,7 +332,12 @@ func applyConfigUpdates(updates service.InstanceConfig) instance.UpdateFunc {
 	}
 }
 
-func (s *Server) PublicSSHKey(instID service.InstanceID, regenerate bool) (ssh.PublicKey, error) {
+func (s *Server) PublicSSHKey(ctx context.Context, regenerate bool) (ssh.PublicKey, error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return ssh.PublicKey{}, err
+	}
+
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return ssh.PublicKey{}, errors.Wrapf(err, "getting instance "+string(instID))
@@ -286,7 +364,12 @@ func (s *Server) PublicSSHKey(instID service.InstanceID, regenerate bool) (ssh.P
 // go, aside from just trying to connection. Therefore, the server
 // will get an error when we try to use the client. We rely on that to
 // break us out of this method.
-func (s *Server) RegisterDaemon(instID service.InstanceID, platform remote.Platform) (err error) {
+func (s *Server) RegisterDaemon(ctx context.Context, platform remote.Platform) (err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return err
+	}
+
 	defer func() {
 		if err != nil {
 			s.logger.Log("method", "RegisterDaemon", "err", err)
@@ -330,7 +413,12 @@ func setDisconnectedIf(t0 time.Time) instance.UpdateFunc {
 	}
 }
 
-func (s *Server) Export(instID service.InstanceID) (res []byte, err error) {
+func (s *Server) Export(ctx context.Context) (res []byte, err error) {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return res, err
+	}
+
 	inst, err := s.instancer.Get(instID)
 	if err != nil {
 		return res, errors.Wrapf(err, "getting instance")
@@ -351,6 +439,10 @@ func (s *Server) instrumentPlatform(instID service.InstanceID, p remote.Platform
 	}
 }
 
-func (s *Server) IsDaemonConnected(instID service.InstanceID) error {
+func (s *Server) IsDaemonConnected(ctx context.Context) error {
+	instID, err := getInstanceID(ctx)
+	if err != nil {
+		return err
+	}
 	return s.messageBus.Ping(instID)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -8,9 +8,8 @@ import (
 
 type InstanceID string
 
-const NoInstanceID InstanceID = "NoInstanceID"
-
-const InstanceIDHeaderKey = "X-Scope-OrgID"
+// Key against which we'll store the instance ID in contexts
+const InstanceIDKey = "InstanceID"
 
 // TODO: How similar should this be to the `get-config` result?
 type Status struct {


### PR DESCRIPTION
We have InstanceID as the first argument to all the api interface
methods, but it's only the upstream service that cares about
instance(ID)s. Nothing else cares, and they all have to fake it.

They _do_ however care about contexts, both on the client side (for
supplying contexts to requests, even if it's `context.Background()`)
and server side (for threading contexts through from requests).

So, make the first argument of all api methods a `context.Context`
rather than an InstanceID. In the case of the service, the instance ID
is fished out of the request and supplied to the context (the _other_
use of contexts ..).

NB old and new flux{ctl,svc,d} can all still interact, since the context change is in code and not in the API or RPC protocol.