### PR TITLE
Dependency changes to facilitate fluxsvc migration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,12 +20,6 @@
   revision = "de5bf2ad457846296e2031421a34e2568e304e35"
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
-  packages = ["."]
-  revision = "f006c2ac4710855cf0f916dd6b77acf6b048dc6e"
-  version = "v1.0.3"
-
-[[projects]]
   name = "github.com/asaskevich/govalidator"
   packages = ["."]
   revision = "73945b6115bfbbcc57d89b7316e28109364124e1"
@@ -104,10 +98,10 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
   name = "github.com/docker/distribution"
-  packages = [".","context","digest","manifest","manifest/schema1","manifest/schema2","reference","uuid"]
-  revision = "48294d928ced5dd9b378f7fd7c6f5da3ff3f2c89"
-  version = "v2.6.2"
+  packages = [".","digestset","manifest","manifest/schema1","manifest/schema2","reference"]
+  revision = "7484e51bf6af0d3b1a849644cdaced3cfcf13617"
 
 [[projects]]
   branch = "master"
@@ -272,8 +266,8 @@
   branch = "handle-relative-nextlinks"
   name = "github.com/heroku/docker-registry-client"
   packages = ["registry"]
-  revision = "2b1d4773467efc125a91237e10268631398de074"
-  source = "https://github.com/paulbellamy/docker-registry-client.git"
+  revision = "b3603f23ac24c8127a10c8733476ccd28204e9b1"
+  source = "https://github.com/weaveworks/docker-registry-client.git"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -348,6 +342,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/opencontainers/go-digest"
+  packages = ["."]
+  revision = "279bed98673dd5bef374d3b6e4b09e2af76183bf"
+  version = "v1.0.0-rc1"
+
+[[projects]]
   name = "github.com/pkg/errors"
   packages = ["."]
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
@@ -384,6 +384,12 @@
   version = "v0.1"
 
 [[projects]]
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  revision = "a3f95b5c423586578a4e099b11a46c2479628cac"
+  version = "1.0.2"
+
+[[projects]]
   branch = "master"
   name = "github.com/spf13/cobra"
   packages = ["."]
@@ -404,7 +410,7 @@
   branch = "master"
   name = "github.com/weaveworks/common"
   packages = ["errors","httpgrpc","logging","middleware","user"]
-  revision = "955c13089be4f5ee948aeca47af832d23e4bc394"
+  revision = "1df6402aaf7232feadf798b64c6a0cae847e84d8"
 
 [[projects]]
   branch = "master"
@@ -413,9 +419,15 @@
   revision = "ebbb8b0518ab326368631225cabc9435fe580dcc"
 
 [[projects]]
+  name = "github.com/weaveworks/promrus"
+  packages = ["."]
+  revision = "0599d764e054d4e983bb120e30759179fafe3942"
+  version = "v1.2.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["pbkdf2","scrypt","ssh/terminal"]
+  packages = ["pbkdf2","scrypt"]
   revision = "c84b36c635ad003a10f0c755dff5685ceef18c71"
 
 [[projects]]
@@ -433,7 +445,7 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix","windows"]
+  packages = ["unix"]
   revision = "314a259e304ff91bd6985da2a7149bbf91237993"
 
 [[projects]]
@@ -505,6 +517,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7e09292ac2896612bd1b5cded2cc8542087be3ac87ca636ada31f19487ec5b7a"
+  inputs-digest = "cf5c6757c5e36837765840141853fa100ad9e856cf8c0474216f668b012759b9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -263,10 +263,10 @@
   revision = "3573b8b52aa7b37b9358d966a898feb387f62437"
 
 [[projects]]
-  branch = "handle-relative-nextlinks"
+  branch = "master"
   name = "github.com/heroku/docker-registry-client"
   packages = ["registry"]
-  revision = "b3603f23ac24c8127a10c8733476ccd28204e9b1"
+  revision = "2e2f1c58a06fae38b08307d1a834ae9c971a2467"
   source = "https://github.com/weaveworks/docker-registry-client.git"
 
 [[projects]]
