### PR TITLE
Use paulbellamy's docker-registry-client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -510,6 +510,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "6a9474def7bfad347176dfe1306e9d0dd4216b1635987fda9d4f8d7a5f49c3df"
+  inputs-digest = "4f967ec3520cdba630e9a1273e761aa560583cb7c4c7c1b44f3edc99c3614330"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -269,10 +269,11 @@
   revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
 
 [[projects]]
-  branch = "master"
+  branch = "handle-relative-nextlinks"
   name = "github.com/heroku/docker-registry-client"
   packages = ["registry"]
-  revision = "95467b6cacee2a06f112a3cf7e47a70fad6000cf"
+  revision = "2b1d4773467efc125a91237e10268631398de074"
+  source = "https://github.com/paulbellamy/docker-registry-client.git"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -509,6 +510,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "5847248fb5e8830e9c089495772680880c77b9f388fbcd0fe85e4285059a3a81"
+  inputs-digest = "6a9474def7bfad347176dfe1306e9d0dd4216b1635987fda9d4f8d7a5f49c3df"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -18,10 +18,15 @@
   name = "github.com/mattes/migrate"
   revision = "ce1b59bb819416ca67422929b1cb48bb342720b6"
 
+[[constraint]]
+  name = "github.com/gorilla/mux"
+  revision = "780415097119f6f61c55475fe59b66f3c3e9ea53"
+
+[[constraint]]
+  name = "github.com/heroku/docker-registry-client"
+  source = "https://github.com/paulbellamy/docker-registry-client.git"
+  branch = "handle-relative-nextlinks"
+
 [[override]]
   name = "github.com/ugorji/go"
   revision = "8c0409fcbb70099c748d71f714529204975f6c3f"
-
-[[override]]
-  name = "github.com/gorilla/mux"
-  revision = "780415097119f6f61c55475fe59b66f3c3e9ea53"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -19,10 +19,6 @@
   revision = "ce1b59bb819416ca67422929b1cb48bb342720b6"
 
 [[constraint]]
-  name = "github.com/gorilla/mux"
-  revision = "780415097119f6f61c55475fe59b66f3c3e9ea53"
-
-[[constraint]]
   name = "github.com/heroku/docker-registry-client"
   source = "https://github.com/paulbellamy/docker-registry-client.git"
   branch = "handle-relative-nextlinks"


### PR DESCRIPTION
This pinned dependency was missed in the gvt/dep migration.