### PR TITLE
Add indexes for common queries

### DIFF
--- a/db/migrations/postgres/012_query_index.up.sql
+++ b/db/migrations/postgres/012_query_index.up.sql
@@ -1,5 +1,7 @@
+-- Optimise per-instance history queries
 CREATE INDEX events_instance_id_started_at_desc_idx ON events USING btree(instance_id, started_at DESC);
 
+-- These optimise queries performed by flux 0.3.x
 CREATE INDEX jobs_instance_id_idx ON jobs USING btree(instance_id);
 CREATE INDEX jobs_busy_instance_id_idx ON jobs USING btree(instance_id) WHERE claimed_at IS NOT NULL AND finished_at IS NULL;
 CREATE INDEX jobs_queue_order_idx ON jobs USING btree((-1 * priority), scheduled_at, submitted_at) WHERE finished_at IS NULL AND claimed_at IS NULL;

--- a/db/migrations/postgres/012_query_index.up.sql
+++ b/db/migrations/postgres/012_query_index.up.sql
@@ -1,0 +1,6 @@
+CREATE INDEX events_instance_id_started_at_idx ON events USING btree(instance_id, started_at);
+
+CREATE INDEX jobs_instance_id_idx ON jobs USING btree(instance_id);
+CREATE INDEX jobs_busy_instance_id_idx ON jobs USING btree(instance_id) WHERE claimed_at IS NOT NULL AND finished_at IS NULL;
+CREATE INDEX jobs_queue_order_idx ON jobs USING btree((-1 * priority), scheduled_at, submitted_at) WHERE finished_at IS NULL AND claimed_at IS NULL;
+CREATE INDEX jobs_instance_id_unfinished_idx ON jobs USING btree(instance_id) WHERE finished_at IS NULL;

--- a/db/migrations/postgres/012_query_index.up.sql
+++ b/db/migrations/postgres/012_query_index.up.sql
@@ -1,4 +1,4 @@
-CREATE INDEX events_instance_id_started_at_idx ON events USING btree(instance_id, started_at);
+CREATE INDEX events_instance_id_started_at_desc_idx ON events USING btree(instance_id, started_at DESC);
 
 CREATE INDEX jobs_instance_id_idx ON jobs USING btree(instance_id);
 CREATE INDEX jobs_busy_instance_id_idx ON jobs USING btree(instance_id) WHERE claimed_at IS NOT NULL AND finished_at IS NULL;


### PR DESCRIPTION
This adds some indexes covering the top queries. Analysis of these queries is in a related Issue.

I've added indexes for the jobs table since they coexist in the same DB right now, and thus they may have a performance impact on each other.