### PR TITLE
Deprecate service nomenclature

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -14,8 +14,8 @@ import (
 
 // API for clients connecting to the service
 type Client interface {
-	ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error)
-	ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error)
+	ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error)
+	ListImages(context.Context, update.ResourceSpec) ([]flux.ImageStatus, error)
 	UpdateImages(context.Context, update.ReleaseSpec, update.Cause) (job.ID, error)
 	SyncNotify(context.Context) error
 	JobStatus(context.Context, job.ID) (job.Status, error)

--- a/api/service.go
+++ b/api/service.go
@@ -14,7 +14,7 @@ type Service interface {
 	Upstream
 
 	Status(context.Context) (service.Status, error)
-	History(context.Context, update.ServiceSpec, time.Time, int64, time.Time) ([]history.Entry, error)
+	History(context.Context, update.ResourceSpec, time.Time, int64, time.Time) ([]history.Entry, error)
 	GetConfig(ctx context.Context, fingerprint string) (service.InstanceConfig, error)
 	SetConfig(context.Context, service.InstanceConfig) error
 	PatchConfig(context.Context, service.ConfigPatch) error

--- a/cluster/kubernetes/policies.go
+++ b/cluster/kubernetes/policies.go
@@ -148,7 +148,7 @@ func parseManifest(def []byte) (Manifest, error) {
 	return m, nil
 }
 
-func (m *Manifests) ServicesWithPolicies(root string) (policy.ServiceMap, error) {
+func (m *Manifests) ServicesWithPolicies(root string) (policy.ResourceMap, error) {
 	all, err := m.FindDefinedServices(root)
 	if err != nil {
 		return nil, err

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -26,7 +26,7 @@ type Manifests interface {
 	// UpdatePolicies modifies a manifest to apply the policy update specified
 	UpdatePolicies([]byte, policy.Update) ([]byte, error)
 	// ServicesWithPolicies returns all services with their associated policies
-	ServicesWithPolicies(path string) (policy.ServiceMap, error)
+	ServicesWithPolicies(path string) (policy.ResourceMap, error)
 }
 
 // UpdateManifest looks for the manifest for a given service, reads

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -21,7 +21,7 @@ type Mock struct {
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
 	UpdatePoliciesFunc       func([]byte, policy.Update) ([]byte, error)
-	ServicesWithPoliciesFunc func(path string) (policy.ServiceMap, error)
+	ServicesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
 }
 
 func (m *Mock) AllControllers(maybeNamespace string) ([]Controller, error) {
@@ -72,6 +72,6 @@ func (m *Mock) UpdatePolicies(def []byte, p policy.Update) ([]byte, error) {
 	return m.UpdatePoliciesFunc(def, p)
 }
 
-func (m *Mock) ServicesWithPolicies(path string) (policy.ServiceMap, error) {
+func (m *Mock) ServicesWithPolicies(path string) (policy.ResourceMap, error) {
 	return m.ServicesWithPoliciesFunc(path)
 }

--- a/cmd/fluxctl/args.go
+++ b/cmd/fluxctl/args.go
@@ -11,11 +11,11 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-func parseServiceOption(s string) (update.ServiceSpec, error) {
+func parseServiceOption(s string) (update.ResourceSpec, error) {
 	if s == "" {
-		return update.ServiceSpecAll, nil
+		return update.ResourceSpecAll, nil
 	}
-	return update.ParseServiceSpec(s)
+	return update.ParseResourceSpec(s)
 }
 
 func AddCauseFlags(cmd *cobra.Command, opts *update.Cause) {

--- a/cmd/fluxctl/args.go
+++ b/cmd/fluxctl/args.go
@@ -11,13 +11,6 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-func parseServiceOption(s string) (update.ResourceSpec, error) {
-	if s == "" {
-		return update.ResourceSpecAll, nil
-	}
-	return update.ParseResourceSpec(s)
-}
-
 func AddCauseFlags(cmd *cobra.Command, opts *update.Cause) {
 	authorInfo := getUserGitconfig()
 	username := getCommitAuthor(authorInfo)

--- a/cmd/fluxctl/error.go
+++ b/cmd/fluxctl/error.go
@@ -29,5 +29,6 @@ func checkExactlyOne(optsDescription string, supplied ...bool) error {
 }
 
 var (
-	errorWantedNoArgs = newUsageError("expected no (non-flag) arguments")
+	errorWantedNoArgs          = newUsageError("expected no (non-flag) arguments")
+	errorServiceFlagDeprecated = newUsageError("--service is deprecated, use --controller instead")
 )

--- a/cmd/fluxctl/format.go
+++ b/cmd/fluxctl/format.go
@@ -15,7 +15,7 @@ type outputOpts struct {
 }
 
 func AddOutputFlags(cmd *cobra.Command, opts *outputOpts) {
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "include ignored services in output")
+	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "include ignored controllers in output")
 }
 
 func newTabwriter() *tabwriter.Writer {

--- a/cmd/fluxctl/list_controllers_cmd.go
+++ b/cmd/fluxctl/list_controllers_cmd.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/policy"
+)
+
+type controllerListOpts struct {
+	*rootOpts
+	namespace     string
+	allNamespaces bool
+}
+
+func newControllerList(parent *rootOpts) *controllerListOpts {
+	return &controllerListOpts{rootOpts: parent}
+}
+
+func (opts *controllerListOpts) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "list-controllers",
+		Short:   "List controllers currently running on the platform.",
+		Example: makeExample("fluxctl list-controllers"),
+		RunE:    opts.RunE,
+	}
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Confine query to namespace")
+	cmd.Flags().BoolVarP(&opts.allNamespaces, "all-namespaces", "a", false, "Query across all namespaces")
+	return cmd
+}
+
+func (opts *controllerListOpts) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return errorWantedNoArgs
+	}
+
+	if opts.allNamespaces {
+		opts.namespace = ""
+	}
+
+	ctx := context.Background()
+
+	controllers, err := opts.API.ListServices(ctx, opts.namespace)
+	if err != nil {
+		return err
+	}
+
+	sort.Sort(controllerStatusByName(controllers))
+
+	w := newTabwriter()
+	fmt.Fprintf(w, "CONTROLLER\tCONTAINER\tIMAGE\tRELEASE\tPOLICY\n")
+	for _, controller := range controllers {
+		if len(controller.Containers) > 0 {
+			c := controller.Containers[0]
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", controller.ID, c.Name, c.Current.ID, controller.Status, policies(controller))
+			for _, c := range controller.Containers[1:] {
+				fmt.Fprintf(w, "\t%s\t%s\t\t\n", c.Name, c.Current.ID)
+			}
+		} else {
+			fmt.Fprintf(w, "%s\t\t\t\t\n", controller.ID)
+		}
+	}
+	w.Flush()
+	return nil
+}
+
+type controllerStatusByName []flux.ControllerStatus
+
+func (s controllerStatusByName) Len() int {
+	return len(s)
+}
+
+func (s controllerStatusByName) Less(a, b int) bool {
+	return s[a].ID.String() < s[b].ID.String()
+}
+
+func (s controllerStatusByName) Swap(a, b int) {
+	s[a], s[b] = s[b], s[a]
+}
+
+func policies(s flux.ControllerStatus) string {
+	var ps []string
+	if s.Automated {
+		ps = append(ps, string(policy.Automated))
+	}
+	if s.Locked {
+		ps = append(ps, string(policy.Locked))
+	}
+	if s.Ignore {
+		ps = append(ps, string(policy.Ignore))
+	}
+	sort.Strings(ps)
+	return strings.Join(ps, ",")
+}

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -63,7 +63,7 @@ func (opts *serviceListOpts) RunE(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-type serviceStatusByName []flux.ServiceStatus
+type serviceStatusByName []flux.ControllerStatus
 
 func (s serviceStatusByName) Len() int {
 	return len(s)
@@ -77,7 +77,7 @@ func (s serviceStatusByName) Swap(a, b int) {
 	s[a], s[b] = s[b], s[a]
 }
 
-func policies(s flux.ServiceStatus) string {
+func policies(s flux.ControllerStatus) string {
 	var ps []string
 	if s.Automated {
 		ps = append(ps, string(policy.Automated))

--- a/cmd/fluxctl/list_services_cmd.go
+++ b/cmd/fluxctl/list_services_cmd.go
@@ -1,15 +1,9 @@
 package main
 
 import (
-	"context"
-	"fmt"
-	"sort"
-	"strings"
+	"errors"
 
 	"github.com/spf13/cobra"
-
-	"github.com/weaveworks/flux"
-	"github.com/weaveworks/flux/policy"
 )
 
 type serviceListOpts struct {
@@ -23,71 +17,15 @@ func newServiceList(parent *rootOpts) *serviceListOpts {
 
 func (opts *serviceListOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list-services",
-		Short:   "List services currently running on the platform.",
-		Example: makeExample("fluxctl list-services"),
-		RunE:    opts.RunE,
+		Use:    "list-services",
+		Short:  "Deprecated - use list-controllers instead",
+		Hidden: true,
+		RunE:   opts.RunE,
 	}
 	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Namespace to query, blank for all namespaces")
 	return cmd
 }
 
 func (opts *serviceListOpts) RunE(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
-		return errorWantedNoArgs
-	}
-
-	ctx := context.Background()
-
-	services, err := opts.API.ListServices(ctx, opts.namespace)
-	if err != nil {
-		return err
-	}
-
-	sort.Sort(serviceStatusByName(services))
-
-	w := newTabwriter()
-	fmt.Fprintf(w, "SERVICE\tCONTAINER\tIMAGE\tRELEASE\tPOLICY\n")
-	for _, s := range services {
-		if len(s.Containers) > 0 {
-			c := s.Containers[0]
-			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\n", s.ID, c.Name, c.Current.ID, s.Status, policies(s))
-			for _, c := range s.Containers[1:] {
-				fmt.Fprintf(w, "\t%s\t%s\t\t\n", c.Name, c.Current.ID)
-			}
-		} else {
-			fmt.Fprintf(w, "%s\t\t\t\t\n", s.ID)
-		}
-	}
-	w.Flush()
-	return nil
-}
-
-type serviceStatusByName []flux.ControllerStatus
-
-func (s serviceStatusByName) Len() int {
-	return len(s)
-}
-
-func (s serviceStatusByName) Less(a, b int) bool {
-	return s[a].ID.String() < s[b].ID.String()
-}
-
-func (s serviceStatusByName) Swap(a, b int) {
-	s[a], s[b] = s[b], s[a]
-}
-
-func policies(s flux.ControllerStatus) string {
-	var ps []string
-	if s.Automated {
-		ps = append(ps, string(policy.Automated))
-	}
-	if s.Locked {
-		ps = append(ps, string(policy.Locked))
-	}
-	if s.Ignore {
-		ps = append(ps, string(policy.Ignore))
-	}
-	sort.Strings(ps)
-	return strings.Join(ps, ",")
+	return errors.New("list-services is deprecated, use list-controllers instead")
 }

--- a/cmd/fluxctl/main_test.go
+++ b/cmd/fluxctl/main_test.go
@@ -86,7 +86,7 @@ func calledURL(method string, calls []mux.RouteMatch) (u *url.URL) {
 
 func testArgs(t *testing.T, args []string, shouldErr bool, errMsg string) *genericMockRoundTripper {
 	svc := newMockService()
-	releaseClient := newServiceRelease(mockServiceOpts(svc))
+	releaseClient := newControllerRelease(mockServiceOpts(svc))
 
 	// Run fluxctl release
 	cmd := releaseClient.Command()

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -62,15 +62,15 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		return newUsageError("please supply either --all, or at least one --service=<service>")
 	}
 
-	var services []update.ServiceSpec
+	var services []update.ResourceSpec
 	if opts.allServices {
-		services = []update.ServiceSpec{update.ServiceSpecAll}
+		services = []update.ResourceSpec{update.ResourceSpecAll}
 	} else {
 		for _, service := range opts.services {
 			if _, err := flux.ParseResourceID(service); err != nil {
 				return err
 			}
-			services = append(services, update.ServiceSpec(service))
+			services = append(services, update.ResourceSpec(service))
 		}
 	}
 

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -10,46 +10,60 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-type serviceReleaseOpts struct {
+type controllerReleaseOpts struct {
 	*rootOpts
-	services    []string
-	allServices bool
-	image       string
-	allImages   bool
-	exclude     []string
-	dryRun      bool
+	namespace      string
+	controllers    []string
+	allControllers bool
+	image          string
+	allImages      bool
+	exclude        []string
+	dryRun         bool
 	outputOpts
 	cause update.Cause
+
+	// Deprecated
+	services []string
 }
 
-func newServiceRelease(parent *rootOpts) *serviceReleaseOpts {
-	return &serviceReleaseOpts{rootOpts: parent}
+func newControllerRelease(parent *rootOpts) *controllerReleaseOpts {
+	return &controllerReleaseOpts{rootOpts: parent}
 }
 
-func (opts *serviceReleaseOpts) Command() *cobra.Command {
+func (opts *controllerReleaseOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "release",
-		Short: "Release a new version of a service.",
+		Short: "Release a new version of a controller.",
 		Example: makeExample(
-			"fluxctl release --service=default/foo --update-image=library/hello:v2",
+			"fluxctl release -n default --controller=deployment/foo --update-image=library/hello:v2",
 			"fluxctl release --all --update-image=library/hello:v2",
-			"fluxctl release --service=default/foo --update-all-images",
+			"fluxctl release --controller=default:deployment/foo --update-all-images",
 		),
 		RunE: opts.RunE,
 	}
 
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", []string{}, "service to release")
-	cmd.Flags().BoolVar(&opts.allServices, "all", false, "release all services")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "controller namespace")
+	cmd.Flags().StringSliceVarP(&opts.controllers, "controller", "c", []string{}, "list of controllers to release <kind>/<name>")
+	cmd.Flags().BoolVar(&opts.allControllers, "all", false, "release all controllers")
 	cmd.Flags().StringVarP(&opts.image, "update-image", "i", "", "update a specific image")
 	cmd.Flags().BoolVar(&opts.allImages, "update-all-images", false, "update all images to latest versions")
-	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "exclude a service")
+	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "exclude a controller")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "do not release anything; just report back what would have been done")
+
+	// Deprecated
+	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", []string{}, "service to release")
+	cmd.Flags().MarkHidden("service")
+
 	return cmd
 }
 
-func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
+func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
+	if len(opts.services) > 0 {
+		return errorServiceFlagDeprecated
+	}
+
 	if len(args) != 0 {
 		return errorWantedNoArgs
 	}
@@ -58,19 +72,20 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if len(opts.services) <= 0 && !opts.allServices {
-		return newUsageError("please supply either --all, or at least one --service=<service>")
+	if len(opts.controllers) <= 0 && !opts.allControllers {
+		return newUsageError("please supply either --all, or at least one --controller=<controller>")
 	}
 
-	var services []update.ResourceSpec
-	if opts.allServices {
-		services = []update.ResourceSpec{update.ResourceSpecAll}
+	var controllers []update.ResourceSpec
+	if opts.allControllers {
+		controllers = []update.ResourceSpec{update.ResourceSpecAll}
 	} else {
-		for _, service := range opts.services {
-			if _, err := flux.ParseResourceID(service); err != nil {
+		for _, controller := range opts.controllers {
+			id, err := flux.ParseResourceIDOptionalNamespace(opts.namespace, controller)
+			if err != nil {
 				return err
 			}
-			services = append(services, update.ResourceSpec(service))
+			controllers = append(controllers, update.MakeResourceSpec(id))
 		}
 	}
 
@@ -95,7 +110,7 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 
 	var excludes []flux.ResourceID
 	for _, exclude := range opts.exclude {
-		s, err := flux.ParseResourceID(exclude)
+		s, err := flux.ParseResourceIDOptionalNamespace(opts.namespace, exclude)
 		if err != nil {
 			return err
 		}
@@ -111,7 +126,7 @@ func (opts *serviceReleaseOpts) RunE(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
 	jobID, err := opts.API.UpdateImages(ctx, update.ReleaseSpec{
-		ServiceSpecs: services,
+		ServiceSpecs: controllers,
 		ImageSpec:    image,
 		Kind:         kind,
 		Excludes:     excludes,

--- a/cmd/fluxctl/release_cmd_test.go
+++ b/cmd/fluxctl/release_cmd_test.go
@@ -26,16 +26,16 @@ func TestReleaseCommand_CLIConversion(t *testing.T) {
 			"image":   "alpine:latest",
 			"kind":    string(update.ReleaseKindExecute),
 		}},
-		{[]string{"--update-all-images", "--service=default/flux"}, map[string]string{
-			"service": "default/flux",
+		{[]string{"--update-all-images", "--controller=deployment/flux"}, map[string]string{
+			"service": "default:deployment/flux",
 			"image":   string(update.ImageSpecLatest),
 			"kind":    string(update.ReleaseKindExecute),
 		}},
-		{[]string{"--update-all-images", "--all", "--exclude=default/test,default/yeah"}, map[string]string{
+		{[]string{"--update-all-images", "--all", "--exclude=deployment/test,deployment/yeah"}, map[string]string{
 			"service": string(update.ResourceSpecAll),
 			"image":   string(update.ImageSpecLatest),
 			"kind":    string(update.ReleaseKindExecute),
-			"exclude": "default/test,default/yeah",
+			"exclude": "default:deployment/test,default:deployment/yeah",
 		}},
 	} {
 		svc := testArgs(t, v.args, false, "")
@@ -66,8 +66,8 @@ func TestReleaseCommand_InputFailures(t *testing.T) {
 		{[]string{}, "Should error when no args"},
 		{[]string{"--all"}, "Should error when not specifying image spec"},
 		{[]string{"--all", "--update-image=alpine"}, "Should error with invalid image spec"},
-		{[]string{"--update-all-images"}, "Should error when not specifying service spec"},
-		{[]string{"--service=invalid&service", "--update-all-images"}, "Should error with invalid service"},
+		{[]string{"--update-all-images"}, "Should error when not specifying controller spec"},
+		{[]string{"--controller=invalid&controller", "--update-all-images"}, "Should error with invalid controller"},
 		{[]string{"subcommand"}, "Should error when given subcommand"},
 	} {
 		testArgs(t, v.args, true, v.msg)

--- a/cmd/fluxctl/release_cmd_test.go
+++ b/cmd/fluxctl/release_cmd_test.go
@@ -12,17 +12,17 @@ func TestReleaseCommand_CLIConversion(t *testing.T) {
 		expectedParams map[string]string
 	}{
 		{[]string{"--update-all-images", "--all"}, map[string]string{
-			"service": string(update.ServiceSpecAll),
+			"service": string(update.ResourceSpecAll),
 			"image":   string(update.ImageSpecLatest),
 			"kind":    string(update.ReleaseKindExecute),
 		}},
 		{[]string{"--update-all-images", "--all", "--dry-run"}, map[string]string{
-			"service": string(update.ServiceSpecAll),
+			"service": string(update.ResourceSpecAll),
 			"image":   string(update.ImageSpecLatest),
 			"kind":    string(update.ReleaseKindPlan),
 		}},
 		{[]string{"--update-image=alpine:latest", "--all"}, map[string]string{
-			"service": string(update.ServiceSpecAll),
+			"service": string(update.ResourceSpecAll),
 			"image":   "alpine:latest",
 			"kind":    string(update.ReleaseKindExecute),
 		}},
@@ -32,7 +32,7 @@ func TestReleaseCommand_CLIConversion(t *testing.T) {
 			"kind":    string(update.ReleaseKindExecute),
 		}},
 		{[]string{"--update-all-images", "--all", "--exclude=default/test,default/yeah"}, map[string]string{
-			"service": string(update.ServiceSpecAll),
+			"service": string(update.ResourceSpecAll),
 			"image":   string(update.ImageSpecLatest),
 			"kind":    string(update.ReleaseKindExecute),
 			"exclude": "default/test,default/yeah",

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -31,9 +31,9 @@ var rootLongHelp = strings.TrimSpace(`
 fluxctl helps you deploy your code.
 
 Workflow:
-  fluxctl list-services                                        # Which services are running?
-  fluxctl list-images --service=default/foo                    # Which images are running/available?
-  fluxctl release --service=default/foo --update-image=bar:v2  # Release new version.
+  fluxctl list-controllers                                           # Which controllers are running?
+  fluxctl list-images --controller=deployment/foo                    # Which images are running/available?
+  fluxctl release --controller=deployment/foo --update-image=bar:v2  # Release new version.
 `)
 
 const (
@@ -57,14 +57,15 @@ func (opts *rootOpts) Command() *cobra.Command {
 
 	cmd.AddCommand(
 		newVersionCommand(),
-		newServiceShow(opts).Command(),
 		newServiceList(opts).Command(),
-		newServiceRelease(opts).Command(),
+		newControllerShow(opts).Command(),
+		newControllerList(opts).Command(),
+		newControllerRelease(opts).Command(),
 		newServiceAutomate(opts).Command(),
-		newServiceDeautomate(opts).Command(),
-		newServiceLock(opts).Command(),
-		newServiceUnlock(opts).Command(),
-		newServicePolicy(opts).Command(),
+		newControllerDeautomate(opts).Command(),
+		newControllerLock(opts).Command(),
+		newControllerUnlock(opts).Command(),
+		newControllerPolicy(opts).Command(),
 		newSave(opts).Command(),
 		newIdentity(opts).Command(),
 	)

--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -26,7 +26,7 @@ func newSave(parent *rootOpts) *saveOpts {
 func (opts *saveOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "save --out config/",
-		Short: "save service definitions to local files in platform-native format",
+		Short: "save controller definitions to local files in platform-native format",
 		Example: makeExample(
 			"fluxctl save",
 		),

--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -74,8 +74,8 @@ func setup(t *testing.T) {
 
 	imageID, _ := flux.ParseImageID("quay.io/weaveworks/helloworld:v1")
 	mockPlatform = &remote.MockPlatform{
-		ListServicesAnswer: []flux.ServiceStatus{
-			flux.ServiceStatus{
+		ListServicesAnswer: []flux.ControllerStatus{
+			flux.ControllerStatus{
 				ID:     flux.MustParseResourceID(helloWorldSvc),
 				Status: "ok",
 				Containers: []flux.Container{
@@ -87,7 +87,7 @@ func setup(t *testing.T) {
 					},
 				},
 			},
-			flux.ServiceStatus{},
+			flux.ControllerStatus{},
 		},
 		ListImagesAnswer: []flux.ImageStatus{
 			flux.ImageStatus{
@@ -202,7 +202,7 @@ func TestFluxsvc_ListImages(t *testing.T) {
 	ctx := context.Background()
 
 	// Test ListImages
-	imgs, err := apiClient.ListImages(ctx, update.ServiceSpecAll)
+	imgs, err := apiClient.ListImages(ctx, update.ResourceSpecAll)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,7 +255,7 @@ func TestFluxsvc_Release(t *testing.T) {
 	r, err := apiClient.UpdateImages(ctx, update.ReleaseSpec{
 		ImageSpec:    "alpine:latest",
 		Kind:         "execute",
-		ServiceSpecs: []update.ServiceSpec{helloWorldSvc},
+		ServiceSpecs: []update.ResourceSpec{helloWorldSvc},
 	}, update.Cause{})
 	if err != nil {
 		t.Fatal(err)

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -129,7 +129,7 @@ func TestDaemon_ListImages(t *testing.T) {
 	ctx := context.Background()
 
 	// List all images for services
-	ss := update.ServiceSpec(update.ServiceSpecAll)
+	ss := update.ResourceSpec(update.ResourceSpecAll)
 	is, err := d.ListImages(ctx, ss)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
@@ -140,7 +140,7 @@ func TestDaemon_ListImages(t *testing.T) {
 	}
 
 	// List images for specific service
-	ss = update.ServiceSpec(svc)
+	ss = update.ResourceSpec(svc)
 	is, err = d.ListImages(ctx, ss)
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
@@ -503,7 +503,7 @@ func updateImage(ctx context.Context, d *Daemon, t *testing.T) job.ID {
 		Type: update.Images,
 		Spec: update.ReleaseSpec{
 			Kind:         update.ReleaseKindExecute,
-			ServiceSpecs: []update.ServiceSpec{update.ServiceSpecAll},
+			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 			ImageSpec:    newHelloImage,
 		},
 	})

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -67,7 +67,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 	}
 }
 
-func getTagPattern(services policy.ServiceMap, service flux.ResourceID, container string) string {
+func getTagPattern(services policy.ResourceMap, service flux.ResourceID, container string) string {
 	policies := services[service]
 	if pattern, ok := policies.Get(policy.TagPrefix(container)); ok {
 		return strings.TrimPrefix(pattern, "glob:")
@@ -75,7 +75,7 @@ func getTagPattern(services policy.ServiceMap, service flux.ResourceID, containe
 	return "*"
 }
 
-func (d *Daemon) unlockedAutomatedServices() (policy.ServiceMap, error) {
+func (d *Daemon) unlockedAutomatedServices() (policy.ResourceMap, error) {
 	services, err := d.Manifests.ServicesWithPolicies(d.Checkout.ManifestDir())
 	if err != nil {
 		return nil, err

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -208,7 +208,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 		}
 	}
 
-	serviceIDs := flux.ServiceIDSet{}
+	serviceIDs := flux.ResourceIDSet{}
 	for _, r := range changedResources {
 		serviceIDs.Add([]flux.ResourceID{r.ResourceID()})
 	}

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -91,7 +91,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ServiceIDs{
+	expectedServiceIDs := flux.ResourceIDs{
 		flux.MustParseResourceID("default:deployment/locked-service"),
 		flux.MustParseResourceID("default:deployment/test-service"),
 		flux.MustParseResourceID("default:deployment/helloworld")}
@@ -123,7 +123,7 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 		t.Errorf("Unexpected event type: %#v", es[0])
 	} else {
 		gotServiceIDs := es[0].ServiceIDs
-		flux.ServiceIDs(gotServiceIDs).Sort()
+		flux.ResourceIDs(gotServiceIDs).Sort()
 		if !reflect.DeepEqual(gotServiceIDs, []flux.ResourceID(expectedServiceIDs)) {
 			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotServiceIDs, expectedServiceIDs)
 		}
@@ -148,7 +148,7 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ServiceIDs{
+	expectedServiceIDs := flux.ResourceIDs{
 		flux.MustParseResourceID("default:deployment/locked-service"),
 		flux.MustParseResourceID("default:deployment/test-service"),
 		flux.MustParseResourceID("default:deployment/helloworld")}
@@ -223,7 +223,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ServiceIDs{
+	expectedServiceIDs := flux.ResourceIDs{
 		flux.MustParseResourceID("default:deployment/locked-service"),
 		flux.MustParseResourceID("default:deployment/test-service"),
 		flux.MustParseResourceID("default:deployment/helloworld")}
@@ -255,7 +255,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 		t.Errorf("Unexpected event type: %#v", es[0])
 	} else {
 		gotServiceIDs := es[0].ServiceIDs
-		flux.ServiceIDs(gotServiceIDs).Sort()
+		flux.ResourceIDs(gotServiceIDs).Sort()
 		// Event should only have changed service ids
 		if !reflect.DeepEqual(gotServiceIDs, []flux.ResourceID{flux.MustParseResourceID("default:deployment/helloworld")}) {
 			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotServiceIDs, []flux.ResourceID{flux.MustParseResourceID("default/helloworld")})

--- a/daemon/notready.go
+++ b/daemon/notready.go
@@ -55,11 +55,11 @@ func (nrd *NotReadyDaemon) Export(ctx context.Context) ([]byte, error) {
 	return nrd.cluster.Export()
 }
 
-func (nrd *NotReadyDaemon) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
+func (nrd *NotReadyDaemon) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
 	return nil, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (nrd *NotReadyDaemon) ListImages(context.Context, update.ResourceSpec) ([]flux.ImageStatus, error) {
 	return nil, nrd.Reason()
 }
 

--- a/daemon/ref.go
+++ b/daemon/ref.go
@@ -46,11 +46,11 @@ func (pr *Ref) Export(ctx context.Context) ([]byte, error) {
 	return pr.Platform().Export(ctx)
 }
 
-func (pr *Ref) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
+func (pr *Ref) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
 	return pr.Platform().ListServices(ctx, namespace)
 }
 
-func (pr *Ref) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (pr *Ref) ListImages(ctx context.Context, spec update.ResourceSpec) ([]flux.ImageStatus, error) {
 	return pr.Platform().ListImages(ctx, spec)
 }
 

--- a/flux.go
+++ b/flux.go
@@ -139,9 +139,9 @@ func (id *ResourceID) UnmarshalText(text []byte) error {
 	return nil
 }
 
-type ServiceIDSet map[ResourceID]struct{}
+type ResourceIDSet map[ResourceID]struct{}
 
-func (s ServiceIDSet) String() string {
+func (s ResourceIDSet) String() string {
 	var ids []string
 	for id := range s {
 		ids = append(ids, id.String())
@@ -149,17 +149,17 @@ func (s ServiceIDSet) String() string {
 	return "{" + strings.Join(ids, ", ") + "}"
 }
 
-func (s ServiceIDSet) Add(ids []ResourceID) {
+func (s ResourceIDSet) Add(ids []ResourceID) {
 	for _, id := range ids {
 		s[id] = struct{}{}
 	}
 }
 
-func (s ServiceIDSet) Without(others ServiceIDSet) ServiceIDSet {
+func (s ResourceIDSet) Without(others ResourceIDSet) ResourceIDSet {
 	if s == nil || len(s) == 0 || others == nil || len(others) == 0 {
 		return s
 	}
-	res := ServiceIDSet{}
+	res := ResourceIDSet{}
 	for id := range s {
 		if !others.Contains(id) {
 			res[id] = struct{}{}
@@ -168,7 +168,7 @@ func (s ServiceIDSet) Without(others ServiceIDSet) ServiceIDSet {
 	return res
 }
 
-func (s ServiceIDSet) Contains(id ResourceID) bool {
+func (s ResourceIDSet) Contains(id ResourceID) bool {
 	if s == nil {
 		return false
 	}
@@ -176,14 +176,14 @@ func (s ServiceIDSet) Contains(id ResourceID) bool {
 	return ok
 }
 
-func (s ServiceIDSet) Intersection(others ServiceIDSet) ServiceIDSet {
+func (s ResourceIDSet) Intersection(others ResourceIDSet) ResourceIDSet {
 	if s == nil {
 		return others
 	}
 	if others == nil {
 		return s
 	}
-	result := ServiceIDSet{}
+	result := ResourceIDSet{}
 	for id := range s {
 		if _, ok := others[id]; ok {
 			result[id] = struct{}{}
@@ -192,9 +192,9 @@ func (s ServiceIDSet) Intersection(others ServiceIDSet) ServiceIDSet {
 	return result
 }
 
-func (s ServiceIDSet) ToSlice() ServiceIDs {
+func (s ResourceIDSet) ToSlice() ResourceIDs {
 	i := 0
-	keys := make(ServiceIDs, len(s))
+	keys := make(ResourceIDs, len(s))
 	for k := range s {
 		keys[i] = k
 		i++
@@ -202,14 +202,14 @@ func (s ServiceIDSet) ToSlice() ServiceIDs {
 	return keys
 }
 
-type ServiceIDs []ResourceID
+type ResourceIDs []ResourceID
 
-func (p ServiceIDs) Len() int           { return len(p) }
-func (p ServiceIDs) Less(i, j int) bool { return p[i].String() < p[j].String() }
-func (p ServiceIDs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
-func (p ServiceIDs) Sort()              { sort.Sort(p) }
+func (p ResourceIDs) Len() int           { return len(p) }
+func (p ResourceIDs) Less(i, j int) bool { return p[i].String() < p[j].String() }
+func (p ResourceIDs) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p ResourceIDs) Sort()              { sort.Sort(p) }
 
-func (ids ServiceIDs) Without(others ServiceIDSet) (res ServiceIDs) {
+func (ids ResourceIDs) Without(others ResourceIDSet) (res ResourceIDs) {
 	for _, id := range ids {
 		if !others.Contains(id) {
 			res = append(res, id)
@@ -218,14 +218,14 @@ func (ids ServiceIDs) Without(others ServiceIDSet) (res ServiceIDs) {
 	return res
 }
 
-func (ids ServiceIDs) Contains(id ResourceID) bool {
-	set := ServiceIDSet{}
+func (ids ResourceIDs) Contains(id ResourceID) bool {
+	set := ResourceIDSet{}
 	set.Add(ids)
 	return set.Contains(id)
 }
 
-func (ids ServiceIDs) Intersection(others ServiceIDSet) ServiceIDSet {
-	set := ServiceIDSet{}
+func (ids ResourceIDs) Intersection(others ResourceIDSet) ResourceIDSet {
+	set := ResourceIDSet{}
 	set.Add(ids)
 	return set.Intersection(others)
 }
@@ -237,7 +237,7 @@ type ImageStatus struct {
 	Containers []Container
 }
 
-type ServiceStatus struct {
+type ControllerStatus struct {
 	ID         ResourceID
 	Containers []Container
 	Status     string

--- a/git/gittest/repo_test.go
+++ b/git/gittest/repo_test.go
@@ -82,7 +82,7 @@ func TestCheckout(t *testing.T) {
 			Spec: update.ReleaseSpec{},
 		},
 		Result: update.Result{
-			flux.MustParseResourceID("default/service1"): update.ServiceResult{
+			flux.MustParseResourceID("default/service1"): update.ControllerResult{
 				Status: update.ReleaseStatusFailed,
 				Error:  "failed the frobulator",
 			},

--- a/history/event.go
+++ b/history/event.go
@@ -91,7 +91,7 @@ func (e Event) String() string {
 			strImageIDs = []string{"no image changes"}
 		}
 		for _, spec := range metadata.Spec.ServiceSpecs {
-			if spec == update.ServiceSpecAll {
+			if spec == update.ResourceSpecAll {
 				strServiceIDs = []string{"all services"}
 				break
 			}

--- a/history/mock.go
+++ b/history/mock.go
@@ -28,7 +28,7 @@ func (m *Mock) EventsForService(serviceID flux.ResourceID, _ time.Time, _ int64,
 	defer m.RUnlock()
 	var found []Event
 	for _, e := range m.events {
-		set := flux.ServiceIDSet{}
+		set := flux.ResourceIDSet{}
 		set.Add(e.ServiceIDs)
 		if set.Contains(serviceID) {
 			found = append(found, e)

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -37,13 +37,13 @@ func New(c *http.Client, router *mux.Router, endpoint string, t flux.Token) *Cli
 	}
 }
 
-func (c *Client) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
-	var res []flux.ServiceStatus
+func (c *Client) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
+	var res []flux.ControllerStatus
 	err := c.Get(ctx, &res, "ListServices", "namespace", namespace)
 	return res, err
 }
 
-func (c *Client) ListImages(ctx context.Context, s update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (c *Client) ListImages(ctx context.Context, s update.ResourceSpec) ([]flux.ImageStatus, error) {
 	var res []flux.ImageStatus
 	err := c.Get(ctx, &res, "ListImages", "service", string(s))
 	return res, err

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -96,7 +96,7 @@ func (s HTTPServer) SyncStatus(w http.ResponseWriter, r *http.Request) {
 
 func (s HTTPServer) ListImages(w http.ResponseWriter, r *http.Request) {
 	service := mux.Vars(r)["service"]
-	spec, err := update.ParseServiceSpec(service)
+	spec, err := update.ParseResourceSpec(service)
 	if err != nil {
 		transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", service))
 		return
@@ -120,9 +120,9 @@ func (s HTTPServer) UpdateImages(w http.ResponseWriter, r *http.Request) {
 		transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing form"))
 		return
 	}
-	var serviceSpecs []update.ServiceSpec
+	var serviceSpecs []update.ResourceSpec
 	for _, service := range r.Form["service"] {
-		serviceSpec, err := update.ParseServiceSpec(service)
+		serviceSpec, err := update.ParseResourceSpec(service)
 		if err != nil {
 			transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", service))
 			return

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -112,9 +112,9 @@ func (s Set) ToStringMap() map[string]string {
 	return m
 }
 
-type ServiceMap map[flux.ResourceID]Set
+type ResourceMap map[flux.ResourceID]Set
 
-func (s ServiceMap) ToSlice() []flux.ResourceID {
+func (s ResourceMap) ToSlice() []flux.ResourceID {
 	slice := []flux.ResourceID{}
 	for service, _ := range s {
 		slice = append(slice, service)
@@ -122,13 +122,13 @@ func (s ServiceMap) ToSlice() []flux.ResourceID {
 	return slice
 }
 
-func (s ServiceMap) Contains(id flux.ResourceID) bool {
+func (s ResourceMap) Contains(id flux.ResourceID) bool {
 	_, ok := s[id]
 	return ok
 }
 
-func (s ServiceMap) Without(other ServiceMap) ServiceMap {
-	newMap := ServiceMap{}
+func (s ResourceMap) Without(other ResourceMap) ResourceMap {
+	newMap := ResourceMap{}
 	for k, v := range s {
 		if !other.Contains(k) {
 			newMap[k] = v
@@ -137,8 +137,8 @@ func (s ServiceMap) Without(other ServiceMap) ServiceMap {
 	return newMap
 }
 
-func (s ServiceMap) OnlyWithPolicy(p Policy) ServiceMap {
-	newMap := ServiceMap{}
+func (s ResourceMap) OnlyWithPolicy(p Policy) ResourceMap {
+	newMap := ResourceMap{}
 	for k, v := range s {
 		if _, ok := v[p]; ok {
 			newMap[k] = v

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -9,7 +9,7 @@ import (
 )
 
 type Changes interface {
-	CalculateRelease(update.ReleaseContext, log.Logger) ([]*update.ServiceUpdate, update.Result, error)
+	CalculateRelease(update.ReleaseContext, log.Logger) ([]*update.ControllerUpdate, update.Result, error)
 	ReleaseKind() update.ReleaseKind
 	ReleaseType() update.ReleaseType
 	CommitMessage() string
@@ -36,7 +36,7 @@ func Release(rc *ReleaseContext, changes Changes, logger log.Logger) (results up
 	return results, err
 }
 
-func ApplyChanges(rc *ReleaseContext, updates []*update.ServiceUpdate, logger log.Logger) error {
+func ApplyChanges(rc *ReleaseContext, updates []*update.ControllerUpdate, logger log.Logger) error {
 	logger.Log("updates", len(updates))
 	if len(updates) == 0 {
 		logger.Log("exit", "no images to update for services given")

--- a/remote/errors.go
+++ b/remote/errors.go
@@ -56,15 +56,16 @@ func UnsupportedResourceKind(err error) error {
 		Type: fluxerr.User,
 		Help: err.Error() + `
 
-The version of the agent running in your cluster (fluxd) can only
-release updates to named deployments. The ability to release to other
-kinds of pod controllers (such as daemon sets and stateful sets) will
-be added in a future version of flux.
+The version of the agent running in your cluster (fluxd) can release updates to
+the following kinds of pod controller: Deployments, DaemonSets, StatefulSets
+and CronJobs. When new kinds are added to Kubernetes, we try to support them as
+quickly as possible - check here to see if a new version of flux is available:
 
-Important - releasing by service name is no longer supported - if
-you're using an old version of fluxctl that does not let you specify
-a kind other than 'service', you will need to upgrade it.
+	https://github.com/weaveworks/flux/releases
 
+Releasing by Service is not supported - if you're using an old version of
+fluxctl that accepts the '--service' argument you will need to get a new one
+that matches your agent.
 `,
 		Err: err,
 	}

--- a/remote/logging.go
+++ b/remote/logging.go
@@ -43,7 +43,7 @@ func (p *ErrorLoggingPlatform) Export(ctx context.Context) (config []byte, err e
 	return p.Platform.Export(ctx)
 }
 
-func (p *ErrorLoggingPlatform) ListServices(ctx context.Context, maybeNamespace string) (_ []flux.ServiceStatus, err error) {
+func (p *ErrorLoggingPlatform) ListServices(ctx context.Context, maybeNamespace string) (_ []flux.ControllerStatus, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "ListServices", "error", err)
@@ -52,7 +52,7 @@ func (p *ErrorLoggingPlatform) ListServices(ctx context.Context, maybeNamespace 
 	return p.Platform.ListServices(ctx, maybeNamespace)
 }
 
-func (p *ErrorLoggingPlatform) ListImages(ctx context.Context, spec update.ServiceSpec) (_ []flux.ImageStatus, err error) {
+func (p *ErrorLoggingPlatform) ListImages(ctx context.Context, spec update.ResourceSpec) (_ []flux.ImageStatus, err error) {
 	defer func() {
 		if err != nil {
 			p.Logger.Log("method", "ListImages", "error", err)

--- a/remote/metrics.go
+++ b/remote/metrics.go
@@ -62,7 +62,7 @@ func (i *instrumentedPlatform) Export(ctx context.Context) (config []byte, err e
 	return i.p.Export(ctx)
 }
 
-func (i *instrumentedPlatform) ListServices(ctx context.Context, namespace string) (_ []flux.ServiceStatus, err error) {
+func (i *instrumentedPlatform) ListServices(ctx context.Context, namespace string) (_ []flux.ControllerStatus, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "ListServices",
@@ -72,7 +72,7 @@ func (i *instrumentedPlatform) ListServices(ctx context.Context, namespace strin
 	return i.p.ListServices(ctx, namespace)
 }
 
-func (i *instrumentedPlatform) ListImages(ctx context.Context, spec update.ServiceSpec) (_ []flux.ImageStatus, err error) {
+func (i *instrumentedPlatform) ListImages(ctx context.Context, spec update.ResourceSpec) (_ []flux.ImageStatus, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "ListImages",

--- a/remote/platform.go
+++ b/remote/platform.go
@@ -39,8 +39,8 @@ type PlatformV5 interface {
 type PlatformV6 interface {
 	PlatformV5
 	// These are new, or newly moved to this interface
-	ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error)
-	ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error)
+	ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error)
+	ListImages(context.Context, update.ResourceSpec) ([]flux.ImageStatus, error)
 	// Send a spec for updating config to the daemon
 	UpdateManifests(context.Context, update.Spec) (job.ID, error)
 	// Poke the daemon to sync with git

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -27,11 +27,11 @@ func (bc baseClient) Export(context.Context) ([]byte, error) {
 	return nil, remote.UpgradeNeededError(errors.New("Export method not implemented"))
 }
 
-func (bc baseClient) ListServices(context.Context, string) ([]flux.ServiceStatus, error) {
+func (bc baseClient) ListServices(context.Context, string) ([]flux.ControllerStatus, error) {
 	return nil, remote.UpgradeNeededError(errors.New("ListServices method not implemented"))
 }
 
-func (bc baseClient) ListImages(context.Context, update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (bc baseClient) ListImages(context.Context, update.ResourceSpec) ([]flux.ImageStatus, error) {
 	return nil, remote.UpgradeNeededError(errors.New("ListImages method not implemented"))
 }
 

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -58,8 +58,8 @@ func (p *RPCClientV6) Export(ctx context.Context) ([]byte, error) {
 }
 
 // Export is used to get service configuration in platform-specific format
-func (p *RPCClientV6) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
-	var services []flux.ServiceStatus
+func (p *RPCClientV6) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
+	var services []flux.ControllerStatus
 	err := p.client.Call("RPCServer.ListServices", namespace, &services)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
 		return nil, remote.FatalError{err}
@@ -70,7 +70,7 @@ func (p *RPCClientV6) ListServices(ctx context.Context, namespace string) ([]flu
 	return services, err
 }
 
-func (p *RPCClientV6) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (p *RPCClientV6) ListImages(ctx context.Context, spec update.ResourceSpec) ([]flux.ImageStatus, error) {
 	var images []flux.ImageStatus
 	if err := requireServiceSpecKinds(spec, supportedKindsV6); err != nil {
 		return images, remote.UpgradeNeededError(err)

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -42,7 +42,7 @@ func (p *RPCClientV7) Export(ctx context.Context) ([]byte, error) {
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
+func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
 	var resp ListServicesResponse
 	err := p.client.Call("RPCServer.ListServices", namespace, &resp)
 	if err != nil {
@@ -56,7 +56,7 @@ func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]flu
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (p *RPCClientV7) ListImages(ctx context.Context, spec update.ResourceSpec) ([]flux.ImageStatus, error) {
 	var resp ListImagesResponse
 	if err := requireServiceSpecKinds(spec, supportedKindsV7); err != nil {
 		return resp.Result, remote.UpgradeNeededError(err)

--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -27,7 +27,7 @@ func NewClientV8(conn io.ReadWriteCloser) *RPCClientV8 {
 	return &RPCClientV8{NewClientV7(conn)}
 }
 
-func (p *RPCClientV8) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (p *RPCClientV8) ListImages(ctx context.Context, spec update.ResourceSpec) ([]flux.ImageStatus, error) {
 	var resp ListImagesResponse
 	if err := requireServiceSpecKinds(spec, supportedKindsV8); err != nil {
 		return resp.Result, remote.UnsupportedResourceKind(err)

--- a/remote/rpc/compat.go
+++ b/remote/rpc/compat.go
@@ -7,7 +7,7 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-func requireServiceSpecKinds(ss update.ServiceSpec, kinds []string) error {
+func requireServiceSpecKinds(ss update.ResourceSpec, kinds []string) error {
 	id, err := ss.AsID()
 	if err != nil {
 		return nil

--- a/remote/rpc/server.go
+++ b/remote/rpc/server.go
@@ -67,7 +67,7 @@ func (p *RPCServer) Export(_ struct{}, resp *ExportResponse) error {
 }
 
 type ListServicesResponse struct {
-	Result           []flux.ServiceStatus
+	Result           []flux.ControllerStatus
 	ApplicationError *fluxerr.Error
 }
 
@@ -88,7 +88,7 @@ type ListImagesResponse struct {
 	ApplicationError *fluxerr.Error
 }
 
-func (p *RPCServer) ListImages(spec update.ServiceSpec, resp *ListImagesResponse) error {
+func (p *RPCServer) ListImages(spec update.ResourceSpec, resp *ListImagesResponse) error {
 	v, err := p.p.ListImages(context.Background(), spec)
 	resp.Result = v
 	if err != nil {

--- a/service/bus/nats/bus.go
+++ b/service/bus/nats/bus.go
@@ -138,7 +138,7 @@ type ExportResponse struct {
 }
 
 type ListServicesResponse struct {
-	Result        []flux.ServiceStatus
+	Result        []flux.ControllerStatus
 	ErrorResponse `json:",omitempty`
 }
 
@@ -234,7 +234,7 @@ func (r *natsPlatform) Export(ctx context.Context) ([]byte, error) {
 	return response.Result, extractError(response.ErrorResponse)
 }
 
-func (r *natsPlatform) ListServices(ctx context.Context, namespace string) ([]flux.ServiceStatus, error) {
+func (r *natsPlatform) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
 	var response ListServicesResponse
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -244,7 +244,7 @@ func (r *natsPlatform) ListServices(ctx context.Context, namespace string) ([]fl
 	return response.Result, extractError(response.ErrorResponse)
 }
 
-func (r *natsPlatform) ListImages(ctx context.Context, spec update.ServiceSpec) ([]flux.ImageStatus, error) {
+func (r *natsPlatform) ListImages(ctx context.Context, spec update.ResourceSpec) ([]flux.ImageStatus, error) {
 	var response ListImagesResponse
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -414,7 +414,7 @@ func (n *NATS) processRequest(ctx context.Context, request *nats.Msg, instID ser
 	case strings.HasSuffix(request.Subject, methodListServices):
 		var (
 			namespace string
-			res       []flux.ServiceStatus
+			res       []flux.ControllerStatus
 		)
 		err = encoder.Decode(request.Subject, request.Data, &namespace)
 		if err == nil {
@@ -424,7 +424,7 @@ func (n *NATS) processRequest(ctx context.Context, request *nats.Msg, instID ser
 
 	case strings.HasSuffix(request.Subject, methodListImages):
 		var (
-			req update.ServiceSpec
+			req update.ResourceSpec
 			res []flux.ImageStatus
 		)
 		err = encoder.Decode(request.Subject, request.Data, &req)

--- a/service/http/server.go
+++ b/service/http/server.go
@@ -141,7 +141,7 @@ func (s HTTPService) ListServices(w http.ResponseWriter, r *http.Request) {
 func (s HTTPService) ListImages(w http.ResponseWriter, r *http.Request) {
 	ctx := getRequestContext(r)
 	service := mux.Vars(r)["service"]
-	spec, err := update.ParseServiceSpec(service)
+	spec, err := update.ParseResourceSpec(service)
 	if err != nil {
 		transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", service))
 		return
@@ -167,9 +167,9 @@ func (s HTTPService) UpdateImages(w http.ResponseWriter, r *http.Request) {
 		transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing form"))
 		return
 	}
-	var serviceSpecs []update.ServiceSpec
+	var serviceSpecs []update.ResourceSpec
 	for _, service := range r.Form["service"] {
-		serviceSpec, err := update.ParseServiceSpec(service)
+		serviceSpec, err := update.ParseResourceSpec(service)
 		if err != nil {
 			transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", service))
 			return
@@ -288,7 +288,7 @@ func (s HTTPService) LogEvent(w http.ResponseWriter, r *http.Request) {
 func (s HTTPService) History(w http.ResponseWriter, r *http.Request) {
 	ctx := getRequestContext(r)
 	service := mux.Vars(r)["service"]
-	spec, err := update.ParseServiceSpec(service)
+	spec, err := update.ParseResourceSpec(service)
 	if err != nil {
 		transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", spec))
 		return

--- a/service/notifications/notifications_test.go
+++ b/service/notifications/notifications_test.go
@@ -35,7 +35,7 @@ func exampleRelease(t *testing.T) *history.ReleaseEventMetadata {
 			Message: "this was to test notifications",
 		},
 		Spec: update.ReleaseSpec{
-			ServiceSpecs: []update.ServiceSpec{update.ServiceSpec("default/helloworld")},
+			ServiceSpecs: []update.ResourceSpec{update.ResourceSpec("default/helloworld")},
 			ImageSpec:    update.ImageSpecLatest,
 			Kind:         update.ReleaseKindExecute,
 			Excludes:     nil,

--- a/service/server/server.go
+++ b/service/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) Status(ctx context.Context) (res service.Status, err error) {
 	return res, nil
 }
 
-func (s *Server) ListServices(ctx context.Context, namespace string) (res []flux.ServiceStatus, err error) {
+func (s *Server) ListServices(ctx context.Context, namespace string) (res []flux.ControllerStatus, err error) {
 	instID, err := getInstanceID(ctx)
 	if err != nil {
 		return res, err
@@ -123,7 +123,7 @@ func (s *Server) ListServices(ctx context.Context, namespace string) (res []flux
 	return services, nil
 }
 
-func (s *Server) ListImages(ctx context.Context, spec update.ServiceSpec) (res []flux.ImageStatus, err error) {
+func (s *Server) ListImages(ctx context.Context, spec update.ResourceSpec) (res []flux.ImageStatus, err error) {
 	instID, err := getInstanceID(ctx)
 	if err != nil {
 		return res, err
@@ -231,7 +231,7 @@ func (s *Server) LogEvent(ctx context.Context, e history.Event) error {
 	return nil
 }
 
-func (s *Server) History(ctx context.Context, spec update.ServiceSpec, before time.Time, limit int64, after time.Time) (res []history.Entry, err error) {
+func (s *Server) History(ctx context.Context, spec update.ResourceSpec, before time.Time, limit int64, after time.Time) (res []history.Entry, err error) {
 	instID, err := getInstanceID(ctx)
 	if err != nil {
 		return res, err
@@ -243,7 +243,7 @@ func (s *Server) History(ctx context.Context, spec update.ServiceSpec, before ti
 	}
 
 	var events []history.Event
-	if spec == update.ServiceSpecAll {
+	if spec == update.ResourceSpecAll {
 		events, err = helper.AllEvents(before, limit, after)
 		if err != nil {
 			return nil, errors.Wrap(err, "fetching all history events")

--- a/update/filter.go
+++ b/update/filter.go
@@ -18,24 +18,24 @@ type SpecificImageFilter struct {
 	Img flux.ImageID
 }
 
-func (f *SpecificImageFilter) Filter(u ServiceUpdate) ServiceResult {
+func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
 	// If there are no containers, then we can't check the image.
-	if len(u.Service.Containers.Containers) == 0 {
-		return ServiceResult{
+	if len(u.Controller.Containers.Containers) == 0 {
+		return ControllerResult{
 			Status: ReleaseStatusIgnored,
 			Error:  NotInCluster,
 		}
 	}
 	// For each container in update
-	for _, c := range u.Service.Containers.Containers {
+	for _, c := range u.Controller.Containers.Containers {
 		cID, _ := flux.ParseImageID(c.Image)
 		// If container image == image in update
 		if cID.HostNamespaceImage() == f.Img.HostNamespaceImage() {
 			// We want to update this
-			return ServiceResult{}
+			return ControllerResult{}
 		}
 	}
-	return ServiceResult{
+	return ControllerResult{
 		Status: ReleaseStatusIgnored,
 		Error:  DifferentImage,
 	}
@@ -45,29 +45,29 @@ type ExcludeFilter struct {
 	IDs []flux.ResourceID
 }
 
-func (f *ExcludeFilter) Filter(u ServiceUpdate) ServiceResult {
+func (f *ExcludeFilter) Filter(u ControllerUpdate) ControllerResult {
 	for _, id := range f.IDs {
-		if u.ServiceID == id {
-			return ServiceResult{
+		if u.ResourceID == id {
+			return ControllerResult{
 				Status: ReleaseStatusIgnored,
 				Error:  Excluded,
 			}
 		}
 	}
-	return ServiceResult{}
+	return ControllerResult{}
 }
 
 type IncludeFilter struct {
 	IDs []flux.ResourceID
 }
 
-func (f *IncludeFilter) Filter(u ServiceUpdate) ServiceResult {
+func (f *IncludeFilter) Filter(u ControllerUpdate) ControllerResult {
 	for _, id := range f.IDs {
-		if u.ServiceID == id {
-			return ServiceResult{}
+		if u.ResourceID == id {
+			return ControllerResult{}
 		}
 	}
-	return ServiceResult{
+	return ControllerResult{
 		Status: ReleaseStatusIgnored,
 		Error:  NotIncluded,
 	}
@@ -77,14 +77,14 @@ type LockedFilter struct {
 	IDs []flux.ResourceID
 }
 
-func (f *LockedFilter) Filter(u ServiceUpdate) ServiceResult {
+func (f *LockedFilter) Filter(u ControllerUpdate) ControllerResult {
 	for _, id := range f.IDs {
-		if u.ServiceID == id {
-			return ServiceResult{
+		if u.ResourceID == id {
+			return ControllerResult{
 				Status: ReleaseStatusSkipped,
 				Error:  Locked,
 			}
 		}
 	}
-	return ServiceResult{}
+	return ControllerResult{}
 }

--- a/update/images.go
+++ b/update/images.go
@@ -37,10 +37,10 @@ func (m ImageMap) LatestImage(repo, tagGlob string) *flux.Image {
 
 // CollectUpdateImages is a convenient shim to
 // `CollectAvailableImages`.
-func collectUpdateImages(registry registry.Registry, updateable []*ServiceUpdate, logger log.Logger) (ImageMap, error) {
+func collectUpdateImages(registry registry.Registry, updateable []*ControllerUpdate, logger log.Logger) (ImageMap, error) {
 	var servicesToCheck []cluster.Controller
 	for _, update := range updateable {
-		servicesToCheck = append(servicesToCheck, update.Service)
+		servicesToCheck = append(servicesToCheck, update.Controller)
 	}
 	return CollectAvailableImages(registry, servicesToCheck, logger)
 }

--- a/update/print.go
+++ b/update/print.go
@@ -10,7 +10,7 @@ import (
 
 func PrintResults(out io.Writer, results Result, verbose bool) {
 	w := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
-	fmt.Fprintln(w, "SERVICE \tSTATUS \tUPDATES")
+	fmt.Fprintln(w, "CONTROLLER \tSTATUS \tUPDATES")
 	for _, serviceID := range results.ServiceIDs() {
 		result := results[flux.MustParseResourceID(serviceID)]
 		switch result.Status {

--- a/update/print_test.go
+++ b/update/print_test.go
@@ -30,7 +30,7 @@ func TestPrintResults(t *testing.T) {
 				},
 			},
 			expected: `
-SERVICE             STATUS   UPDATES
+CONTROLLER          STATUS   UPDATES
 default/helloworld  success  helloworld: quay.io/weaveworks/helloworld:master-a000002 -> master-a000001
 `,
 		},
@@ -51,7 +51,7 @@ default/helloworld  success  helloworld: quay.io/weaveworks/helloworld:master-a0
 				},
 			},
 			expected: `
-SERVICE             STATUS   UPDATES
+CONTROLLER          STATUS   UPDATES
 default/helloworld  success  test error
                              helloworld: quay.io/weaveworks/helloworld:master-a000002 -> master-a000001
 `,
@@ -66,11 +66,11 @@ default/helloworld  success  test error
 				flux.MustParseResourceID("default/a"): ControllerResult{Status: ReleaseStatusSuccess},
 			},
 			expected: `
-SERVICE    STATUS   UPDATES
-default/a  success  
-default/b  success  
-default/c  success  
-default/d  success  
+CONTROLLER   STATUS   UPDATES
+default/a    success  
+default/b    success  
+default/c    success  
+default/d    success  
 `,
 		},
 	} {

--- a/update/print_test.go
+++ b/update/print_test.go
@@ -17,7 +17,7 @@ func TestPrintResults(t *testing.T) {
 		{
 			name: "basic, just results",
 			result: Result{
-				flux.MustParseResourceID("default/helloworld"): ServiceResult{
+				flux.MustParseResourceID("default/helloworld"): ControllerResult{
 					Status: ReleaseStatusSuccess,
 					Error:  "",
 					PerContainer: []ContainerUpdate{
@@ -38,7 +38,7 @@ default/helloworld  success  helloworld: quay.io/weaveworks/helloworld:master-a0
 		{
 			name: "With an error, *and* results",
 			result: Result{
-				flux.MustParseResourceID("default/helloworld"): ServiceResult{
+				flux.MustParseResourceID("default/helloworld"): ControllerResult{
 					Status: ReleaseStatusSuccess,
 					Error:  "test error",
 					PerContainer: []ContainerUpdate{
@@ -60,10 +60,10 @@ default/helloworld  success  test error
 		{
 			name: "Service results should be sorted",
 			result: Result{
-				flux.MustParseResourceID("default/d"): ServiceResult{Status: ReleaseStatusSuccess},
-				flux.MustParseResourceID("default/c"): ServiceResult{Status: ReleaseStatusSuccess},
-				flux.MustParseResourceID("default/b"): ServiceResult{Status: ReleaseStatusSuccess},
-				flux.MustParseResourceID("default/a"): ServiceResult{Status: ReleaseStatusSuccess},
+				flux.MustParseResourceID("default/d"): ControllerResult{Status: ReleaseStatusSuccess},
+				flux.MustParseResourceID("default/c"): ControllerResult{Status: ReleaseStatusSuccess},
+				flux.MustParseResourceID("default/b"): ControllerResult{Status: ReleaseStatusSuccess},
+				flux.MustParseResourceID("default/a"): ControllerResult{Status: ReleaseStatusSuccess},
 			},
 			expected: `
 SERVICE    STATUS   UPDATES

--- a/update/release.go
+++ b/update/release.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	ServiceSpecAll  = ServiceSpec("<all>")
+	ResourceSpecAll = ResourceSpec("<all>")
 	ImageSpecLatest = ImageSpec("<all latest>")
 )
 
@@ -45,8 +45,8 @@ func ParseReleaseKind(s string) (ReleaseKind, error) {
 const UserAutomated = "<automated>"
 
 type ReleaseContext interface {
-	SelectServices(Result, ...ServiceFilter) ([]*ServiceUpdate, error)
-	ServicesWithPolicies() (policy.ServiceMap, error)
+	SelectServices(Result, ...ControllerFilter) ([]*ControllerUpdate, error)
+	ServicesWithPolicies() (policy.ResourceMap, error)
 	Registry() registry.Registry
 	Manifests() cluster.Manifests
 }
@@ -54,7 +54,7 @@ type ReleaseContext interface {
 // NB: these get sent from fluxctl, so we have to maintain the json format of
 // this. Eugh.
 type ReleaseSpec struct {
-	ServiceSpecs []ServiceSpec
+	ServiceSpecs []ResourceSpec
 	ImageSpec    ImageSpec
 	Kind         ReleaseKind
 	Excludes     []flux.ResourceID
@@ -71,7 +71,7 @@ func (s ReleaseSpec) ReleaseType() ReleaseType {
 	}
 }
 
-func (s ReleaseSpec) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*ServiceUpdate, Result, error) {
+func (s ReleaseSpec) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*ControllerUpdate, Result, error) {
 	results := Result{}
 	timer := NewStageTimer("select_services")
 	updates, err := s.selectServices(rc, results)
@@ -106,7 +106,7 @@ func (s ReleaseSpec) CommitMessage() string {
 // Take the spec given in the job, and figure out which services are
 // in question based on the running services and those defined in the
 // repo. Fill in the release results along the way.
-func (s ReleaseSpec) selectServices(rc ReleaseContext, results Result) ([]*ServiceUpdate, error) {
+func (s ReleaseSpec) selectServices(rc ReleaseContext, results Result) ([]*ControllerUpdate, error) {
 	// Build list of filters
 	filtList, err := s.filters(rc)
 	if err != nil {
@@ -120,9 +120,9 @@ func (s ReleaseSpec) selectServices(rc ReleaseContext, results Result) ([]*Servi
 }
 
 // filters converts a ReleaseSpec (and Lock config) into ServiceFilters
-func (s ReleaseSpec) filters(rc ReleaseContext) ([]ServiceFilter, error) {
+func (s ReleaseSpec) filters(rc ReleaseContext) ([]ControllerFilter, error) {
 	// Image filter
-	var filtList []ServiceFilter
+	var filtList []ControllerFilter
 	if s.ImageSpec != ImageSpecLatest {
 		id, err := flux.ParseImageID(s.ImageSpec.String())
 		if err != nil {
@@ -134,7 +134,7 @@ func (s ReleaseSpec) filters(rc ReleaseContext) ([]ServiceFilter, error) {
 	// Service filter
 	ids := []flux.ResourceID{}
 	for _, s := range s.ServiceSpecs {
-		if s == ServiceSpecAll {
+		if s == ResourceSpecAll {
 			// "<all>" Overrides any other filters
 			ids = []flux.ResourceID{}
 			break
@@ -166,7 +166,7 @@ func (s ReleaseSpec) filters(rc ReleaseContext) ([]ServiceFilter, error) {
 
 func (s ReleaseSpec) markSkipped(results Result) {
 	for _, v := range s.ServiceSpecs {
-		if v == ServiceSpecAll {
+		if v == ResourceSpecAll {
 			continue
 		}
 		id, err := v.AsID()
@@ -174,7 +174,7 @@ func (s ReleaseSpec) markSkipped(results Result) {
 			continue
 		}
 		if _, ok := results[id]; !ok {
-			results[id] = ServiceResult{
+			results[id] = ControllerResult{
 				Status: ReleaseStatusSkipped,
 				Error:  NotInRepo,
 			}
@@ -188,7 +188,7 @@ func (s ReleaseSpec) markSkipped(results Result) {
 // however we do want to see if we *can* do the replacements, because
 // if not, it indicates there's likely some problem with the running
 // system vs the definitions given in the repo.)
-func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*ServiceUpdate, results Result, logger log.Logger) ([]*ServiceUpdate, error) {
+func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*ControllerUpdate, results Result, logger log.Logger) ([]*ControllerUpdate, error) {
 	// Compile an `ImageMap` of all relevant images
 	var images ImageMap
 	var repo string
@@ -212,11 +212,11 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Serv
 
 	// Look through all the services' containers to see which have an
 	// image that could be updated.
-	var updates []*ServiceUpdate
+	var updates []*ControllerUpdate
 	for _, u := range candidates {
-		containers, err := u.Service.ContainersOrError()
+		containers, err := u.Controller.ContainersOrError()
 		if err != nil {
-			results[u.ServiceID] = ServiceResult{
+			results[u.ResourceID] = ControllerResult{
 				Status: ReleaseStatusFailed,
 				Error:  err.Error(),
 			}
@@ -268,22 +268,22 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Serv
 		case len(containerUpdates) > 0:
 			u.Updates = containerUpdates
 			updates = append(updates, u)
-			results[u.ServiceID] = ServiceResult{
+			results[u.ResourceID] = ControllerResult{
 				Status:       ReleaseStatusSuccess,
 				PerContainer: containerUpdates,
 			}
 		case ignoredOrSkipped == ReleaseStatusSkipped:
-			results[u.ServiceID] = ServiceResult{
+			results[u.ResourceID] = ControllerResult{
 				Status: ReleaseStatusSkipped,
 				Error:  ImageUpToDate,
 			}
 		case ignoredOrSkipped == ReleaseStatusIgnored:
-			results[u.ServiceID] = ServiceResult{
+			results[u.ResourceID] = ControllerResult{
 				Status: ReleaseStatusIgnored,
 				Error:  DoesNotUseImage,
 			}
 		case ignoredOrSkipped == ReleaseStatusUnknown:
-			results[u.ServiceID] = ServiceResult{
+			results[u.ResourceID] = ControllerResult{
 				Status: ReleaseStatusSkipped,
 				Error:  ImageNotFound,
 			}
@@ -293,24 +293,24 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Serv
 	return updates, nil
 }
 
-type ServiceSpec string // ServiceID or "<all>"
+type ResourceSpec string // ResourceID or "<all>"
 
-func ParseServiceSpec(s string) (ServiceSpec, error) {
-	if s == string(ServiceSpecAll) {
-		return ServiceSpecAll, nil
+func ParseResourceSpec(s string) (ResourceSpec, error) {
+	if s == string(ResourceSpecAll) {
+		return ResourceSpecAll, nil
 	}
 	id, err := flux.ParseResourceID(s)
 	if err != nil {
 		return "", errors.Wrap(err, "invalid service spec")
 	}
-	return ServiceSpec(id.String()), nil
+	return ResourceSpec(id.String()), nil
 }
 
-func (s ServiceSpec) AsID() (flux.ResourceID, error) {
+func (s ResourceSpec) AsID() (flux.ResourceID, error) {
 	return flux.ParseResourceID(string(s))
 }
 
-func (s ServiceSpec) String() string {
+func (s ResourceSpec) String() string {
 	return string(s)
 }
 

--- a/update/release.go
+++ b/update/release.go
@@ -306,6 +306,10 @@ func ParseResourceSpec(s string) (ResourceSpec, error) {
 	return ResourceSpec(id.String()), nil
 }
 
+func MakeResourceSpec(id flux.ResourceID) ResourceSpec {
+	return ResourceSpec(id.String())
+}
+
 func (s ResourceSpec) AsID() (flux.ResourceID, error) {
 	return flux.ParseResourceID(string(s))
 }

--- a/update/result.go
+++ b/update/result.go
@@ -8,17 +8,17 @@ import (
 	"github.com/weaveworks/flux"
 )
 
-type ServiceUpdateStatus string
+type ControllerUpdateStatus string
 
 const (
-	ReleaseStatusSuccess ServiceUpdateStatus = "success"
-	ReleaseStatusFailed  ServiceUpdateStatus = "failed"
-	ReleaseStatusSkipped ServiceUpdateStatus = "skipped"
-	ReleaseStatusIgnored ServiceUpdateStatus = "ignored"
-	ReleaseStatusUnknown ServiceUpdateStatus = "unknown"
+	ReleaseStatusSuccess ControllerUpdateStatus = "success"
+	ReleaseStatusFailed  ControllerUpdateStatus = "failed"
+	ReleaseStatusSkipped ControllerUpdateStatus = "skipped"
+	ReleaseStatusIgnored ControllerUpdateStatus = "ignored"
+	ReleaseStatusUnknown ControllerUpdateStatus = "unknown"
 )
 
-type Result map[flux.ResourceID]ServiceResult
+type Result map[flux.ResourceID]ControllerResult
 
 func (r Result) ServiceIDs() []string {
 	var result []string
@@ -64,13 +64,13 @@ func (r Result) Error() string {
 	}
 }
 
-type ServiceResult struct {
-	Status       ServiceUpdateStatus // summary of what happened, e.g., "incomplete", "ignored", "success"
-	Error        string              `json:",omitempty"` // error if there was one finding the service (e.g., it doesn't exist in repo)
-	PerContainer []ContainerUpdate   // what happened with each container
+type ControllerResult struct {
+	Status       ControllerUpdateStatus // summary of what happened, e.g., "incomplete", "ignored", "success"
+	Error        string                 `json:",omitempty"` // error if there was one finding the service (e.g., it doesn't exist in repo)
+	PerContainer []ContainerUpdate      // what happened with each container
 }
 
-func (fr ServiceResult) Msg(id flux.ResourceID) string {
+func (fr ControllerResult) Msg(id flux.ResourceID) string {
 	return fmt.Sprintf("%s service %s as it is %s", fr.Status, id.String(), fr.Error)
 }
 

--- a/update/service.go
+++ b/update/service.go
@@ -5,24 +5,24 @@ import (
 	"github.com/weaveworks/flux/cluster"
 )
 
-type ServiceUpdate struct {
-	ServiceID     flux.ResourceID
-	Service       cluster.Controller
+type ControllerUpdate struct {
+	ResourceID    flux.ResourceID
+	Controller    cluster.Controller
 	ManifestPath  string
 	ManifestBytes []byte
 	Updates       []ContainerUpdate
 }
 
-type ServiceFilter interface {
-	Filter(ServiceUpdate) ServiceResult
+type ControllerFilter interface {
+	Filter(ControllerUpdate) ControllerResult
 }
 
-func (s *ServiceUpdate) Filter(filters ...ServiceFilter) ServiceResult {
+func (s *ControllerUpdate) Filter(filters ...ControllerFilter) ControllerResult {
 	for _, f := range filters {
 		fr := f.Filter(*s)
 		if fr.Error != "" {
 			return fr
 		}
 	}
-	return ServiceResult{}
+	return ControllerResult{}
 }


### PR DESCRIPTION
### Mechanical gorenames of types and constants

See the commit message for a summary of the renames. You will note that in some cases 'Service' is replaced by 'Resource' and in other cases by 'Controller' - this split is because sometimes (starting with `flux.ResourceID` itself) these types can be used to refer to _any_ kind of cluster resource, but in other cases (such as `flux.ControllerStatus`) they obviously refer specifically to pod controllers only. 

### Changes to the `fluxctl` UI

* The `list-services` command is no longer supported, and now returns a deprecation error (not a warning!) advising the use of `list-controllers` instead
* Similarly, commands previously accepting `--service` will now return a deprecation error if this flag is passed and advise the use of `--controller` instead

The rationale for this decision (rather than a deprecation warning) is that the 'new' fluxd can't provide meaningful behaviour WRT the old `<namespace>/<servicename>` identifier (other than perhaps guessing that there is also a deployment in `<namespace>` called `<servicename>`, and using that) so it seemed safest to generate a hard error.

Fixes #776.