@@ -517,6 +517,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "cf5c6757c5e36837765840141853fa100ad9e856cf8c0474216f668b012759b9"
+  inputs-digest = "7b8c8eaf027d0fe23661785bbc0685fd7284adbdb3366bb90508ded81e1f69f9"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -324,11 +324,6 @@
   revision = "2a92e673c9a6302dd05c3a691ae1f24aef46457d"
 
 [[projects]]
-  name = "github.com/mattes/migrate"
-  packages = ["driver","driver/postgres","file","migrate","migrate/direction","pipe"]
-  revision = "ce1b59bb819416ca67422929b1cb48bb342720b6"
-
-[[projects]]
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
   revision = "3247c84500bff8d9fb6d579d800f20b3e091582c"
@@ -478,6 +473,12 @@
   version = "v0.9.0"
 
 [[projects]]
+  name = "gopkg.in/mattes/migrate.v1"
+  packages = ["driver","driver/postgres","file","migrate","migrate/direction","pipe"]
+  revision = "afc973c4e5a6b746217c2d3950fcd110ed1ba349"
+  version = "v1.3.2"
+
+[[projects]]
   branch = "v2"
   name = "gopkg.in/mgo.v2"
   packages = ["bson","internal/json"]
@@ -504,6 +505,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "024a7b8ff1fe11667a508d388ed8055d62a53dacbf9173463aeeddf87b7b586a"
+  inputs-digest = "7e09292ac2896612bd1b5cded2cc8542087be3ac87ca636ada31f19487ec5b7a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -21,7 +21,7 @@
 [[constraint]]
   name = "github.com/heroku/docker-registry-client"
   source = "https://github.com/weaveworks/docker-registry-client.git"
-  branch = "handle-relative-nextlinks"
+  branch = "master"
 
 [[override]]
   name = "github.com/ugorji/go"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 
 [[constraint]]
   name = "github.com/heroku/docker-registry-client"
-  source = "https://github.com/paulbellamy/docker-registry-client.git"
+  source = "https://github.com/weaveworks/docker-registry-client.git"
   branch = "handle-relative-nextlinks"
 
 [[override]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -14,9 +14,9 @@
   name = "github.com/google/go-github"
   revision = "dfd20fd7fa6edec56447fcb049acd5e17a78ec2e"
 
-[[constraint]]
-  name = "github.com/mattes/migrate"
-  revision = "ce1b59bb819416ca67422929b1cb48bb342720b6"
+[[override]]
+  name = "gopkg.in/mattes/migrate.v1"
+  version = "v1.3.2"
 
 [[constraint]]
   name = "github.com/heroku/docker-registry-client"

--- a/db/db.go
+++ b/db/db.go
@@ -11,15 +11,15 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/mattes/migrate/migrate"
 	"github.com/pkg/errors"
+	"gopkg.in/mattes/migrate.v1/migrate"
 
 	// This section imports the data/sql drivers and the migration
 	// drivers.
 	_ "github.com/cznic/ql/driver"
 	_ "github.com/lib/pq"
-	_ "github.com/mattes/migrate/driver/postgres"
 	_ "github.com/weaveworks/flux/db/ql"
+	_ "gopkg.in/mattes/migrate.v1/driver/postgres"
 )
 
 // Most SQL drivers expect the driver name to appear as the scheme in

--- a/db/ql/migration_driver.go
+++ b/db/ql/migration_driver.go
@@ -3,9 +3,9 @@ package ql
 import (
 	"database/sql"
 
-	"github.com/mattes/migrate/driver"
-	"github.com/mattes/migrate/file"
-	"github.com/mattes/migrate/migrate/direction"
+	"gopkg.in/mattes/migrate.v1/driver"
+	"gopkg.in/mattes/migrate.v1/file"
+	"gopkg.in/mattes/migrate.v1/migrate/direction"
 )
 
 // These are registered under the URL schemes, since that's how they


### PR DESCRIPTION
In preparation for moving fluxsvc to [service](https://github.com/weaveworks/service), these dependencies need to be updated:

1. `github.com/mattes/migrate`: Needs to use v1.3.2 from `gopkg.in` in order to not cause a conflict. Fortunately the API didn't change in the ~1 year between our old version and v1.3.2.
2. `github.com/paulbellamy/docker-registry-client`: Had to be forked to remove the (false) dependency on `github.com/Sirupsen/logrus` because of that wonderful S-to-s change.