### PR TITLE
Replace <> with () in Slack notification author field

### DIFF
--- a/service/notifications/slack.go
+++ b/service/notifications/slack.go
@@ -102,6 +102,8 @@ func slackNotifyRelease(config service.NotifierConfig, release *history.ReleaseE
 	if release.Cause.User != "" || release.Cause.Message != "" {
 		cause := SlackAttachment{}
 		if user := release.Cause.User; user != "" {
+			user = strings.Replace(user, "<", "(", -1)
+			user = strings.Replace(user, ">", ")", -1)
 			cause.Author = user
 		}
 		if msg := release.Cause.Message; msg != "" {


### PR DESCRIPTION
Due to [Reasons](https://github.com/weaveworks/flux/issues/751), we can't user the `Name <email>` author format in Slack notifications without it getting escaped.

Fixes #751. (ish)