### PR TITLE
Add events-url flag for internal notifications service

### DIFF
--- a/cmd/fluxsvc/fluxsvc_test.go
+++ b/cmd/fluxsvc/fluxsvc_test.go
@@ -142,7 +142,7 @@ func setup(t *testing.T) {
 	}
 
 	// Server
-	apiServer := server.New(ver, instancer, instanceDB, messageBus, log.NewNopLogger())
+	apiServer := server.New(ver, instancer, instanceDB, messageBus, log.NewNopLogger(), nil)
 	router = httpserver.NewServiceRouter()
 	handler := httpserver.NewHandler(apiServer, router, log.NewNopLogger())
 	handler = addInstanceIDHandler(handler)

--- a/service/notifications/notifications.go
+++ b/service/notifications/notifications.go
@@ -5,7 +5,7 @@ import (
 	"github.com/weaveworks/flux/service/instance"
 )
 
-var DefaultNotifyEvents = []string{"release", "autorelease"}
+var DefaultNotifyEvents = []string{event.EventRelease, event.EventAutoRelease}
 
 func Event(cfg instance.Config, e event.Event) error {
 	// If this is a release

--- a/service/notifications/notifications_test.go
+++ b/service/notifications/notifications_test.go
@@ -1,6 +1,7 @@
 package notifications
 
 import (
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -64,5 +65,46 @@ func TestRelease_DryRun(t *testing.T) {
 		},
 	}, ev); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestNotificationEventsURL(t *testing.T) {
+	var gotReq *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotReq = r
+		w.WriteHeader(200)
+	}))
+	defer server.Close()
+
+	var instanceID service.InstanceID = "2"
+	var eventsURL = new(string)
+	*eventsURL = server.URL + fmt.Sprintf("/%v/{eventType}", instanceID)
+	eventType := "deploy"
+	expectedPath := fmt.Sprintf("/%v/%v", instanceID, eventType)
+
+	cfg := instance.Config{
+		Settings: service.InstanceConfig{
+			Slack: service.NotifierConfig{
+				HookURL:         *eventsURL,
+				ReleaseTemplate: "",
+				NotifyEvents: []string{
+					event.EventRelease,
+					event.EventAutoRelease,
+					event.EventSync,
+				},
+			},
+		},
+	}
+
+	ev := event.Event{Metadata: exampleRelease(t), Type: event.EventRelease}
+
+	err := Event(cfg, ev)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if gotReq.URL.EscapedPath() != expectedPath {
+		t.Fatalf("Expected: %v, Got: %v", expectedPath, gotReq.URL.String())
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/weaveworks/notification/issues/51

Adds a flag to tell `fluxsvc` to override instance-specific Slack settings and apply a default config instead.

Also allows for a tokenized URL to be used to populate the user's instanceID and the eventType (all of which are set to deploy for now).

This represents the shortest path for us to get Flux converted to the new notifications service.

Related: https://github.com/weaveworks/service-conf/pull/1415