### PR TITLE
Mark where images have been left out of the list-images output

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -113,7 +113,7 @@ func (opts *controllerShowOpts) RunE(cmd *cobra.Command, args []string) error {
 					printEllipsis, printLine = lineCount > (opts.limit+1), true
 				}
 				if printEllipsis {
-					fmt.Fprintf(out, "\t\t%s\t\n", ":")
+					fmt.Fprintf(out, "\t\t%s (%d image(s) omitted)\t\n", ":", lineCount-opts.limit-1)
 				}
 				if printLine {
 					createdAt := ""

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -82,8 +82,8 @@ func (opts *controllerShowOpts) RunE(cmd *cobra.Command, args []string) error {
 		}
 
 		controllerName := controller.ID.String()
-		var lineCount int
 		for _, container := range controller.Containers {
+			var lineCount int
 			containerName := container.Name
 			reg, repo, currentTag := container.Current.ID.Components()
 			if reg != "" {


### PR DESCRIPTION
Example output:

```
$ fluxctl $DEV list-images --controller=scope:deployment/memcached --limit=4
CONTROLLER                  CONTAINER  IMAGE                              CREATED
scope:deployment/memcached  memcached  index.docker.io/library/memcached  
                                       |   1                              09 Oct 17 23:58 UTC
                                       |   1.5                            09 Oct 17 23:58 UTC
                                       |   1.5.2                          09 Oct 17 23:58 UTC
                                       |   latest                         09 Oct 17 23:58 UTC
                                       : (16 image(s) omitted)            
                                       '-> 1.4.36-alpine                  30 May 17 20:41 UTC
```
