### PR TITLE
Make yaml parsing failure a User error

### DIFF
--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -73,10 +73,7 @@ func unmarshalObject(source string, bytes []byte) (resource.Resource, error) {
 	}
 	r, err := unmarshalKind(base, bytes)
 	if err != nil {
-		return nil, &fluxerr.Error{
-			Type: fluxerr.User,
-			Err:  err,
-		}
+		return nil, makeUnmarshalObjectErr(source, err)
 	}
 	return r, nil
 }
@@ -124,6 +121,17 @@ func unmarshalKind(base baseObject, bytes []byte) (resource.Resource, error) {
 	// treat specially
 	default:
 		return &base, nil
+	}
+}
+
+func makeUnmarshalObjectErr(source string, err error) *fluxerr.Error {
+	return &fluxerr.Error{
+		Type: fluxerr.User,
+		Err:  err,
+		Help: `Could not parse "` + source + `".
+
+This likely means it is malformed YAML.
+`,
 	}
 }
 

--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -6,6 +6,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/weaveworks/flux"
+	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/resource"
 )
@@ -70,7 +71,17 @@ func unmarshalObject(source string, bytes []byte) (resource.Resource, error) {
 	if err := yaml.Unmarshal(bytes, &base); err != nil {
 		return nil, err
 	}
+	r, err := unmarshalKind(base, bytes)
+	if err != nil {
+		return nil, &fluxerr.Error{
+			Type: fluxerr.User,
+			Err:  err,
+		}
+	}
+	return r, nil
+}
 
+func unmarshalKind(base baseObject, bytes []byte) (resource.Resource, error) {
 	switch base.Kind {
 	case "CronJob":
 		var cj = CronJob{baseObject: base}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
-	//	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/guid"
 	"github.com/weaveworks/flux/history"


### PR DESCRIPTION
This allows us to detect when fluxd returns an error due to user
fault, and use a 4xx instead of 5xx status code.