### PR TITLE
Update to use latest go-kit/log API

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -136,7 +136,8 @@
 [[projects]]
   name = "github.com/go-kit/kit"
   packages = ["log","metrics","metrics/internal/lv","metrics/prometheus"]
-  revision = "00e2b89d8ad42af22b20fdb9adfbbfa0d5f34660"
+  revision = "4dc7be5d2d12881735283bcab7352178e190fc71"
+  version = "v0.6.0"
 
 [[projects]]
   name = "github.com/go-logfmt/logfmt"
@@ -517,6 +518,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "202aaec71181f11c25dc1dd2a37cd55dbc7a06f551c4d3834a1cbd978972b090"
+  inputs-digest = "acb592cfe864d6061e477e877382e7746ab70371ab2f0468d0444fd72c646375"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -7,10 +7,6 @@
   version = "4.0.0"
 
 [[constraint]]
-  name = "github.com/go-kit/kit"
-  revision = "00e2b89d8ad42af22b20fdb9adfbbfa0d5f34660"
-
-[[constraint]]
   name = "github.com/google/go-github"
   revision = "dfd20fd7fa6edec56447fcb049acd5e17a78ec2e"
 

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -211,11 +211,11 @@ func (c *Cluster) AllControllers(namespace string) (res []cluster.Controller, er
 // asynchronous, but serialised.
 func (c *Cluster) Sync(spec cluster.SyncDef) error {
 	errc := make(chan error)
-	logger := log.NewContext(c.logger).With("method", "Sync")
+	logger := log.With(c.logger, "method", "Sync")
 	c.actionc <- func() {
 		errs := cluster.SyncError{}
 		for _, action := range spec.Actions {
-			logger := log.NewContext(logger).With("resource", action.ResourceID)
+			logger := log.With(logger, "resource", action.ResourceID)
 			if len(action.Delete) > 0 {
 				obj, err := definitionObj(action.Delete)
 				if err == nil {

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -124,8 +124,8 @@ func main() {
 	var logger log.Logger
 	{
 		logger = log.NewLogfmtLogger(os.Stderr)
-		logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC)
-		logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+		logger = log.With(logger, "caller", log.DefaultCaller)
 	}
 
 	// Sort out values for the git tag and notes ref. There are
@@ -191,7 +191,7 @@ func main() {
 
 		publicKey, privateKeyPath := sshKeyRing.KeyPair()
 
-		logger := log.NewContext(logger).With("component", "platform")
+		logger := log.With(logger, "component", "platform")
 		logger.Log("identity", privateKeyPath)
 		logger.Log("identity.pub", publicKey.Key)
 		logger.Log("host", restClientConfig.Host, "version", clusterVersion)
@@ -240,7 +240,7 @@ func main() {
 				Service:        *memcachedService,
 				Timeout:        *memcachedTimeout,
 				UpdateInterval: 1 * time.Minute,
-				Logger:         log.NewContext(logger).With("component", "memcached"),
+				Logger:         log.With(logger, "component", "memcached"),
 				MaxIdleConns:   defaultMemcacheConnections,
 			})
 			memcacheRegistry = registryMemcache.InstrumentMemcacheClient(memcacheRegistry)
@@ -253,14 +253,14 @@ func main() {
 				Service:        *memcachedService,
 				Timeout:        *memcachedTimeout,
 				UpdateInterval: 1 * time.Minute,
-				Logger:         log.NewContext(logger).With("component", "memcached"),
+				Logger:         log.With(logger, "component", "memcached"),
 				MaxIdleConns:   *registryBurst,
 			})
 			memcacheWarmer = registryMemcache.InstrumentMemcacheClient(memcacheWarmer)
 			defer memcacheWarmer.Stop()
 		}
 
-		cacheLogger := log.NewContext(logger).With("component", "cache")
+		cacheLogger := log.With(logger, "component", "cache")
 		cache = registry.NewRegistry(
 			registry.NewCacheClientFactory(cacheLogger, memcacheRegistry, *registryCacheExpiry),
 			cacheLogger,
@@ -269,14 +269,14 @@ func main() {
 		cache = registry.NewInstrumentedRegistry(cache)
 
 		// Remote
-		registryLogger := log.NewContext(logger).With("component", "registry")
+		registryLogger := log.With(logger, "component", "registry")
 		remoteFactory := registry.NewRemoteClientFactory(registryLogger, registryMiddleware.RateLimiterConfig{
 			RPS:   *registryRPS,
 			Burst: *registryBurst,
 		})
 
 		// Warmer
-		warmerLogger := log.NewContext(logger).With("component", "warmer")
+		warmerLogger := log.With(logger, "component", "warmer")
 		cacheWarmer = registry.Warmer{
 			Logger:        warmerLogger,
 			ClientFactory: remoteFactory,
@@ -302,7 +302,7 @@ func main() {
 	{
 		// Connect to fluxsvc if given an upstream address
 		if *upstreamURL != "" {
-			upstreamLogger := log.NewContext(logger).With("component", "upstream")
+			upstreamLogger := log.With(logger, "component", "upstream")
 			upstreamLogger.Log("URL", *upstreamURL)
 			upstream, err := daemonhttp.NewUpstream(
 				&http.Client{Timeout: 10 * time.Second},
@@ -348,7 +348,7 @@ func main() {
 	// report anything before seeing if it works. So, don't start
 	// until we have failed or succeeded.
 	var checker *checkpoint.Checker
-	updateCheckLogger := log.NewContext(logger).With("component", "checkpoint")
+	updateCheckLogger := log.With(logger, "component", "checkpoint")
 
 	var repo git.Repo
 	var checkout *git.Checkout
@@ -410,14 +410,14 @@ func main() {
 		JobStatusCache: &job.StatusCache{Size: 100},
 
 		EventWriter: eventWriter,
-		Logger:      log.NewContext(logger).With("component", "daemon"), LoopVars: &daemon.LoopVars{
+		Logger:      log.With(logger, "component", "daemon"), LoopVars: &daemon.LoopVars{
 			GitPollInterval:      *gitPollInterval,
 			RegistryPollInterval: *registryPollInterval,
 		},
 	}
 
 	shutdownWg.Add(1)
-	go daemon.GitPollLoop(shutdown, shutdownWg, log.NewContext(logger).With("component", "sync-loop"))
+	go daemon.GitPollLoop(shutdown, shutdownWg, log.With(logger, "component", "sync-loop"))
 
 	shutdownWg.Add(1)
 	go cacheWarmer.Loop(shutdown, shutdownWg, image_creds)

--- a/cmd/fluxsvc/main.go
+++ b/cmd/fluxsvc/main.go
@@ -60,8 +60,8 @@ func main() {
 	var logger log.Logger
 	{
 		logger = log.NewLogfmtLogger(os.Stderr)
-		logger = log.NewContext(logger).With("ts", log.DefaultTimestampUTC)
-		logger = log.NewContext(logger).With("caller", log.DefaultCaller)
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+		logger = log.With(logger, "caller", log.DefaultCaller)
 	}
 
 	// Initialise database; we must fail if we can't do this, because

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -43,7 +43,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 	changes := &update.Automated{}
 	for _, service := range services {
 		for _, container := range service.ContainersOrNil() {
-			logger := log.NewContext(logger).With("service", service.ID, "container", container.Name, "currentimage", container.Image)
+			logger := log.With(logger, "service", service.ID, "container", container.Name, "currentimage", container.Image)
 
 			currentImageID, err := flux.ParseImageID(container.Image)
 			if err != nil {

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -86,7 +86,7 @@ func (d *Daemon) GitPollLoop(stop chan struct{}, wg *sync.WaitGroup, logger log.
 			d.askForSync()
 		case job := <-d.Jobs.Ready():
 			queueLength.Set(float64(d.Jobs.Len()))
-			jobLogger := log.NewContext(logger).With("jobID", job.ID)
+			jobLogger := log.With(logger, "jobID", job.ID)
 			jobLogger.Log("state", "in-progress")
 			// It's assumed that (successful) jobs will push commits
 			// to the upstream repo, and therefore we probably want to

--- a/registry/cache/memcached_test.go
+++ b/registry/cache/memcached_test.go
@@ -30,7 +30,7 @@ func TestMemcache_ExpiryReadWrite(t *testing.T) {
 	mc := NewFixedServerMemcacheClient(MemcacheConfig{
 		Timeout:        time.Second,
 		UpdateInterval: 1 * time.Minute,
-		Logger:         log.NewContext(log.NewLogfmtLogger(os.Stderr)).With("component", "memcached"),
+		Logger:         log.With(log.NewLogfmtLogger(os.Stderr), "component", "memcached"),
 	}, strings.Fields(*memcachedIPs)...)
 
 	// Set some dummy data
@@ -57,7 +57,7 @@ func TestMemcache_ReadWrite(t *testing.T) {
 	mc := NewFixedServerMemcacheClient(MemcacheConfig{
 		Timeout:        time.Second,
 		UpdateInterval: 1 * time.Minute,
-		Logger:         log.NewContext(log.NewLogfmtLogger(os.Stderr)).With("component", "memcached"),
+		Logger:         log.With(log.NewLogfmtLogger(os.Stderr), "component", "memcached"),
 	}, strings.Fields(*memcachedIPs)...)
 
 	// Set some dummy data

--- a/registry/integration_test.go
+++ b/registry/integration_test.go
@@ -29,32 +29,32 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 	mc := cache.NewFixedServerMemcacheClient(cache.MemcacheConfig{
 		Timeout:        time.Second,
 		UpdateInterval: 1 * time.Minute,
-		Logger:         log.NewContext(log.NewLogfmtLogger(os.Stderr)).With("component", "memcached"),
+		Logger:         log.With(log.NewLogfmtLogger(os.Stderr), "component", "memcached"),
 	}, strings.Fields(*memcachedIPs)...)
 
 	id, _ := flux.ParseImageID("alpine")
 
-	logger := log.NewContext(log.NewLogfmtLogger(os.Stderr))
+	logger := log.NewLogfmtLogger(os.Stderr)
 
 	remote := NewRemoteClientFactory(
-		logger.With("component", "client"),
+		log.With(logger, "component", "client"),
 		middleware.RateLimiterConfig{200, 10},
 	)
 
 	cache := NewCacheClientFactory(
-		logger.With("component", "cache"),
+		log.With(logger, "component", "cache"),
 		mc,
 		time.Hour,
 	)
 
 	r := NewRegistry(
 		cache,
-		logger.With("component", "registry"),
+		log.With(logger, "component", "registry"),
 		512,
 	)
 
 	w := Warmer{
-		Logger:        logger.With("component", "warmer"),
+		Logger:        log.With(logger, "component", "warmer"),
 		ClientFactory: remote,
 		Creds:         NoCredentials(),
 		Expiry:        time.Hour,

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -25,7 +25,7 @@ func Release(rc *ReleaseContext, changes Changes, logger log.Logger) (results up
 		)
 	}(time.Now())
 
-	logger = log.NewContext(logger).With("type", "release")
+	logger = log.With(logger, "type", "release")
 
 	updates, results, err := changes.CalculateRelease(rc, logger)
 	if err != nil {

--- a/service/http/server.go
+++ b/service/http/server.go
@@ -113,7 +113,7 @@ func NewHandler(s api.Service, r *mux.Router, logger log.Logger) http.Handler {
 		"GetPublicSSHKey":          handle.GetPublicSSHKey,
 		"RegeneratePublicSSHKey":   handle.RegeneratePublicSSHKey,
 	} {
-		handler := logging(handlerMethod, log.NewContext(logger).With("method", method))
+		handler := logging(handlerMethod, log.With(logger, "method", method))
 		r.Get(method).Handler(handler)
 	}
 
@@ -562,13 +562,14 @@ func logging(next http.Handler, logger log.Logger) http.Handler {
 
 		next.ServeHTTP(tw, r)
 
-		requestLogger := log.NewContext(logger).With(
+		requestLogger := log.With(
+			logger,
 			"url", mustUnescape(r.URL.String()),
 			"took", time.Since(begin).String(),
 			"status_code", cw.code,
 		)
 		if cw.code != http.StatusOK {
-			requestLogger = requestLogger.With("error", strings.TrimSpace(tw.buf.String()))
+			requestLogger = log.With(requestLogger, "error", strings.TrimSpace(tw.buf.String()))
 		}
 		requestLogger.Log()
 	})

--- a/service/instance/multi.go
+++ b/service/instance/multi.go
@@ -24,7 +24,7 @@ func (m *MultitenantInstancer) Get(instanceID service.InstanceID) (*Instance, er
 	}
 
 	// Logger specialised to this instance
-	instanceLogger := log.NewContext(m.Logger).With("instanceID", instanceID)
+	instanceLogger := log.With(m.Logger, "instanceID", instanceID)
 
 	// Events for this instance
 	eventRW := EventReadWriter{instanceID, m.History}

--- a/service/server/server.go
+++ b/service/server/server.go
@@ -436,7 +436,7 @@ func (s *Server) Export(ctx context.Context) (res []byte, err error) {
 func (s *Server) instrumentPlatform(instID service.InstanceID, p remote.Platform) remote.Platform {
 	return &remote.ErrorLoggingPlatform{
 		remote.Instrument(p),
-		log.NewContext(s.logger).With("instanceID", instID),
+		log.With(s.logger, "instanceID", instID),
 	}
 }
 


### PR DESCRIPTION
This means we can remove the dep constraint. Fixes #798.