### PR TITLE
simplify args test

### DIFF
--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -166,6 +166,6 @@ func TestGetCommitAuthor_EmailAndEmptyName(t *testing.T) {
 func checkAuthor(t *testing.T, input map[string]string, expected string) {
 	author := getCommitAuthor(input)
 	if author != expected {
-		t.Fatal("author did not match expected value")
+		t.Fatalf("author %q does not match expected value %q", author, expected)
 	}
 }

--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -14,12 +14,7 @@ func TestUserGitconfigMap_EmptyString(t *testing.T) {
 }
 
 func TestUserGitconfigMap(t *testing.T) {
-	d := `push.default=simple
-	merge.conflictstyle=diff3
-	pull.ff=only
-	core.repositoryformatversion=0
-	core.filemode=true
-	core.bare=false`
+	d := gitConfig
 	expected := gitConfigMap(nil)
 
 	userGitconfigInfo := userGitconfigMap(d)
@@ -33,16 +28,10 @@ func TestUserGitconfigMap(t *testing.T) {
 
 func TestUserGitconfigMap_WithEmptyLines(t *testing.T) {
 	d := `
-	user.name=Jane Doe
-	push.default=simple
-	merge.conflictstyle=diff3
-	pull.ff=only
+    user.name=Jane Doe
 
-	core.repositoryformatversion=0
-	core.filemode=true
-	core.bare=false
-
-	`
+    ` + gitConfig + `
+    `
 	expected := gitConfigMap(map[string]string{
 		"user.name": "Jane Doe",
 	})
@@ -119,6 +108,14 @@ func checkAuthor(t *testing.T, input map[string]string, expected string) {
 		t.Fatalf("author %q does not match expected value %q", author, expected)
 	}
 }
+
+var gitConfig = `push.default=simple
+    merge.conflictstyle=diff3
+    pull.ff=only
+    core.repositoryformatversion=0
+    core.filemode=true
+    core.bare=false
+    `
 
 func gitConfigMap(input map[string]string) map[string]string {
 	res := map[string]string{

--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -94,11 +94,7 @@ func TestGetCommitAuthor_BothNameAndEmail(t *testing.T) {
 		"core.filemode":                "true",
 		"core.bare":                    "false",
 	}
-	expected := "Jane Doe <jd@j.d>"
-	author := getCommitAuthor(input)
-	if author != expected {
-		t.Fatal("author did not match expected value")
-	}
+	checkAuthor(t, input, "Jane Doe <jd@j.d>")
 }
 
 func TestGetCommitAuthor_OnlyName(t *testing.T) {
@@ -111,11 +107,7 @@ func TestGetCommitAuthor_OnlyName(t *testing.T) {
 		"core.filemode":                "true",
 		"core.bare":                    "false",
 	}
-	expected := "Jane Doe"
-	author := getCommitAuthor(input)
-	if author != expected {
-		t.Fatal("author did not match expected value")
-	}
+	checkAuthor(t, input, "Jane Doe")
 }
 
 func TestGetCommitAuthor_OnlyEmail(t *testing.T) {
@@ -128,11 +120,7 @@ func TestGetCommitAuthor_OnlyEmail(t *testing.T) {
 		"core.filemode":                "true",
 		"core.bare":                    "false",
 	}
-	expected := "jd@j.d"
-	author := getCommitAuthor(input)
-	if author != expected {
-		t.Fatal("author did not match expected value")
-	}
+	checkAuthor(t, input, "jd@j.d")
 }
 
 func TestGetCommitAuthor_NoNameNoEmail(t *testing.T) {
@@ -144,11 +132,7 @@ func TestGetCommitAuthor_NoNameNoEmail(t *testing.T) {
 		"core.filemode":                "true",
 		"core.bare":                    "false",
 	}
-	expected := ""
-	author := getCommitAuthor(input)
-	if author != expected {
-		t.Fatal("author did not match expected value")
-	}
+	checkAuthor(t, input, "")
 }
 
 func TestGetCommitAuthor_NameAndEmptyEmail(t *testing.T) {
@@ -162,11 +146,7 @@ func TestGetCommitAuthor_NameAndEmptyEmail(t *testing.T) {
 		"core.filemode":                "true",
 		"core.bare":                    "false",
 	}
-	expected := "Jane Doe"
-	author := getCommitAuthor(input)
-	if author != expected {
-		t.Fatal("author did not match expected value")
-	}
+	checkAuthor(t, input, "Jane Doe")
 }
 
 func TestGetCommitAuthor_EmailAndEmptyName(t *testing.T) {
@@ -180,7 +160,10 @@ func TestGetCommitAuthor_EmailAndEmptyName(t *testing.T) {
 		"core.filemode":                "true",
 		"core.bare":                    "false",
 	}
-	expected := "jd@j.d"
+	checkAuthor(t, input, "jd@j.d")
+}
+
+func checkAuthor(t *testing.T, input map[string]string, expected string) {
 	author := getCommitAuthor(input)
 	if author != expected {
 		t.Fatal("author did not match expected value")

--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -7,23 +7,14 @@ import (
 
 func TestUserGitconfigMap_EmptyString(t *testing.T) {
 	d := ""
-	userGitconfigInfo := userGitconfigMap(d)
-	if len(userGitconfigInfo) != 0 {
-		t.Fatal("expected map with no keys")
-	}
+	expected := map[string]string{}
+	checkUserGitconfigMap(t, d, expected)
 }
 
 func TestUserGitconfigMap(t *testing.T) {
 	d := gitConfig
 	expected := gitConfigMap(nil)
-
-	userGitconfigInfo := userGitconfigMap(d)
-	if len(userGitconfigInfo) != 6 {
-		t.Fatal("got map with unexpected number of keys")
-	}
-	if !reflect.DeepEqual(userGitconfigInfo, expected) {
-		t.Fatal("result does not match expected structure")
-	}
+	checkUserGitconfigMap(t, d, expected)
 }
 
 func TestUserGitconfigMap_WithEmptyLines(t *testing.T) {
@@ -35,28 +26,14 @@ func TestUserGitconfigMap_WithEmptyLines(t *testing.T) {
 	expected := gitConfigMap(map[string]string{
 		"user.name": "Jane Doe",
 	})
-	userGitconfigInfo := userGitconfigMap(d)
-
-	if len(userGitconfigInfo) != 7 {
-		t.Fatal("got map with unexpected number of keys")
-	}
-	if !reflect.DeepEqual(userGitconfigInfo, expected) {
-		t.Fatal("result does not match expected structure")
-	}
+	checkUserGitconfigMap(t, d, expected)
 }
 
 func TestUserGitconfigMap_WithNoKeys(t *testing.T) {
 	d := `
 	`
-	expected := make(map[string]string)
-
-	userGitconfigInfo := userGitconfigMap(d)
-	if len(userGitconfigInfo) != 0 {
-		t.Fatal("expected map with no keys")
-	}
-	if !reflect.DeepEqual(userGitconfigInfo, expected) {
-		t.Fatal("result does not match expected structure")
-	}
+	expected := map[string]string{}
+	checkUserGitconfigMap(t, d, expected)
 }
 
 func TestGetCommitAuthor_BothNameAndEmail(t *testing.T) {
@@ -130,4 +107,16 @@ func gitConfigMap(input map[string]string) map[string]string {
 		res[k] = v
 	}
 	return res
+}
+
+func checkUserGitconfigMap(t *testing.T, d string, expected map[string]string) {
+	userGitconfigInfo := userGitconfigMap(d)
+
+	if len(userGitconfigInfo) != len(expected) {
+		t.Fatalf("got map with %d keys instead of expected %d",
+			len(userGitconfigInfo), len(expected))
+	}
+	if !reflect.DeepEqual(userGitconfigInfo, expected) {
+		t.Fatal("result map does not match expected structure")
+	}
 }

--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -5,6 +5,48 @@ import (
 	"testing"
 )
 
+var gitConfig = `push.default=simple
+    merge.conflictstyle=diff3
+    pull.ff=only
+    core.repositoryformatversion=0
+    core.filemode=true
+    core.bare=false
+    `
+
+func gitConfigMap(input map[string]string) map[string]string {
+	res := map[string]string{
+		"push.default":                 "simple",
+		"merge.conflictstyle":          "diff3",
+		"pull.ff":                      "only",
+		"core.repositoryformatversion": "0",
+		"core.filemode":                "true",
+		"core.bare":                    "false",
+	}
+	for k, v := range input {
+		res[k] = v
+	}
+	return res
+}
+
+func checkUserGitconfigMap(t *testing.T, d string, expected map[string]string) {
+	userGitconfigInfo := userGitconfigMap(d)
+
+	if len(userGitconfigInfo) != len(expected) {
+		t.Fatalf("got map with %d keys instead of expected %d",
+			len(userGitconfigInfo), len(expected))
+	}
+	if !reflect.DeepEqual(userGitconfigInfo, expected) {
+		t.Fatal("result map does not match expected structure")
+	}
+}
+
+func checkAuthor(t *testing.T, input map[string]string, expected string) {
+	author := getCommitAuthor(input)
+	if author != expected {
+		t.Fatalf("author %q does not match expected value %q", author, expected)
+	}
+}
+
 func TestUserGitconfigMap_EmptyString(t *testing.T) {
 	d := ""
 	expected := map[string]string{}
@@ -77,46 +119,4 @@ func TestGetCommitAuthor_EmailAndEmptyName(t *testing.T) {
 		"user.email": "jd@j.d",
 	})
 	checkAuthor(t, input, "jd@j.d")
-}
-
-func checkAuthor(t *testing.T, input map[string]string, expected string) {
-	author := getCommitAuthor(input)
-	if author != expected {
-		t.Fatalf("author %q does not match expected value %q", author, expected)
-	}
-}
-
-var gitConfig = `push.default=simple
-    merge.conflictstyle=diff3
-    pull.ff=only
-    core.repositoryformatversion=0
-    core.filemode=true
-    core.bare=false
-    `
-
-func gitConfigMap(input map[string]string) map[string]string {
-	res := map[string]string{
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
-	for k, v := range input {
-		res[k] = v
-	}
-	return res
-}
-
-func checkUserGitconfigMap(t *testing.T, d string, expected map[string]string) {
-	userGitconfigInfo := userGitconfigMap(d)
-
-	if len(userGitconfigInfo) != len(expected) {
-		t.Fatalf("got map with %d keys instead of expected %d",
-			len(userGitconfigInfo), len(expected))
-	}
-	if !reflect.DeepEqual(userGitconfigInfo, expected) {
-		t.Fatal("result map does not match expected structure")
-	}
 }

--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -20,14 +20,7 @@ func TestUserGitconfigMap(t *testing.T) {
 	core.repositoryformatversion=0
 	core.filemode=true
 	core.bare=false`
-	expected := map[string]string{
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	expected := gitConfigMap(nil)
 
 	userGitconfigInfo := userGitconfigMap(d)
 	if len(userGitconfigInfo) != 6 {
@@ -50,15 +43,9 @@ func TestUserGitconfigMap_WithEmptyLines(t *testing.T) {
 	core.bare=false
 
 	`
-	expected := map[string]string{
-		"user.name":                    "Jane Doe",
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	expected := gitConfigMap(map[string]string{
+		"user.name": "Jane Doe",
+	})
 	userGitconfigInfo := userGitconfigMap(d)
 
 	if len(userGitconfigInfo) != 7 {
@@ -84,82 +71,45 @@ func TestUserGitconfigMap_WithNoKeys(t *testing.T) {
 }
 
 func TestGetCommitAuthor_BothNameAndEmail(t *testing.T) {
-	input := map[string]string{
-		"user.name":                    "Jane Doe",
-		"user.email":                   "jd@j.d",
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	input := gitConfigMap(map[string]string{
+		"user.name":  "Jane Doe",
+		"user.email": "jd@j.d",
+	})
 	checkAuthor(t, input, "Jane Doe <jd@j.d>")
 }
 
 func TestGetCommitAuthor_OnlyName(t *testing.T) {
-	input := map[string]string{
-		"user.name":                    "Jane Doe",
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	input := gitConfigMap(map[string]string{
+		"user.name": "Jane Doe",
+	})
 	checkAuthor(t, input, "Jane Doe")
 }
 
 func TestGetCommitAuthor_OnlyEmail(t *testing.T) {
-	input := map[string]string{
-		"user.email":                   "jd@j.d",
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	input := gitConfigMap(map[string]string{
+		"user.email": "jd@j.d",
+	})
 	checkAuthor(t, input, "jd@j.d")
 }
 
 func TestGetCommitAuthor_NoNameNoEmail(t *testing.T) {
-	input := map[string]string{
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	input := gitConfigMap(nil)
 	checkAuthor(t, input, "")
 }
 
 func TestGetCommitAuthor_NameAndEmptyEmail(t *testing.T) {
-	input := map[string]string{
-		"user.name":                    "Jane Doe",
-		"user.email":                   "",
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	input := gitConfigMap(map[string]string{
+		"user.name":  "Jane Doe",
+		"user.email": "",
+	})
 	checkAuthor(t, input, "Jane Doe")
 }
 
 func TestGetCommitAuthor_EmailAndEmptyName(t *testing.T) {
-	input := map[string]string{
-		"user.name":                    "",
-		"user.email":                   "jd@j.d",
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
+	input := gitConfigMap(map[string]string{
+		"user.name":  "",
+		"user.email": "jd@j.d",
+	})
 	checkAuthor(t, input, "jd@j.d")
 }
 
@@ -168,4 +118,19 @@ func checkAuthor(t *testing.T, input map[string]string, expected string) {
 	if author != expected {
 		t.Fatalf("author %q does not match expected value %q", author, expected)
 	}
+}
+
+func gitConfigMap(input map[string]string) map[string]string {
+	res := map[string]string{
+		"push.default":                 "simple",
+		"merge.conflictstyle":          "diff3",
+		"pull.ff":                      "only",
+		"core.repositoryformatversion": "0",
+		"core.filemode":                "true",
+		"core.bare":                    "false",
+	}
+	for k, v := range input {
+		res[k] = v
+	}
+	return res
 }


### PR DESCRIPTION
Extract common code and constants, and add more info to test failure message.