### PR TITLE
Parse shorthand dockerhub images correctly

### DIFF
--- a/registry/cache/memcached.go
+++ b/registry/cache/memcached.go
@@ -237,7 +237,7 @@ type manifestKey struct {
 }
 
 func NewManifestKey(username string, id flux.ImageID) (Keyer, error) {
-	return &manifestKey{username, id.HostImage(), id.Tag}, nil
+	return &manifestKey{username, id.CanonicalName(), id.Tag}, nil
 }
 
 func (k *manifestKey) Key() string {
@@ -257,7 +257,7 @@ type tagKey struct {
 }
 
 func NewTagKey(username string, id flux.ImageID) (Keyer, error) {
-	return &tagKey{username, id.HostImage()}, nil
+	return &tagKey{username, id.CanonicalName()}, nil
 }
 
 func (k *tagKey) Key() string {

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -50,15 +50,8 @@ func NewRegistry(c ClientFactory, l log.Logger, connections int) Registry {
 }
 
 // GetRepository yields a repository matching the given name, if any exists.
-// Repository may be of various forms, in which case omitted elements take
-// assumed defaults.
-//
-//   helloworld             -> index.docker.io/library/helloworld
-//   foo/helloworld         -> index.docker.io/foo/helloworld
-//   quay.io/foo/helloworld -> quay.io/foo/helloworld
-//
 func (reg *registry) GetRepository(id flux.ImageID) ([]flux.Image, error) {
-	client, err := reg.factory.ClientFor(id.Host, Credentials{})
+	client, err := reg.factory.ClientFor(id.Registry(), Credentials{})
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +72,7 @@ func (reg *registry) GetRepository(id flux.ImageID) ([]flux.Image, error) {
 
 // Get a single Image from the registry if it exists
 func (reg *registry) GetImage(id flux.ImageID) (flux.Image, error) {
-	client, err := reg.factory.ClientFor(id.Host, Credentials{})
+	client, err := reg.factory.ClientFor(id.Registry(), Credentials{})
 	if err != nil {
 		return flux.Image{}, err
 	}

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -95,7 +95,7 @@ func TestRemoteFactory_RawClient(t *testing.T) {
 
 	// Refresh tags first
 	var tags []string
-	client, err := fact.ClientFor(id.Host, Credentials{})
+	client, err := fact.ClientFor(id.Registry(), Credentials{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,7 +109,7 @@ func TestRemoteFactory_RawClient(t *testing.T) {
 		t.Fatal("Should have some tags")
 	}
 
-	client, err = fact.ClientFor(id.Host, Credentials{})
+	client, err = fact.ClientFor(id.Registry(), Credentials{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +133,7 @@ func TestRemoteFactory_InvalidHost(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	client, err := fact.ClientFor(invalidId.Host, Credentials{})
+	client, err := fact.ClientFor(invalidId.Registry(), Credentials{})
 	if err != nil {
 		return
 	}

--- a/registry/warming.go
+++ b/registry/warming.go
@@ -58,14 +58,14 @@ func (w *Warmer) Loop(stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFun
 }
 
 func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
-	client, err := w.ClientFactory.ClientFor(id.Host, creds)
+	client, err := w.ClientFactory.ClientFor(id.Registry(), creds)
 	if err != nil {
 		w.Logger.Log("err", err.Error())
 		return
 	}
 	defer client.Cancel()
 
-	username := w.Creds.credsFor(id.Host).username
+	username := w.Creds.credsFor(id.Registry()).username
 
 	// Refresh tags first
 	// Only, for example, "library/alpine" because we have the host information in the client above.
@@ -126,7 +126,7 @@ func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
 	w.Logger.Log("fetching", id.String(), "to-update", len(toUpdate))
 
 	if expired {
-		w.Logger.Log("expiring", id.HostImage())
+		w.Logger.Log("expiring", id.String())
 	}
 
 	// The upper bound for concurrent fetches against a single host is
@@ -168,7 +168,7 @@ func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
 		}(imID)
 	}
 	awaitFetchers.Wait()
-	w.Logger.Log("updated", id.HostImage())
+	w.Logger.Log("updated", id.String())
 }
 
 func withinExpiryBuffer(expiry time.Time, buffer time.Duration) bool {

--- a/update/filter.go
+++ b/update/filter.go
@@ -30,7 +30,7 @@ func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
 	for _, c := range u.Controller.Containers.Containers {
 		cID, _ := flux.ParseImageID(c.Image)
 		// If container image == image in update
-		if cID.HostImage() == f.Img.HostImage() {
+		if cID.CanonicalName() == f.Img.CanonicalName() {
 			// We want to update this
 			return ControllerResult{}
 		}

--- a/update/print.go
+++ b/update/print.go
@@ -25,7 +25,7 @@ func PrintResults(out io.Writer, results Result, verbose bool) {
 			extraLines = append(extraLines, result.Error)
 		}
 		for _, update := range result.PerContainer {
-			extraLines = append(extraLines, fmt.Sprintf("%s: %s -> %s", update.Container, update.Current.FullID(), update.Target.Tag))
+			extraLines = append(extraLines, fmt.Sprintf("%s: %s -> %s", update.Container, update.Current.String(), update.Target.Tag))
 		}
 
 		var inline string


### PR DESCRIPTION
This fixes issue #804 by adding test cases that were missing, and
rewriting the parsing to pass.

In addition, I have changed the use of ImageID such that it
canonicalises elements (e.g., the domain) when asked, rather than when
parsing. This means that in general, images will appear as they are
supplied by users -- e.g., `alpine:3.5`.