### PR TITLE
Distinguish names, refs, and canonical forms

### DIFF
--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/ssh"
 )
@@ -350,12 +351,12 @@ func mergeCredentials(c *Cluster, namespace string, podTemplate apiv1.PodTemplat
 
 	// Now create the service and attach the credentials
 	for _, container := range podTemplate.Spec.Containers {
-		r, err := flux.ParseImageRef(container.Image)
+		r, err := image.ParseRef(container.Image)
 		if err != nil {
 			c.logger.Log("err", err.Error())
 			continue
 		}
-		imageCreds[r.Name()] = creds
+		imageCreds[r.Name] = creds
 	}
 }
 

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -350,12 +350,12 @@ func mergeCredentials(c *Cluster, namespace string, podTemplate apiv1.PodTemplat
 
 	// Now create the service and attach the credentials
 	for _, container := range podTemplate.Spec.Containers {
-		r, err := flux.ParseImageID(container.Image)
+		r, err := flux.ParseImageRef(container.Image)
 		if err != nil {
 			c.logger.Log("err", err.Error())
 			continue
 		}
-		imageCreds[r] = creds
+		imageCreds[r.Name()] = creds
 	}
 }
 

--- a/cluster/kubernetes/manifests.go
+++ b/cluster/kubernetes/manifests.go
@@ -19,7 +19,7 @@ func (c *Manifests) ParseManifests(allDefs []byte) (map[string]resource.Resource
 	return kresource.ParseMultidoc(allDefs, "exported")
 }
 
-func (c *Manifests) UpdateDefinition(def []byte, container string, image flux.ImageID) ([]byte, error) {
+func (c *Manifests) UpdateDefinition(def []byte, container string, image flux.ImageRef) ([]byte, error) {
 	return updatePodController(def, container, image)
 }
 

--- a/cluster/kubernetes/manifests.go
+++ b/cluster/kubernetes/manifests.go
@@ -1,8 +1,8 @@
 package kubernetes
 
 import (
-	"github.com/weaveworks/flux"
 	kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/resource"
 )
 
@@ -19,7 +19,7 @@ func (c *Manifests) ParseManifests(allDefs []byte) (map[string]resource.Resource
 	return kresource.ParseMultidoc(allDefs, "exported")
 }
 
-func (c *Manifests) UpdateDefinition(def []byte, container string, image flux.ImageRef) ([]byte, error) {
+func (c *Manifests) UpdateDefinition(def []byte, container string, image image.Ref) ([]byte, error) {
 	return updatePodController(def, container, image)
 }
 

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -7,7 +7,7 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 )
 
 // updatePodController takes the body of a Deployment resource definition
@@ -18,7 +18,7 @@ import (
 //
 // This function has many additional requirements that are likely in flux. Read
 // the source to learn about them.
-func updatePodController(def []byte, container string, newImageID flux.ImageRef) ([]byte, error) {
+func updatePodController(def []byte, container string, newImageID image.Ref) ([]byte, error) {
 	// Sanity check
 	obj, err := definitionObj(def)
 	if err != nil {
@@ -77,7 +77,7 @@ func updatePodController(def []byte, container string, newImageID flux.ImageRef)
 //         ports:
 //         - containerPort: 80
 // ```
-func tryUpdate(def []byte, container string, newImage flux.ImageRef, out io.Writer) error {
+func tryUpdate(def []byte, container string, newImage image.Ref, out io.Writer) error {
 	manifest, err := parseManifest(def)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func tryUpdate(def []byte, container string, newImage flux.ImageRef, out io.Writ
 		if c.Name != container {
 			continue
 		}
-		currentImage, err := flux.ParseImageRef(c.Image)
+		currentImage, err := image.ParseRef(c.Image)
 		if err != nil {
 			return fmt.Errorf("could not parse image %s", c.Image)
 		}

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -18,7 +18,7 @@ import (
 //
 // This function has many additional requirements that are likely in flux. Read
 // the source to learn about them.
-func updatePodController(def []byte, container string, newImageID flux.ImageID) ([]byte, error) {
+func updatePodController(def []byte, container string, newImageID flux.ImageRef) ([]byte, error) {
 	// Sanity check
 	obj, err := definitionObj(def)
 	if err != nil {
@@ -77,7 +77,7 @@ func updatePodController(def []byte, container string, newImageID flux.ImageID) 
 //         ports:
 //         - containerPort: 80
 // ```
-func tryUpdate(def []byte, container string, newImage flux.ImageID, out io.Writer) error {
+func tryUpdate(def []byte, container string, newImage flux.ImageRef, out io.Writer) error {
 	manifest, err := parseManifest(def)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func tryUpdate(def []byte, container string, newImage flux.ImageID, out io.Write
 		if c.Name != container {
 			continue
 		}
-		currentImage, err := flux.ParseImageID(c.Image)
+		currentImage, err := flux.ParseImageRef(c.Image)
 		if err != nil {
 			return fmt.Errorf("could not parse image %s", c.Image)
 		}

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -7,7 +7,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 )
 
 type update struct {
@@ -18,7 +18,7 @@ type update struct {
 }
 
 func testUpdate(t *testing.T, u update) {
-	id, err := flux.ParseImageRef(u.updatedImage)
+	id, err := image.ParseRef(u.updatedImage)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -18,7 +18,7 @@ type update struct {
 }
 
 func testUpdate(t *testing.T, u update) {
-	id, err := flux.ParseImageID(u.updatedImage)
+	id, err := flux.ParseImageRef(u.updatedImage)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -18,7 +18,7 @@ type Manifests interface {
 	FindDefinedServices(path string) (map[flux.ResourceID][]string, error)
 	// Update the definitions in a manifests bytes according to the
 	// spec given.
-	UpdateDefinition(def []byte, container string, newImageID flux.ImageID) ([]byte, error)
+	UpdateDefinition(def []byte, container string, newImageID flux.ImageRef) ([]byte, error)
 	// Load all the resource manifests under the path given
 	LoadManifests(paths ...string) (map[string]resource.Resource, error)
 	// Parse the manifests given in an exported blob

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/resource"
 )
@@ -18,7 +19,7 @@ type Manifests interface {
 	FindDefinedServices(path string) (map[flux.ResourceID][]string, error)
 	// Update the definitions in a manifests bytes according to the
 	// spec given.
-	UpdateDefinition(def []byte, container string, newImageID flux.ImageRef) ([]byte, error)
+	UpdateDefinition(def []byte, container string, newImageID image.Ref) ([]byte, error)
 	// Load all the resource manifests under the path given
 	LoadManifests(paths ...string) (map[string]resource.Resource, error)
 	// Parse the manifests given in an exported blob

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -16,7 +16,7 @@ type Mock struct {
 	SyncFunc                 func(SyncDef) error
 	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
 	FindDefinedServicesFunc  func(path string) (map[flux.ResourceID][]string, error)
-	UpdateDefinitionFunc     func(def []byte, container string, newImageID flux.ImageID) ([]byte, error)
+	UpdateDefinitionFunc     func(def []byte, container string, newImageID flux.ImageRef) ([]byte, error)
 	LoadManifestsFunc        func(paths ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
@@ -52,7 +52,7 @@ func (m *Mock) FindDefinedServices(path string) (map[flux.ResourceID][]string, e
 	return m.FindDefinedServicesFunc(path)
 }
 
-func (m *Mock) UpdateDefinition(def []byte, container string, newImageID flux.ImageID) ([]byte, error) {
+func (m *Mock) UpdateDefinition(def []byte, container string, newImageID flux.ImageRef) ([]byte, error) {
 	return m.UpdateDefinitionFunc(def, container, newImageID)
 }
 

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/ssh"
@@ -16,7 +17,7 @@ type Mock struct {
 	SyncFunc                 func(SyncDef) error
 	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
 	FindDefinedServicesFunc  func(path string) (map[flux.ResourceID][]string, error)
-	UpdateDefinitionFunc     func(def []byte, container string, newImageID flux.ImageRef) ([]byte, error)
+	UpdateDefinitionFunc     func(def []byte, container string, newImageID image.Ref) ([]byte, error)
 	LoadManifestsFunc        func(paths ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
@@ -52,7 +53,7 @@ func (m *Mock) FindDefinedServices(path string) (map[flux.ResourceID][]string, e
 	return m.FindDefinedServicesFunc(path)
 }
 
-func (m *Mock) UpdateDefinition(def []byte, container string, newImageID flux.ImageRef) ([]byte, error) {
+func (m *Mock) UpdateDefinition(def []byte, container string, newImageID image.Ref) ([]byte, error) {
 	return m.UpdateDefinitionFunc(def, container, newImageID)
 }
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -417,7 +417,7 @@ func (d *Daemon) LogEvent(ev event.Event) error {
 func containers2containers(cs []cluster.Container) []flux.Container {
 	res := make([]flux.Container, len(cs))
 	for i, c := range cs {
-		id, _ := flux.ParseImageID(c.Image)
+		id, _ := flux.ParseImageRef(c.Image)
 		res[i] = flux.Container{
 			Name: c.Name,
 			Current: flux.Image{
@@ -430,7 +430,7 @@ func containers2containers(cs []cluster.Container) []flux.Container {
 
 func containersWithAvailable(service cluster.Controller, images update.ImageMap) (res []flux.Container) {
 	for _, c := range service.ContainersOrNil() {
-		id, _ := flux.ParseImageID(c.Image)
+		id, _ := flux.ParseImageRef(c.Image)
 		repo := id.CanonicalName()
 		available := images[repo]
 		res = append(res, flux.Container{

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -15,6 +15,7 @@ import (
 	"github.com/weaveworks/flux/event"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/guid"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
@@ -417,10 +418,10 @@ func (d *Daemon) LogEvent(ev event.Event) error {
 func containers2containers(cs []cluster.Container) []flux.Container {
 	res := make([]flux.Container, len(cs))
 	for i, c := range cs {
-		id, _ := flux.ParseImageRef(c.Image)
+		id, _ := image.ParseRef(c.Image)
 		res[i] = flux.Container{
 			Name: c.Name,
-			Current: flux.Image{
+			Current: image.Info{
 				ID: id,
 			},
 		}
@@ -430,12 +431,12 @@ func containers2containers(cs []cluster.Container) []flux.Container {
 
 func containersWithAvailable(service cluster.Controller, images update.ImageMap) (res []flux.Container) {
 	for _, c := range service.ContainersOrNil() {
-		id, _ := flux.ParseImageRef(c.Image)
+		id, _ := image.ParseRef(c.Image)
 		repo := id.CanonicalName()
 		available := images[repo]
 		res = append(res, flux.Container{
 			Name: c.Name,
-			Current: flux.Image{
+			Current: image.Info{
 				ID: id,
 			},
 			Available: available,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaveworks/flux/event"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/git/gittest"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
@@ -395,10 +396,10 @@ func mockDaemon(t *testing.T) (*Daemon, func(), *cluster.Mock, *mockEventWriter)
 
 	var imageRegistry registry.Registry
 	{
-		img1, _ := flux.ParseImage(currentHelloImage, time.Now())
-		img2, _ := flux.ParseImage(newHelloImage, time.Now().Add(1*time.Second))
-		img3, _ := flux.ParseImage("another/service:latest", time.Now().Add(1*time.Second))
-		imageRegistry = registry.NewMockRegistry([]flux.Image{
+		img1, _ := image.ParseInfo(currentHelloImage, time.Now())
+		img2, _ := image.ParseInfo(newHelloImage, time.Now().Add(1*time.Second))
+		img3, _ := image.ParseInfo("another/service:latest", time.Now().Add(1*time.Second))
+		imageRegistry = registry.NewMockRegistry([]image.Info{
 			img1,
 			img2,
 			img3,
@@ -506,8 +507,8 @@ func (w *wait) ForSyncStatus(d *Daemon, rev string, expectedNumCommits int) []st
 	return revs
 }
 
-func imageIDs(status []flux.ImageStatus) []flux.Image {
-	var availableImgs []flux.Image
+func imageIDs(status []flux.ImageStatus) []image.Info {
+	var availableImgs []image.Info
 	for _, i := range status {
 		for _, c := range i.Containers {
 			availableImgs = append(availableImgs, c.Available...)

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -45,14 +45,14 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 		for _, container := range service.ContainersOrNil() {
 			logger := log.With(logger, "service", service.ID, "container", container.Name, "currentimage", container.Image)
 
-			currentImageID, err := flux.ParseImageID(container.Image)
+			currentImageID, err := flux.ParseImageRef(container.Image)
 			if err != nil {
 				logger.Log("error", err)
 				continue
 			}
 
 			pattern := getTagPattern(candidateServices, service.ID, container.Name)
-			repo := currentImageID.CanonicalName()
+			repo := currentImageID.Name()
 			logger.Log("repo", repo, "pattern", pattern)
 
 			if latest := imageMap.LatestImage(repo, pattern); latest != nil && latest.ID != currentImageID {

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/update"
 )
@@ -45,14 +46,14 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 		for _, container := range service.ContainersOrNil() {
 			logger := log.With(logger, "service", service.ID, "container", container.Name, "currentimage", container.Image)
 
-			currentImageID, err := flux.ParseImageRef(container.Image)
+			currentImageID, err := image.ParseRef(container.Image)
 			if err != nil {
 				logger.Log("error", err)
 				continue
 			}
 
 			pattern := getTagPattern(candidateServices, service.ID, container.Name)
-			repo := currentImageID.Name()
+			repo := currentImageID.Name
 			logger.Log("repo", repo, "pattern", pattern)
 
 			if latest := imageMap.LatestImage(repo, pattern); latest != nil && latest.ID != currentImageID {

--- a/flux.go
+++ b/flux.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/ssh"
 )
 
@@ -263,8 +264,8 @@ type ControllerStatus struct {
 
 type Container struct {
 	Name      string
-	Current   Image
-	Available []Image
+	Current   image.Info
+	Available []image.Info
 }
 
 // --- config types

--- a/image/image.go
+++ b/image/image.go
@@ -1,4 +1,4 @@
-package flux
+package image
 
 import (
 	"encoding/json"
@@ -22,7 +22,7 @@ var (
 	ErrMalformedImageID = errors.Wrap(ErrInvalidImageID, `expected image name as either <image>:<tag> or just <image>`)
 )
 
-// ImageName represents an unversioned (i.e., untagged) image a.k.a.,
+// Name represents an unversioned (i.e., untagged) image a.k.a.,
 // an image repo. These sometimes include a domain, e.g., quay.io, and
 // always include a path with at least one element. By convention,
 // images at DockerHub may have the domain omitted; and, if they only
@@ -33,18 +33,18 @@ var (
 //   * library/alpine
 //   * quay.io/weaveworks/flux
 //   * localhost:5000/arbitrary/path/to/repo
-type ImageName struct {
+type Name struct {
 	Domain, Image string
 }
 
 // CanonicalName is an image name with none of the fields left to be
 // implied by convention.
 type CanonicalName struct {
-	ImageName
+	Name
 }
 
 //
-func (i ImageName) String() string {
+func (i Name) String() string {
 	if i.Image == "" {
 		return "" // Doesn't make sense to return anything if it doesn't even have an image
 	}
@@ -55,8 +55,8 @@ func (i ImageName) String() string {
 	return fmt.Sprintf("%s%s", host, i.Image)
 }
 
-// Repository returns the canonicalised path part of an ImageName.
-func (i ImageName) Repository() string {
+// Repository returns the canonicalised path part of an Name.
+func (i Name) Repository() string {
 	switch i.Domain {
 	case "", oldDockerHubHost, dockerHubHost:
 		path := strings.Split(i.Image, "/")
@@ -71,7 +71,7 @@ func (i ImageName) Repository() string {
 
 // Registry returns the domain name of the Docker image registry, to
 // use to fetch the image or image metadata.
-func (i ImageName) Registry() string {
+func (i Name) Registry() string {
 	switch i.Domain {
 	case "", oldDockerHubHost:
 		return dockerHubHost
@@ -82,61 +82,57 @@ func (i ImageName) Registry() string {
 
 // CanonicalName returns the canonicalised registry host and image parts
 // of the ID.
-func (i ImageName) CanonicalName() CanonicalName {
+func (i Name) CanonicalName() CanonicalName {
 	return CanonicalName{
-		ImageName: ImageName{
+		Name: Name{
 			Domain: i.Registry(),
 			Image:  i.Repository(),
 		},
 	}
 }
 
-func (i ImageName) ToRef(tag string) ImageRef {
-	return ImageRef{
-		ImageName: i,
-		Tag:       tag,
+func (i Name) ToRef(tag string) Ref {
+	return Ref{
+		Name: i,
+		Tag:  tag,
 	}
 }
 
-// ImageRef represents a versioned (i.e., tagged) image. The tag is
+// Ref represents a versioned (i.e., tagged) image. The tag is
 // allowed to be empty, though it is in general undefined what that
-// means. As such, `ImageRef` also includes all `ImageName` values.
+// means. As such, `Ref` also includes all `Name` values.
 //
 // Examples (stringified):
 //  * alpine:3.5
 //  * library/alpine:3.5
 //  * quay.io/weaveworks/flux:1.1.0
 //  * localhost:5000/arbitrary/path/to/repo:revision-sha1
-type ImageRef struct {
-	ImageName
+type Ref struct {
+	Name
 	Tag string
 }
 
 // CanonicalRef is an image ref with none of the fields left to be
 // implied by convention.
 type CanonicalRef struct {
-	ImageRef
+	Ref
 }
 
-// String returns the ImageRef as a string (i.e., unparsed) without canonicalising it.
-func (i ImageRef) String() string {
+// String returns the Ref as a string (i.e., unparsed) without canonicalising it.
+func (i Ref) String() string {
 	var tag string
 	if i.Tag != "" {
 		tag = ":" + i.Tag
 	}
-	return fmt.Sprintf("%s%s", i.ImageName.String(), tag)
+	return fmt.Sprintf("%s%s", i.Name.String(), tag)
 }
 
-func (i ImageRef) Name() ImageName {
-	return i.ImageName
-}
-
-// ParseImageRef parses a string representation of an image id into an
-// ImageRef value. The grammar is shown here:
+// ParseRef parses a string representation of an image id into an
+// Ref value. The grammar is shown here:
 // https://github.com/docker/distribution/blob/master/reference/reference.go
 // (but we do not care about all the productions.)
-func ParseImageRef(s string) (ImageRef, error) {
-	var id ImageRef
+func ParseRef(s string) (Ref, error) {
+	var id Ref
 	if s == "" {
 		return id, ErrBlankImageID
 	}
@@ -187,66 +183,66 @@ var (
 )
 
 // ImageID is serialized/deserialized as a string
-func (i ImageRef) MarshalJSON() ([]byte, error) {
+func (i Ref) MarshalJSON() ([]byte, error) {
 	return json.Marshal(i.String())
 }
 
 // ImageID is serialized/deserialized as a string
-func (i *ImageRef) UnmarshalJSON(data []byte) (err error) {
+func (i *Ref) UnmarshalJSON(data []byte) (err error) {
 	var str string
 	if err := json.Unmarshal(data, &str); err != nil {
 		return err
 	}
-	*i, err = ParseImageRef(string(str))
+	*i, err = ParseRef(string(str))
 	return err
 }
 
 // CanonicalRef returns the canonicalised reference including the tag
 // if present.
-func (i ImageRef) CanonicalRef() CanonicalRef {
+func (i Ref) CanonicalRef() CanonicalRef {
 	name := i.CanonicalName()
 	return CanonicalRef{
-		ImageRef: ImageRef{
-			ImageName: name.ImageName,
-			Tag:       i.Tag,
+		Ref: Ref{
+			Name: name.Name,
+			Tag:  i.Tag,
 		},
 	}
 }
 
-func (i ImageRef) Components() (domain, repo, tag string) {
+func (i Ref) Components() (domain, repo, tag string) {
 	return i.Domain, i.Image, i.Tag
 }
 
 // WithNewTag makes a new copy of an ImageID with a new tag
-func (i ImageRef) WithNewTag(t string) ImageRef {
-	var img ImageRef
+func (i Ref) WithNewTag(t string) Ref {
+	var img Ref
 	img = i
 	img.Tag = t
 	return img
 }
 
-// Image can't really be a primitive string only, because we need to also
-// record information about its creation time. (maybe more in the future)
-type Image struct {
-	ID        ImageRef
+// Info has the metadata we are able to determine about an image, from
+// its registry.
+type Info struct {
+	ID        Ref
 	CreatedAt time.Time
 }
 
-func (im Image) MarshalJSON() ([]byte, error) {
+func (im Info) MarshalJSON() ([]byte, error) {
 	var t string
 	if !im.CreatedAt.IsZero() {
 		t = im.CreatedAt.UTC().Format(time.RFC3339Nano)
 	}
 	encode := struct {
-		ID        ImageRef
+		ID        Ref
 		CreatedAt string `json:",omitempty"`
 	}{im.ID, t}
 	return json.Marshal(encode)
 }
 
-func (im *Image) UnmarshalJSON(b []byte) error {
+func (im *Info) UnmarshalJSON(b []byte) error {
 	unencode := struct {
-		ID        ImageRef
+		ID        Ref
 		CreatedAt string `json:",omitempty"`
 	}{}
 	json.Unmarshal(b, &unencode)
@@ -263,19 +259,19 @@ func (im *Image) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-func ParseImage(s string, createdAt time.Time) (Image, error) {
-	id, err := ParseImageRef(s)
+func ParseInfo(s string, createdAt time.Time) (Info, error) {
+	id, err := ParseRef(s)
 	if err != nil {
-		return Image{}, err
+		return Info{}, err
 	}
-	return Image{
+	return Info{
 		ID:        id,
 		CreatedAt: createdAt,
 	}, nil
 }
 
-// Sort image by creation date
-type ByCreatedDesc []Image
+// ByCreatedDesc is a shim used to sort image info by creation date
+type ByCreatedDesc []Info
 
 func (is ByCreatedDesc) Len() int      { return len(is) }
 func (is ByCreatedDesc) Swap(i, j int) { is[i], is[j] = is[j], is[i] }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -1,4 +1,4 @@
-package flux
+package image
 
 import (
 	"encoding/json"
@@ -28,7 +28,7 @@ func TestDomainRegexp(t *testing.T) {
 	}
 }
 
-func TestParseImageRef(t *testing.T) {
+func TestParseRef(t *testing.T) {
 	for _, x := range []struct {
 		test     string
 		registry string
@@ -52,7 +52,7 @@ func TestParseImageRef(t *testing.T) {
 		{"quay.io/library/alpine:mytag", "quay.io", "library/alpine", "quay.io/library/alpine:mytag"},
 		{"localhost:5000/path/to/repo/alpine:mytag", "localhost:5000", "path/to/repo/alpine", "localhost:5000/path/to/repo/alpine:mytag"},
 	} {
-		i, err := ParseImageRef(x.test)
+		i, err := ParseRef(x.test)
 		if err != nil {
 			t.Errorf("Failed parsing %q: %s", x.test, err)
 		}
@@ -71,7 +71,7 @@ func TestParseImageRef(t *testing.T) {
 	}
 }
 
-func TestParseImageRefErrorCases(t *testing.T) {
+func TestParseRefErrorCases(t *testing.T) {
 	for _, x := range []struct {
 		test string
 	}{
@@ -80,7 +80,7 @@ func TestParseImageRefErrorCases(t *testing.T) {
 		{"/leading/slash"},
 		{"trailing/slash/"},
 	} {
-		_, err := ParseImageRef(x.test)
+		_, err := ParseRef(x.test)
 		if err == nil {
 			t.Fatalf("Expected parse failure for %q", x.test)
 		}
@@ -92,7 +92,7 @@ func TestComponents(t *testing.T) {
 	image := "my/repo"
 	tag := "mytag"
 	fqn := fmt.Sprintf("%v/%v:%v", host, image, tag)
-	i, err := ParseImageRef(fqn)
+	i, err := ParseRef(fqn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,13 +111,13 @@ func TestComponents(t *testing.T) {
 	}
 }
 
-func TestImageRefSerialization(t *testing.T) {
+func TestRefSerialization(t *testing.T) {
 	for _, x := range []struct {
-		test     ImageRef
+		test     Ref
 		expected string
 	}{
-		{ImageRef{ImageName: ImageName{Image: "alpine"}, Tag: "a123"}, `"alpine:a123"`},
-		{ImageRef{ImageName: ImageName{Domain: "quay.io", Image: "weaveworks/foobar"}, Tag: "baz"}, `"quay.io/weaveworks/foobar:baz"`},
+		{Ref{Name: Name{Image: "alpine"}, Tag: "a123"}, `"alpine:a123"`},
+		{Ref{Name: Name{Domain: "quay.io", Image: "weaveworks/foobar"}, Tag: "baz"}, `"quay.io/weaveworks/foobar:baz"`},
 	} {
 		serialized, err := json.Marshal(x.test)
 		if err != nil {
@@ -127,7 +127,7 @@ func TestImageRefSerialization(t *testing.T) {
 			t.Errorf("Encoded %v as %s, but expected %s", x.test, string(serialized), x.expected)
 		}
 
-		var decoded ImageRef
+		var decoded Ref
 		if err := json.Unmarshal([]byte(x.expected), &decoded); err != nil {
 			t.Errorf("Error decoding %v: %v", x.expected, err)
 		}
@@ -141,12 +141,12 @@ func TestImage_OrderByCreationDate(t *testing.T) {
 	fmt.Printf("testTime: %s\n", testTime)
 	time0 := testTime.Add(time.Second)
 	time2 := testTime.Add(-time.Second)
-	imA, _ := ParseImage("my/Image:3", testTime)
-	imB, _ := ParseImage("my/Image:1", time0)
-	imC, _ := ParseImage("my/Image:4", time2)
-	imD, _ := ParseImage("my/Image:0", time.Time{}) // test nil
-	imE, _ := ParseImage("my/Image:2", testTime)    // test equal
-	imgs := []Image{imA, imB, imC, imD, imE}
+	imA, _ := ParseInfo("my/Image:3", testTime)
+	imB, _ := ParseInfo("my/Image:1", time0)
+	imC, _ := ParseInfo("my/Image:4", time2)
+	imD, _ := ParseInfo("my/Image:0", time.Time{}) // test nil
+	imE, _ := ParseInfo("my/Image:2", testTime)    // test equal
+	imgs := []Info{imA, imB, imC, imD, imE}
 	sort.Sort(ByCreatedDesc(imgs))
 	for i, im := range imgs {
 		if strconv.Itoa(i) != im.ID.Tag {

--- a/image_test.go
+++ b/image_test.go
@@ -28,7 +28,7 @@ func TestDomainRegexp(t *testing.T) {
 	}
 }
 
-func TestImageID_ParseImageID(t *testing.T) {
+func TestParseImageRef(t *testing.T) {
 	for _, x := range []struct {
 		test     string
 		registry string
@@ -52,12 +52,12 @@ func TestImageID_ParseImageID(t *testing.T) {
 		{"quay.io/library/alpine:mytag", "quay.io", "library/alpine", "quay.io/library/alpine:mytag"},
 		{"localhost:5000/path/to/repo/alpine:mytag", "localhost:5000", "path/to/repo/alpine", "localhost:5000/path/to/repo/alpine:mytag"},
 	} {
-		i, err := ParseImageID(x.test)
+		i, err := ParseImageRef(x.test)
 		if err != nil {
 			t.Errorf("Failed parsing %q: %s", x.test, err)
 		}
 		if i.String() != x.test {
-			t.Errorf("%q does not stringify as itself", x.test)
+			t.Errorf("%q does not stringify as itself; got %q", x.test, i.String())
 		}
 		if i.Registry() != x.registry {
 			t.Errorf("%q registry: expected %q, got %q", x.test, x.registry, i.Registry())
@@ -65,13 +65,13 @@ func TestImageID_ParseImageID(t *testing.T) {
 		if i.Repository() != x.repo {
 			t.Errorf("%q repo: expected %q, got %q", x.test, x.repo, i.Repository())
 		}
-		if i.CanonicalRef() != x.canon {
-			t.Errorf("%q full ID: expected %q, got %q", x.test, x.canon, i.CanonicalRef())
+		if i.CanonicalRef().String() != x.canon {
+			t.Errorf("%q full ID: expected %q, got %q", x.test, x.canon, i.CanonicalRef().String())
 		}
 	}
 }
 
-func TestImageID_ParseImageIDErrorCases(t *testing.T) {
+func TestParseImageRefErrorCases(t *testing.T) {
 	for _, x := range []struct {
 		test string
 	}{
@@ -80,19 +80,19 @@ func TestImageID_ParseImageIDErrorCases(t *testing.T) {
 		{"/leading/slash"},
 		{"trailing/slash/"},
 	} {
-		_, err := ParseImageID(x.test)
+		_, err := ParseImageRef(x.test)
 		if err == nil {
 			t.Fatalf("Expected parse failure for %q", x.test)
 		}
 	}
 }
 
-func TestImageID_TestComponents(t *testing.T) {
+func TestComponents(t *testing.T) {
 	host := "quay.io"
 	image := "my/repo"
 	tag := "mytag"
 	fqn := fmt.Sprintf("%v/%v:%v", host, image, tag)
-	i, err := ParseImageID(fqn)
+	i, err := ParseImageRef(fqn)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -109,16 +109,15 @@ func TestImageID_TestComponents(t *testing.T) {
 			t.Fatalf("Expected %v, but got %v", x.expected, x.test)
 		}
 	}
-
 }
 
-func TestImageID_Serialization(t *testing.T) {
+func TestImageRefSerialization(t *testing.T) {
 	for _, x := range []struct {
-		test     ImageID
+		test     ImageRef
 		expected string
 	}{
-		{ImageID{Image: "alpine", Tag: "a123"}, `"alpine:a123"`},
-		{ImageID{Domain: "quay.io", Image: "weaveworks/foobar", Tag: "baz"}, `"quay.io/weaveworks/foobar:baz"`},
+		{ImageRef{ImageName: ImageName{Image: "alpine"}, Tag: "a123"}, `"alpine:a123"`},
+		{ImageRef{ImageName: ImageName{Domain: "quay.io", Image: "weaveworks/foobar"}, Tag: "baz"}, `"quay.io/weaveworks/foobar:baz"`},
 	} {
 		serialized, err := json.Marshal(x.test)
 		if err != nil {
@@ -128,7 +127,7 @@ func TestImageID_Serialization(t *testing.T) {
 			t.Errorf("Encoded %v as %s, but expected %s", x.test, string(serialized), x.expected)
 		}
 
-		var decoded ImageID
+		var decoded ImageRef
 		if err := json.Unmarshal([]byte(x.expected), &decoded); err != nil {
 			t.Errorf("Error decoding %v: %v", x.expected, err)
 		}

--- a/registry/cache/memcached.go
+++ b/registry/cache/memcached.go
@@ -13,8 +13,8 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 
-	"github.com/weaveworks/flux"
 	fluxerr "github.com/weaveworks/flux/errors"
+	"github.com/weaveworks/flux/image"
 )
 
 const (
@@ -236,7 +236,7 @@ type manifestKey struct {
 	username, fullRepositoryPath, reference string
 }
 
-func NewManifestKey(username string, image flux.CanonicalRef) (Keyer, error) {
+func NewManifestKey(username string, image image.CanonicalRef) (Keyer, error) {
 	return &manifestKey{username, image.CanonicalName().String(), image.Tag}, nil
 }
 
@@ -256,7 +256,7 @@ type tagKey struct {
 	username, fullRepositoryPath string
 }
 
-func NewTagKey(username string, id flux.CanonicalName) (Keyer, error) {
+func NewTagKey(username string, id image.CanonicalName) (Keyer, error) {
 	return &tagKey{username, id.String()}, nil
 }
 

--- a/registry/cache/memcached.go
+++ b/registry/cache/memcached.go
@@ -236,8 +236,8 @@ type manifestKey struct {
 	username, fullRepositoryPath, reference string
 }
 
-func NewManifestKey(username string, id flux.ImageID) (Keyer, error) {
-	return &manifestKey{username, id.CanonicalName(), id.Tag}, nil
+func NewManifestKey(username string, image flux.CanonicalRef) (Keyer, error) {
+	return &manifestKey{username, image.CanonicalName().String(), image.Tag}, nil
 }
 
 func (k *manifestKey) Key() string {
@@ -256,8 +256,8 @@ type tagKey struct {
 	username, fullRepositoryPath string
 }
 
-func NewTagKey(username string, id flux.ImageID) (Keyer, error) {
-	return &tagKey{username, id.CanonicalName()}, nil
+func NewTagKey(username string, id flux.CanonicalName) (Keyer, error) {
+	return &tagKey{username, id.String()}, nil
 }
 
 func (k *tagKey) Key() string {

--- a/registry/client.go
+++ b/registry/client.go
@@ -12,15 +12,15 @@ import (
 	dockerregistry "github.com/heroku/docker-registry-client/registry"
 	"github.com/pkg/errors"
 
-	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry/cache"
 )
 
 // A client represents an entity that returns manifest and tags
 // information.  It might be a cache, it might be a real registry.
 type Client interface {
-	Tags(name flux.ImageName) ([]string, error)
-	Manifest(name flux.ImageRef) (flux.Image, error)
+	Tags(name image.Name) ([]string, error)
+	Manifest(name image.Ref) (image.Info, error)
 	Cancel()
 }
 
@@ -34,13 +34,13 @@ type Remote struct {
 }
 
 // Return the tags for this repository.
-func (a *Remote) Tags(id flux.ImageName) ([]string, error) {
+func (a *Remote) Tags(id image.Name) ([]string, error) {
 	return a.Registry.Tags(id.Repository())
 }
 
 // We need to do some adapting here to convert from the return values
 // from dockerregistry to our domain types.
-func (a *Remote) Manifest(id flux.ImageRef) (flux.Image, error) {
+func (a *Remote) Manifest(id image.Ref) (image.Info, error) {
 	manifestV2, err := a.Registry.ManifestV2(id.Repository(), id.Tag)
 	if err != nil {
 		if err, ok := err.(*url.Error); ok {
@@ -50,7 +50,7 @@ func (a *Remote) Manifest(id flux.ImageRef) (flux.Image, error) {
 				}
 			}
 		}
-		return flux.Image{}, err
+		return image.Info{}, err
 	}
 	// The above request will happily return a bogus, empty manifest
 	// if handed something other than a schema2 manifest.
@@ -64,10 +64,10 @@ func (a *Remote) Manifest(id flux.ImageRef) (flux.Image, error) {
 	conf := manifestV2.Config
 	reader, err := a.Registry.DownloadLayer(id.Repository(), conf.Digest)
 	if err != nil {
-		return flux.Image{}, err
+		return image.Info{}, err
 	}
 	if reader == nil {
-		return flux.Image{}, fmt.Errorf("nil reader from DownloadLayer")
+		return image.Info{}, fmt.Errorf("nil reader from DownloadLayer")
 	}
 
 	type config struct {
@@ -77,18 +77,18 @@ func (a *Remote) Manifest(id flux.ImageRef) (flux.Image, error) {
 
 	err = json.NewDecoder(reader).Decode(&imageConf)
 	if err != nil {
-		return flux.Image{}, err
+		return image.Info{}, err
 	}
-	return flux.Image{
+	return image.Info{
 		ID:        id,
 		CreatedAt: imageConf.Created,
 	}, nil
 }
 
-func (a *Remote) ManifestFromV1(id flux.ImageRef) (flux.Image, error) {
+func (a *Remote) ManifestFromV1(id image.Ref) (image.Info, error) {
 	history, err := a.Registry.Manifest(id.Repository(), id.Tag)
 	if err != nil || history == nil {
-		return flux.Image{}, errors.Wrap(err, "getting remote manifest")
+		return image.Info{}, errors.Wrap(err, "getting remote manifest")
 	}
 
 	// the manifest includes some v1-backwards-compatibility data,
@@ -100,7 +100,7 @@ func (a *Remote) ManifestFromV1(id flux.ImageRef) (flux.Image, error) {
 		Created time.Time `json:"created"`
 	}
 	var topmost v1image
-	var img flux.Image
+	var img image.Info
 	img.ID = id
 	if len(history) > 0 {
 		if err = json.Unmarshal([]byte(history[0].V1Compatibility), &topmost); err == nil {
@@ -141,26 +141,26 @@ func NewCache(creds Credentials, cr cache.Reader, expiry time.Duration, logger l
 	}
 }
 
-func (c *Cache) Manifest(id flux.ImageRef) (flux.Image, error) {
+func (c *Cache) Manifest(id image.Ref) (image.Info, error) {
 	creds := c.creds.credsFor(id.Registry())
 	key, err := cache.NewManifestKey(creds.username, id.CanonicalRef())
 	if err != nil {
-		return flux.Image{}, err
+		return image.Info{}, err
 	}
 	val, err := c.cr.GetKey(key)
 	if err != nil {
-		return flux.Image{}, err
+		return image.Info{}, err
 	}
-	var img flux.Image
+	var img image.Info
 	err = json.Unmarshal(val, &img)
 	if err != nil {
 		c.logger.Log("err", err.Error)
-		return flux.Image{}, err
+		return image.Info{}, err
 	}
 	return img, nil
 }
 
-func (c *Cache) Tags(id flux.ImageName) ([]string, error) {
+func (c *Cache) Tags(id image.Name) ([]string, error) {
 	creds := c.creds.credsFor(id.Registry())
 	key, err := cache.NewTagKey(creds.username, id.CanonicalName())
 	if err != nil {

--- a/registry/integration_test.go
+++ b/registry/integration_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 
-	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry/cache"
 	"github.com/weaveworks/flux/registry/middleware"
 )
@@ -32,7 +32,7 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 		Logger:         log.With(log.NewLogfmtLogger(os.Stderr), "component", "memcached"),
 	}, strings.Fields(*memcachedIPs)...)
 
-	id, _ := flux.ParseImageID("alpine")
+	id, _ := image.ParseRef("alpine")
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 
@@ -73,7 +73,7 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 	shutdownWg.Add(1)
 	go w.Loop(shutdown, shutdownWg, func() ImageCreds {
 		return ImageCreds{
-			id: NoCredentials(),
+			id.Name: NoCredentials(),
 		}
 	})
 
@@ -86,14 +86,14 @@ Loop:
 		case <-timeout.C:
 			t.Fatal("Cache timeout")
 		case <-tick.C:
-			_, err := r.GetRepository(id)
+			_, err := r.GetRepository(id.Name)
 			if err == nil {
 				break Loop
 			}
 		}
 	}
 
-	img, err := r.GetRepository(id)
+	img, err := r.GetRepository(id.Name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/mock.go
+++ b/registry/mock.go
@@ -17,8 +17,8 @@ type mockRemote struct {
 	err  error
 }
 
-type ManifestFunc func(id flux.ImageID) (flux.Image, error)
-type TagsFunc func(id flux.ImageID) ([]string, error)
+type ManifestFunc func(id flux.ImageRef) (flux.Image, error)
+type TagsFunc func(id flux.ImageName) ([]string, error)
 type mockDockerClient struct {
 	manifest ManifestFunc
 	tags     TagsFunc
@@ -31,11 +31,11 @@ func NewMockClient(manifest ManifestFunc, tags TagsFunc) Client {
 	}
 }
 
-func (m *mockDockerClient) Manifest(id flux.ImageID) (flux.Image, error) {
+func (m *mockDockerClient) Manifest(id flux.ImageRef) (flux.Image, error) {
 	return m.manifest(id)
 }
 
-func (m *mockDockerClient) Tags(id flux.ImageID) ([]string, error) {
+func (m *mockDockerClient) Tags(id flux.ImageName) ([]string, error) {
 	return m.tags(id)
 }
 
@@ -71,7 +71,7 @@ func NewMockRegistry(images []flux.Image, err error) Registry {
 	}
 }
 
-func (m *mockRegistry) GetRepository(id flux.ImageID) ([]flux.Image, error) {
+func (m *mockRegistry) GetRepository(id flux.ImageName) ([]flux.Image, error) {
 	var imgs []flux.Image
 	for _, i := range m.imgs {
 		// include only if it's the same repository in the same place
@@ -82,7 +82,7 @@ func (m *mockRegistry) GetRepository(id flux.ImageID) ([]flux.Image, error) {
 	return imgs, m.err
 }
 
-func (m *mockRegistry) GetImage(id flux.ImageID) (flux.Image, error) {
+func (m *mockRegistry) GetImage(id flux.ImageRef) (flux.Image, error) {
 	if len(m.imgs) > 0 {
 		for _, i := range m.imgs {
 			if i.ID.String() == id.String() {

--- a/registry/mock.go
+++ b/registry/mock.go
@@ -3,22 +3,22 @@ package registry
 import (
 	"github.com/pkg/errors"
 
-	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 )
 
 type mockClientAdapter struct {
-	imgs []flux.Image
+	imgs []image.Info
 	err  error
 }
 
 type mockRemote struct {
-	img  flux.Image
+	img  image.Info
 	tags []string
 	err  error
 }
 
-type ManifestFunc func(id flux.ImageRef) (flux.Image, error)
-type TagsFunc func(id flux.ImageName) ([]string, error)
+type ManifestFunc func(id image.Ref) (image.Info, error)
+type TagsFunc func(id image.Name) ([]string, error)
 type mockDockerClient struct {
 	manifest ManifestFunc
 	tags     TagsFunc
@@ -31,11 +31,11 @@ func NewMockClient(manifest ManifestFunc, tags TagsFunc) Client {
 	}
 }
 
-func (m *mockDockerClient) Manifest(id flux.ImageRef) (flux.Image, error) {
+func (m *mockDockerClient) Manifest(id image.Ref) (image.Info, error) {
 	return m.manifest(id)
 }
 
-func (m *mockDockerClient) Tags(id flux.ImageName) ([]string, error) {
+func (m *mockDockerClient) Tags(id image.Name) ([]string, error) {
 	return m.tags(id)
 }
 
@@ -60,19 +60,19 @@ func (m *mockRemoteFactory) ClientFor(repository string, creds Credentials) (Cli
 }
 
 type mockRegistry struct {
-	imgs []flux.Image
+	imgs []image.Info
 	err  error
 }
 
-func NewMockRegistry(images []flux.Image, err error) Registry {
+func NewMockRegistry(images []image.Info, err error) Registry {
 	return &mockRegistry{
 		imgs: images,
 		err:  err,
 	}
 }
 
-func (m *mockRegistry) GetRepository(id flux.ImageName) ([]flux.Image, error) {
-	var imgs []flux.Image
+func (m *mockRegistry) GetRepository(id image.Name) ([]image.Info, error) {
+	var imgs []image.Info
 	for _, i := range m.imgs {
 		// include only if it's the same repository in the same place
 		if i.ID.Image == id.Image {
@@ -82,7 +82,7 @@ func (m *mockRegistry) GetRepository(id flux.ImageName) ([]flux.Image, error) {
 	return imgs, m.err
 }
 
-func (m *mockRegistry) GetImage(id flux.ImageRef) (flux.Image, error) {
+func (m *mockRegistry) GetImage(id image.Ref) (image.Info, error) {
 	if len(m.imgs) > 0 {
 		for _, i := range m.imgs {
 			if i.ID.String() == id.String() {
@@ -90,5 +90,5 @@ func (m *mockRegistry) GetImage(id flux.ImageRef) (flux.Image, error) {
 			}
 		}
 	}
-	return flux.Image{}, errors.New("not found")
+	return image.Info{}, errors.New("not found")
 }

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -46,7 +46,7 @@ func NewInstrumentedRegistry(next Registry) InstrumentedRegistry {
 	}
 }
 
-func (m *instrumentedRegistry) GetRepository(id flux.ImageID) (res []flux.Image, err error) {
+func (m *instrumentedRegistry) GetRepository(id flux.ImageName) (res []flux.Image, err error) {
 	start := time.Now()
 	res, err = m.next.GetRepository(id)
 	registryDuration.With(
@@ -55,7 +55,7 @@ func (m *instrumentedRegistry) GetRepository(id flux.ImageID) (res []flux.Image,
 	return
 }
 
-func (m *instrumentedRegistry) GetImage(id flux.ImageID) (res flux.Image, err error) {
+func (m *instrumentedRegistry) GetImage(id flux.ImageRef) (res flux.Image, err error) {
 	start := time.Now()
 	res, err = m.next.GetImage(id)
 	registryDuration.With(
@@ -76,7 +76,7 @@ func NewInstrumentedClient(next Client) Client {
 	}
 }
 
-func (m *instrumentedClient) Manifest(id flux.ImageID) (res flux.Image, err error) {
+func (m *instrumentedClient) Manifest(id flux.ImageRef) (res flux.Image, err error) {
 	start := time.Now()
 	res, err = m.next.Manifest(id)
 	remoteDuration.With(
@@ -86,7 +86,7 @@ func (m *instrumentedClient) Manifest(id flux.ImageID) (res flux.Image, err erro
 	return
 }
 
-func (m *instrumentedClient) Tags(id flux.ImageID) (res []string, err error) {
+func (m *instrumentedClient) Tags(id flux.ImageName) (res []string, err error) {
 	start := time.Now()
 	res, err = m.next.Tags(id)
 	remoteDuration.With(

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -8,7 +8,8 @@ import (
 
 	"github.com/go-kit/kit/metrics/prometheus"
 	stdprometheus "github.com/prometheus/client_golang/prometheus"
-	"github.com/weaveworks/flux"
+
+	"github.com/weaveworks/flux/image"
 	fluxmetrics "github.com/weaveworks/flux/metrics"
 )
 
@@ -46,7 +47,7 @@ func NewInstrumentedRegistry(next Registry) InstrumentedRegistry {
 	}
 }
 
-func (m *instrumentedRegistry) GetRepository(id flux.ImageName) (res []flux.Image, err error) {
+func (m *instrumentedRegistry) GetRepository(id image.Name) (res []image.Info, err error) {
 	start := time.Now()
 	res, err = m.next.GetRepository(id)
 	registryDuration.With(
@@ -55,7 +56,7 @@ func (m *instrumentedRegistry) GetRepository(id flux.ImageName) (res []flux.Imag
 	return
 }
 
-func (m *instrumentedRegistry) GetImage(id flux.ImageRef) (res flux.Image, err error) {
+func (m *instrumentedRegistry) GetImage(id image.Ref) (res image.Info, err error) {
 	start := time.Now()
 	res, err = m.next.GetImage(id)
 	registryDuration.With(
@@ -76,7 +77,7 @@ func NewInstrumentedClient(next Client) Client {
 	}
 }
 
-func (m *instrumentedClient) Manifest(id flux.ImageRef) (res flux.Image, err error) {
+func (m *instrumentedClient) Manifest(id image.Ref) (res image.Info, err error) {
 	start := time.Now()
 	res, err = m.next.Manifest(id)
 	remoteDuration.With(
@@ -86,7 +87,7 @@ func (m *instrumentedClient) Manifest(id flux.ImageRef) (res flux.Image, err err
 	return
 }
 
-func (m *instrumentedClient) Tags(id flux.ImageName) (res []string, err error) {
+func (m *instrumentedClient) Tags(id image.Name) (res []string, err error) {
 	start := time.Now()
 	res, err = m.next.Tags(id)
 	remoteDuration.With(

--- a/registry/registry_test.go
+++ b/registry/registry_test.go
@@ -19,7 +19,7 @@ const testImageStr = "alpine:" + testTagStr
 const constTime = "2017-01-13T16:22:58.009923189Z"
 
 var (
-	id, _ = flux.ParseImageID(testImageStr)
+	id, _ = flux.ParseImageRef(testImageStr)
 	man   = schema1.SignedManifest{
 		Manifest: schema1.Manifest{
 			History: []schema1.History{
@@ -34,11 +34,11 @@ var (
 var (
 	testTags = []string{testTagStr, "anotherTag"}
 	mClient  = NewMockClient(
-		func(repository flux.ImageID) (flux.Image, error) {
+		func(repository flux.ImageRef) (flux.Image, error) {
 			img, _ := flux.ParseImage(testImageStr, time.Time{})
 			return img, nil
 		},
-		func(repository flux.ImageID) ([]string, error) {
+		func(repository flux.ImageName) ([]string, error) {
 			return testTags, nil
 		},
 	)
@@ -47,7 +47,7 @@ var (
 func TestRegistry_GetRepository(t *testing.T) {
 	fact := NewMockClientFactory(mClient, nil)
 	reg := NewRegistry(fact, log.NewNopLogger(), 512)
-	imgs, err := reg.GetRepository(id)
+	imgs, err := reg.GetRepository(id.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -61,7 +61,7 @@ func TestRegistry_GetRepository(t *testing.T) {
 func TestRegistry_GetRepositoryFactoryError(t *testing.T) {
 	errFact := NewMockClientFactory(mClient, errors.New(""))
 	reg := NewRegistry(errFact, nil, 512)
-	_, err := reg.GetRepository(id)
+	_, err := reg.GetRepository(id.Name())
 	if err == nil {
 		t.Fatal("Expecting error")
 	}
@@ -69,16 +69,16 @@ func TestRegistry_GetRepositoryFactoryError(t *testing.T) {
 
 func TestRegistry_GetRepositoryManifestError(t *testing.T) {
 	errClient := NewMockClient(
-		func(repository flux.ImageID) (flux.Image, error) {
+		func(repository flux.ImageRef) (flux.Image, error) {
 			return flux.Image{}, errors.New("")
 		},
-		func(repository flux.ImageID) ([]string, error) {
+		func(repository flux.ImageName) ([]string, error) {
 			return testTags, nil
 		},
 	)
 	errFact := NewMockClientFactory(errClient, nil)
 	reg := NewRegistry(errFact, log.NewNopLogger(), 512)
-	_, err := reg.GetRepository(id)
+	_, err := reg.GetRepository(id.Name())
 	if err == nil {
 		t.Fatal("Expecting error")
 	}
@@ -100,7 +100,7 @@ func TestRemoteFactory_RawClient(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	tags, err = client.Tags(id)
+	tags, err = client.Tags(id.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -129,7 +129,7 @@ func TestRemoteFactory_RawClient(t *testing.T) {
 
 func TestRemoteFactory_InvalidHost(t *testing.T) {
 	fact := NewRemoteClientFactory(log.NewNopLogger(), middleware.RateLimiterConfig{})
-	invalidId, err := flux.ParseImageID("invalid.host/library/alpine:latest")
+	invalidId, err := flux.ParseImageRef("invalid.host/library/alpine:latest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,17 +145,17 @@ func TestRemoteFactory_InvalidHost(t *testing.T) {
 
 func TestRemote_BetterError(t *testing.T) {
 	errClient := NewMockClient(
-		func(repository flux.ImageID) (flux.Image, error) {
+		func(repository flux.ImageRef) (flux.Image, error) {
 			return flux.Image{}, cache.ErrNotCached
 		},
-		func(repository flux.ImageID) ([]string, error) {
+		func(repository flux.ImageName) ([]string, error) {
 			return []string{}, cache.ErrNotCached
 		},
 	)
 
 	fact := NewMockClientFactory(errClient, nil)
 	reg := NewRegistry(fact, log.NewNopLogger(), 512)
-	_, err := reg.GetRepository(id)
+	_, err := reg.GetRepository(id.Name())
 	if err == nil {
 		t.Fatal("Should have errored")
 	}

--- a/registry/warming.go
+++ b/registry/warming.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
-	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry/cache"
 )
 
@@ -28,7 +28,7 @@ type Warmer struct {
 	Burst         int
 }
 
-type ImageCreds map[flux.ImageName]Credentials
+type ImageCreds map[image.Name]Credentials
 
 // Continuously get the images to populate the cache with, and
 // populate the cache with them.
@@ -57,7 +57,7 @@ func (w *Warmer) Loop(stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFun
 	}
 }
 
-func (w *Warmer) warm(id flux.ImageName, creds Credentials) {
+func (w *Warmer) warm(id image.Name, creds Credentials) {
 	client, err := w.ClientFactory.ClientFor(id.Registry(), creds)
 	if err != nil {
 		w.Logger.Log("err", err.Error())
@@ -96,7 +96,7 @@ func (w *Warmer) warm(id flux.ImageName, creds Credentials) {
 	}
 
 	// Create a list of manifests that need updating
-	var toUpdate []flux.ImageRef
+	var toUpdate []image.Ref
 	var expired bool
 	for _, tag := range tags {
 		// See if we have the manifest already cached
@@ -136,7 +136,7 @@ func (w *Warmer) warm(id flux.ImageName, creds Credentials) {
 	for _, imID := range toUpdate {
 		awaitFetchers.Add(1)
 		fetchers <- struct{}{}
-		go func(imageID flux.ImageRef) {
+		go func(imageID image.Ref) {
 			defer func() { awaitFetchers.Done(); <-fetchers }()
 			// Get the image from the remote
 			img, err := client.Manifest(imageID)

--- a/registry/warming.go
+++ b/registry/warming.go
@@ -28,7 +28,7 @@ type Warmer struct {
 	Burst         int
 }
 
-type ImageCreds map[flux.ImageID]Credentials
+type ImageCreds map[flux.ImageName]Credentials
 
 // Continuously get the images to populate the cache with, and
 // populate the cache with them.
@@ -57,7 +57,7 @@ func (w *Warmer) Loop(stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFun
 	}
 }
 
-func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
+func (w *Warmer) warm(id flux.ImageName, creds Credentials) {
 	client, err := w.ClientFactory.ClientFor(id.Registry(), creds)
 	if err != nil {
 		w.Logger.Log("err", err.Error())
@@ -83,7 +83,7 @@ func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
 		return
 	}
 
-	key, err := cache.NewTagKey(username, id)
+	key, err := cache.NewTagKey(username, id.CanonicalName())
 	if err != nil {
 		w.Logger.Log("err", errors.Wrap(err, "creating key for cache"))
 		return
@@ -96,13 +96,13 @@ func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
 	}
 
 	// Create a list of manifests that need updating
-	var toUpdate []flux.ImageID
+	var toUpdate []flux.ImageRef
 	var expired bool
 	for _, tag := range tags {
 		// See if we have the manifest already cached
 		// We don't want to re-download a manifest again.
-		newID := id.WithNewTag(tag)
-		key, err := cache.NewManifestKey(username, newID)
+		newID := id.ToRef(tag)
+		key, err := cache.NewManifestKey(username, newID.CanonicalRef())
 		if err != nil {
 			w.Logger.Log("err", errors.Wrap(err, "creating key for memcache"))
 			continue
@@ -136,7 +136,7 @@ func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
 	for _, imID := range toUpdate {
 		awaitFetchers.Add(1)
 		fetchers <- struct{}{}
-		go func(imageID flux.ImageID) {
+		go func(imageID flux.ImageRef) {
 			defer func() { awaitFetchers.Done(); <-fetchers }()
 			// Get the image from the remote
 			img, err := client.Manifest(imageID)
@@ -149,7 +149,7 @@ func (w *Warmer) warm(id flux.ImageID, creds Credentials) {
 				return
 			}
 
-			key, err := cache.NewManifestKey(username, img.ID)
+			key, err := cache.NewManifestKey(username, img.ID.CanonicalRef())
 			if err != nil {
 				w.Logger.Log("err", errors.Wrap(err, "creating key for memcache"))
 				return

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/weaveworks/flux/cluster/kubernetes"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/git/gittest"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/update"
 )
@@ -20,13 +21,13 @@ var (
 	// This must match the value in cluster/kubernetes/testfiles/data.go
 	container = "goodbyeworld"
 
-	oldImage           = "quay.io/weaveworks/helloworld:master-a000001"
-	oldImageRef, _     = flux.ParseImageRef(oldImage)
-	sidecarImage       = "quay.io/weaveworks/sidecar:master-a000002"
-	sidecarImageRef, _ = flux.ParseImageRef(sidecarImage)
-	hwSvcID, _         = flux.ParseResourceID("default:deployment/helloworld")
-	hwSvcSpec, _       = update.ParseResourceSpec(hwSvcID.String())
-	hwSvc              = cluster.Controller{
+	oldImage      = "quay.io/weaveworks/helloworld:master-a000001"
+	oldRef, _     = image.ParseRef(oldImage)
+	sidecarImage  = "quay.io/weaveworks/sidecar:master-a000002"
+	sidecarRef, _ = image.ParseRef(sidecarImage)
+	hwSvcID, _    = flux.ParseResourceID("default:deployment/helloworld")
+	hwSvcSpec, _  = update.ParseResourceSpec(hwSvcID.String())
+	hwSvc         = cluster.Controller{
 		ID: hwSvcID,
 		Containers: cluster.ContainersOrExcuse{
 			Containers: []cluster.Container{
@@ -44,7 +45,7 @@ var (
 
 	oldLockedImg     = "quay.io/weaveworks/locked-service:1"
 	newLockedImg     = "quay.io/weaveworks/locked-service:2"
-	newLockedID, _   = flux.ParseImageRef(newLockedImg)
+	newLockedID, _   = image.ParseRef(newLockedImg)
 	lockedSvcID, _   = flux.ParseResourceID("default:deployment/locked-service")
 	lockedSvcSpec, _ = update.ParseResourceSpec(lockedSvcID.String())
 	lockedSvc        = cluster.Controller{
@@ -77,14 +78,14 @@ var (
 		lockedSvc,
 		testSvc,
 	}
-	newImageRef, _ = flux.ParseImageRef("quay.io/weaveworks/helloworld:master-a000002")
-	timeNow        = time.Now()
-	mockRegistry   = registry.NewMockRegistry([]flux.Image{
-		flux.Image{
-			ID:        newImageRef,
+	newRef, _    = image.ParseRef("quay.io/weaveworks/helloworld:master-a000002")
+	timeNow      = time.Now()
+	mockRegistry = registry.NewMockRegistry([]image.Info{
+		image.Info{
+			ID:        newRef,
 			CreatedAt: timeNow,
 		},
-		flux.Image{
+		image.Info{
 			ID:        newLockedID,
 			CreatedAt: timeNow,
 		},
@@ -131,8 +132,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageRef,
-							Target:    newImageRef,
+							Current:   oldRef,
+							Target:    newRef,
 						},
 					},
 				},
@@ -159,8 +160,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageRef,
-							Target:    newImageRef,
+							Current:   oldRef,
+							Target:    newRef,
 						},
 					},
 				},
@@ -177,7 +178,7 @@ func Test_FilterLogic(t *testing.T) {
 			Name: "not image",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
-				ImageSpec:    update.ImageSpecFromRef(newImageRef),
+				ImageSpec:    update.ImageSpecFromRef(newRef),
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
@@ -187,8 +188,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageRef,
-							Target:    newImageRef,
+							Current:   oldRef,
+							Target:    newRef,
 						},
 					},
 				},
@@ -218,8 +219,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageRef,
-							Target:    newImageRef,
+							Current:   oldRef,
+							Target:    newRef,
 						},
 					},
 				},
@@ -247,8 +248,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageRef,
-							Target:    newImageRef,
+							Current:   oldRef,
+							Target:    newRef,
 						},
 					},
 				},
@@ -315,13 +316,13 @@ func Test_ImageStatus(t *testing.T) {
 		},
 	}
 
-	upToDateRegistry := registry.NewMockRegistry([]flux.Image{
-		flux.Image{
-			ID:        oldImageRef,
+	upToDateRegistry := registry.NewMockRegistry([]image.Info{
+		image.Info{
+			ID:        oldRef,
 			CreatedAt: timeNow,
 		},
-		flux.Image{
-			ID:        sidecarImageRef,
+		image.Info{
+			ID:        sidecarRef,
 			CreatedAt: timeNow,
 		},
 	}, nil)

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -20,13 +20,13 @@ var (
 	// This must match the value in cluster/kubernetes/testfiles/data.go
 	container = "goodbyeworld"
 
-	oldImage          = "quay.io/weaveworks/helloworld:master-a000001"
-	oldImageID, _     = flux.ParseImageID(oldImage)
-	sidecarImage      = "quay.io/weaveworks/sidecar:master-a000002"
-	sidecarImageID, _ = flux.ParseImageID(sidecarImage)
-	hwSvcID, _        = flux.ParseResourceID("default:deployment/helloworld")
-	hwSvcSpec, _      = update.ParseResourceSpec(hwSvcID.String())
-	hwSvc             = cluster.Controller{
+	oldImage           = "quay.io/weaveworks/helloworld:master-a000001"
+	oldImageRef, _     = flux.ParseImageRef(oldImage)
+	sidecarImage       = "quay.io/weaveworks/sidecar:master-a000002"
+	sidecarImageRef, _ = flux.ParseImageRef(sidecarImage)
+	hwSvcID, _         = flux.ParseResourceID("default:deployment/helloworld")
+	hwSvcSpec, _       = update.ParseResourceSpec(hwSvcID.String())
+	hwSvc              = cluster.Controller{
 		ID: hwSvcID,
 		Containers: cluster.ContainersOrExcuse{
 			Containers: []cluster.Container{
@@ -44,7 +44,7 @@ var (
 
 	oldLockedImg     = "quay.io/weaveworks/locked-service:1"
 	newLockedImg     = "quay.io/weaveworks/locked-service:2"
-	newLockedID, _   = flux.ParseImageID(newLockedImg)
+	newLockedID, _   = flux.ParseImageRef(newLockedImg)
 	lockedSvcID, _   = flux.ParseResourceID("default:deployment/locked-service")
 	lockedSvcSpec, _ = update.ParseResourceSpec(lockedSvcID.String())
 	lockedSvc        = cluster.Controller{
@@ -77,11 +77,11 @@ var (
 		lockedSvc,
 		testSvc,
 	}
-	newImageID, _ = flux.ParseImageID("quay.io/weaveworks/helloworld:master-a000002")
-	timeNow       = time.Now()
-	mockRegistry  = registry.NewMockRegistry([]flux.Image{
+	newImageRef, _ = flux.ParseImageRef("quay.io/weaveworks/helloworld:master-a000002")
+	timeNow        = time.Now()
+	mockRegistry   = registry.NewMockRegistry([]flux.Image{
 		flux.Image{
-			ID:        newImageID,
+			ID:        newImageRef,
 			CreatedAt: timeNow,
 		},
 		flux.Image{
@@ -131,8 +131,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageID,
-							Target:    newImageID,
+							Current:   oldImageRef,
+							Target:    newImageRef,
 						},
 					},
 				},
@@ -159,8 +159,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageID,
-							Target:    newImageID,
+							Current:   oldImageRef,
+							Target:    newImageRef,
 						},
 					},
 				},
@@ -177,7 +177,7 @@ func Test_FilterLogic(t *testing.T) {
 			Name: "not image",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
-				ImageSpec:    update.ImageSpecFromID(newImageID),
+				ImageSpec:    update.ImageSpecFromRef(newImageRef),
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
@@ -187,8 +187,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageID,
-							Target:    newImageID,
+							Current:   oldImageRef,
+							Target:    newImageRef,
 						},
 					},
 				},
@@ -218,8 +218,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageID,
-							Target:    newImageID,
+							Current:   oldImageRef,
+							Target:    newImageRef,
 						},
 					},
 				},
@@ -247,8 +247,8 @@ func Test_FilterLogic(t *testing.T) {
 					PerContainer: []update.ContainerUpdate{
 						update.ContainerUpdate{
 							Container: container,
-							Current:   oldImageID,
-							Target:    newImageID,
+							Current:   oldImageRef,
+							Target:    newImageRef,
 						},
 					},
 				},
@@ -317,11 +317,11 @@ func Test_ImageStatus(t *testing.T) {
 
 	upToDateRegistry := registry.NewMockRegistry([]flux.Image{
 		flux.Image{
-			ID:        oldImageID,
+			ID:        oldImageRef,
 			CreatedAt: timeNow,
 		},
 		flux.Image{
-			ID:        sidecarImageID,
+			ID:        sidecarImageRef,
 			CreatedAt: timeNow,
 		},
 	}, nil)

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/guid"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/update"
 )
@@ -106,7 +107,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 
 	now := time.Now().UTC()
 
-	imageID, _ := flux.ParseImageRef("quay.io/example.com/frob:v0.4.5")
+	imageID, _ := image.ParseRef("quay.io/example.com/frob:v0.4.5")
 	serviceAnswer := []flux.ControllerStatus{
 		flux.ControllerStatus{
 			ID:     flux.MustParseResourceID("foobar/hello"),
@@ -114,7 +115,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 			Containers: []flux.Container{
 				flux.Container{
 					Name: "frobnicator",
-					Current: flux.Image{
+					Current: image.Info{
 						ID:        imageID,
 						CreatedAt: now,
 					},
@@ -130,7 +131,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 			Containers: []flux.Container{
 				{
 					Name: "flubnicator",
-					Current: flux.Image{
+					Current: image.Info{
 						ID: imageID,
 					},
 				},

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -106,7 +106,7 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 
 	now := time.Now().UTC()
 
-	imageID, _ := flux.ParseImageID("quay.io/example.com/frob:v0.4.5")
+	imageID, _ := flux.ParseImageRef("quay.io/example.com/frob:v0.4.5")
 	serviceAnswer := []flux.ControllerStatus{
 		flux.ControllerStatus{
 			ID:     flux.MustParseResourceID("foobar/hello"),

--- a/update/automated.go
+++ b/update/automated.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/image"
 )
 
 type Automated struct {
@@ -16,10 +17,10 @@ type Automated struct {
 type Change struct {
 	ServiceID flux.ResourceID
 	Container cluster.Container
-	ImageID   flux.ImageRef
+	ImageID   image.Ref
 }
 
-func (a *Automated) Add(service flux.ResourceID, container cluster.Container, image flux.ImageRef) {
+func (a *Automated) Add(service flux.ResourceID, container cluster.Container, image image.Ref) {
 	a.Changes = append(a.Changes, Change{service, container, image})
 }
 
@@ -60,12 +61,12 @@ func (a *Automated) CommitMessage() string {
 	return fmt.Sprintf("Release %s to automated", strings.Join(images, ", "))
 }
 
-func (a *Automated) Images() []flux.ImageRef {
-	imageMap := map[flux.ImageRef]struct{}{}
+func (a *Automated) Images() []image.Ref {
+	imageMap := map[image.Ref]struct{}{}
 	for _, change := range a.Changes {
 		imageMap[change.ImageID] = struct{}{}
 	}
-	var images []flux.ImageRef
+	var images []image.Ref
 	for image, _ := range imageMap {
 		images = append(images, image)
 	}
@@ -106,7 +107,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 		changes := serviceMap[u.ResourceID]
 		containerUpdates := []ContainerUpdate{}
 		for _, container := range containers {
-			currentImageID, err := flux.ParseImageRef(container.Image)
+			currentImageID, err := image.ParseRef(container.Image)
 			if err != nil {
 				return nil, err
 			}

--- a/update/automated.go
+++ b/update/automated.go
@@ -16,10 +16,10 @@ type Automated struct {
 type Change struct {
 	ServiceID flux.ResourceID
 	Container cluster.Container
-	ImageID   flux.ImageID
+	ImageID   flux.ImageRef
 }
 
-func (a *Automated) Add(service flux.ResourceID, container cluster.Container, image flux.ImageID) {
+func (a *Automated) Add(service flux.ResourceID, container cluster.Container, image flux.ImageRef) {
 	a.Changes = append(a.Changes, Change{service, container, image})
 }
 
@@ -60,12 +60,12 @@ func (a *Automated) CommitMessage() string {
 	return fmt.Sprintf("Release %s to automated", strings.Join(images, ", "))
 }
 
-func (a *Automated) Images() []flux.ImageID {
-	imageMap := map[flux.ImageID]struct{}{}
+func (a *Automated) Images() []flux.ImageRef {
+	imageMap := map[flux.ImageRef]struct{}{}
 	for _, change := range a.Changes {
 		imageMap[change.ImageID] = struct{}{}
 	}
-	var images []flux.ImageID
+	var images []flux.ImageRef
 	for image, _ := range imageMap {
 		images = append(images, image)
 	}
@@ -106,7 +106,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 		changes := serviceMap[u.ResourceID]
 		containerUpdates := []ContainerUpdate{}
 		for _, container := range containers {
-			currentImageID, err := flux.ParseImageID(container.Image)
+			currentImageID, err := flux.ParseImageRef(container.Image)
 			if err != nil {
 				return nil, err
 			}

--- a/update/filter.go
+++ b/update/filter.go
@@ -15,7 +15,7 @@ const (
 )
 
 type SpecificImageFilter struct {
-	Img flux.ImageID
+	Img flux.ImageRef
 }
 
 func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
@@ -28,7 +28,7 @@ func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
 	}
 	// For each container in update
 	for _, c := range u.Controller.Containers.Containers {
-		cID, _ := flux.ParseImageID(c.Image)
+		cID, _ := flux.ParseImageRef(c.Image)
 		// If container image == image in update
 		if cID.CanonicalName() == f.Img.CanonicalName() {
 			// We want to update this

--- a/update/filter.go
+++ b/update/filter.go
@@ -1,6 +1,9 @@
 package update
 
-import "github.com/weaveworks/flux"
+import (
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
+)
 
 const (
 	Locked          = "locked"
@@ -15,7 +18,7 @@ const (
 )
 
 type SpecificImageFilter struct {
-	Img flux.ImageRef
+	Img image.Ref
 }
 
 func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
@@ -28,7 +31,7 @@ func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
 	}
 	// For each container in update
 	for _, c := range u.Controller.Containers.Containers {
-		cID, _ := flux.ParseImageRef(c.Image)
+		cID, _ := image.ParseRef(c.Image)
 		// If container image == image in update
 		if cID.CanonicalName() == f.Img.CanonicalName() {
 			// We want to update this

--- a/update/images.go
+++ b/update/images.go
@@ -14,15 +14,15 @@ import (
 	"github.com/weaveworks/flux/registry"
 )
 
-type ImageMap map[string][]flux.Image
+type ImageMap map[flux.CanonicalName][]flux.Image
 
 // LatestImage returns the latest releasable image for a repository for
 // which the tag matches a given pattern. A releasable image is one that
 // is not tagged "latest". (Assumes the available images are in
 // descending order of latestness.) If no such image exists, returns nil,
 // and the caller can decide whether that's an error or not.
-func (m ImageMap) LatestImage(repo, tagGlob string) *flux.Image {
-	for _, image := range m[repo] {
+func (m ImageMap) LatestImage(repo flux.ImageName, tagGlob string) *flux.Image {
+	for _, image := range m[repo.CanonicalName()] {
 		_, _, tag := image.ID.Components()
 		// Ignore latest if and only if it's not what the user wants.
 		if !strings.EqualFold(tagGlob, "latest") && strings.EqualFold(tag, "latest") {
@@ -52,7 +52,7 @@ func CollectAvailableImages(reg registry.Registry, services []cluster.Controller
 	images := ImageMap{}
 	for _, service := range services {
 		for _, container := range service.ContainersOrNil() {
-			id, err := flux.ParseImageID(container.Image)
+			id, err := flux.ParseImageRef(container.Image)
 			if err != nil {
 				// container is running an invalid image id? what?
 				return nil, err
@@ -60,26 +60,22 @@ func CollectAvailableImages(reg registry.Registry, services []cluster.Controller
 			images[id.CanonicalName()] = nil
 		}
 	}
-	for repo := range images {
-		id, err := flux.ParseImageID(repo)
-		if err != nil {
-			return nil, errors.Wrapf(err, "parsing repository %s", repo)
-		}
-		imageRepo, err := reg.GetRepository(id)
+	for name := range images {
+		imageRepo, err := reg.GetRepository(name.ImageName)
 		if err != nil {
 			// Not an error if missing. Use empty images.
 			if !fluxerr.IsMissing(err) {
-				logger.Log("err", errors.Wrapf(err, "fetching image metadata for %s", repo))
+				logger.Log("err", errors.Wrapf(err, "fetching image metadata for %s", name))
 				continue
 			}
 		}
-		images[repo] = imageRepo
+		images[name] = imageRepo
 	}
 	return images, nil
 }
 
 // Create a map of images. It will check that each image exists.
-func exactImages(reg registry.Registry, images []flux.ImageID) (ImageMap, error) {
+func exactImages(reg registry.Registry, images []flux.ImageRef) (ImageMap, error) {
 	m := ImageMap{}
 	for _, id := range images {
 		// We must check that the exact images requested actually exist. Otherwise we risk pushing invalid images to git.
@@ -97,7 +93,7 @@ func exactImages(reg registry.Registry, images []flux.ImageID) (ImageMap, error)
 
 // Checks whether the given image exists in the repository.
 // Return true if exist, false otherwise
-func imageExists(reg registry.Registry, imageID flux.ImageID) (bool, error) {
+func imageExists(reg registry.Registry, imageID flux.ImageRef) (bool, error) {
 	_, err := reg.GetImage(imageID)
 	if err != nil {
 		return false, nil

--- a/update/print_test.go
+++ b/update/print_test.go
@@ -7,6 +7,14 @@ import (
 	"github.com/weaveworks/flux"
 )
 
+func mustParseImageRef(s string) flux.ImageRef {
+	ref, err := flux.ParseImageRef(s)
+	if err != nil {
+		panic(err)
+	}
+	return ref
+}
+
 func TestPrintResults(t *testing.T) {
 	for _, example := range []struct {
 		name     string
@@ -23,8 +31,8 @@ func TestPrintResults(t *testing.T) {
 					PerContainer: []ContainerUpdate{
 						{
 							Container: "helloworld",
-							Current:   flux.ImageID{"quay.io", "weaveworks/helloworld", "master-a000002"},
-							Target:    flux.ImageID{"quay.io", "weaveworks/helloworld", "master-a000001"},
+							Current:   mustParseImageRef("quay.io/weaveworks/helloworld:master-a000002"),
+							Target:    mustParseImageRef("quay.io/weaveworks/helloworld:master-a000001"),
 						},
 					},
 				},
@@ -44,8 +52,8 @@ default/helloworld  success  helloworld: quay.io/weaveworks/helloworld:master-a0
 					PerContainer: []ContainerUpdate{
 						{
 							Container: "helloworld",
-							Current:   flux.ImageID{"quay.io", "weaveworks/helloworld", "master-a000002"},
-							Target:    flux.ImageID{"quay.io", "weaveworks/helloworld", "master-a000001"},
+							Current:   mustParseImageRef("quay.io/weaveworks/helloworld:master-a000002"),
+							Target:    mustParseImageRef("quay.io/weaveworks/helloworld:master-a000001"),
 						},
 					},
 				},

--- a/update/print_test.go
+++ b/update/print_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 )
 
-func mustParseImageRef(s string) flux.ImageRef {
-	ref, err := flux.ParseImageRef(s)
+func mustParseRef(s string) image.Ref {
+	ref, err := image.ParseRef(s)
 	if err != nil {
 		panic(err)
 	}
@@ -31,8 +32,8 @@ func TestPrintResults(t *testing.T) {
 					PerContainer: []ContainerUpdate{
 						{
 							Container: "helloworld",
-							Current:   mustParseImageRef("quay.io/weaveworks/helloworld:master-a000002"),
-							Target:    mustParseImageRef("quay.io/weaveworks/helloworld:master-a000001"),
+							Current:   mustParseRef("quay.io/weaveworks/helloworld:master-a000002"),
+							Target:    mustParseRef("quay.io/weaveworks/helloworld:master-a000001"),
 						},
 					},
 				},
@@ -52,8 +53,8 @@ default/helloworld  success  helloworld: quay.io/weaveworks/helloworld:master-a0
 					PerContainer: []ContainerUpdate{
 						{
 							Container: "helloworld",
-							Current:   mustParseImageRef("quay.io/weaveworks/helloworld:master-a000002"),
-							Target:    mustParseImageRef("quay.io/weaveworks/helloworld:master-a000001"),
+							Current:   mustParseRef("quay.io/weaveworks/helloworld:master-a000002"),
+							Target:    mustParseRef("quay.io/weaveworks/helloworld:master-a000001"),
 						},
 					},
 				},

--- a/update/release.go
+++ b/update/release.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
 )
@@ -124,7 +125,7 @@ func (s ReleaseSpec) filters(rc ReleaseContext) ([]ControllerFilter, error) {
 	// Image filter
 	var filtList []ControllerFilter
 	if s.ImageSpec != ImageSpecLatest {
-		id, err := flux.ParseImageRef(s.ImageSpec.String())
+		id, err := image.ParseRef(s.ImageSpec.String())
 		if err != nil {
 			return nil, err
 		}
@@ -191,18 +192,18 @@ func (s ReleaseSpec) markSkipped(results Result) {
 func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*ControllerUpdate, results Result, logger log.Logger) ([]*ControllerUpdate, error) {
 	// Compile an `ImageMap` of all relevant images
 	var images ImageMap
-	var singleRepo flux.CanonicalName
+	var singleRepo image.CanonicalName
 	var err error
 
 	switch s.ImageSpec {
 	case ImageSpecLatest:
 		images, err = collectUpdateImages(rc.Registry(), candidates, logger)
 	default:
-		var image flux.ImageRef
-		image, err = s.ImageSpec.AsRef()
+		var ref image.Ref
+		ref, err = s.ImageSpec.AsRef()
 		if err == nil {
-			singleRepo = image.CanonicalName()
-			images, err = exactImages(rc.Registry(), []flux.ImageRef{image})
+			singleRepo = ref.CanonicalName()
+			images, err = exactImages(rc.Registry(), []image.Ref{ref})
 		}
 	}
 
@@ -230,14 +231,14 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		var containerUpdates []ContainerUpdate
 
 		for _, container := range containers {
-			currentImageID, err := flux.ParseImageRef(container.Image)
+			currentImageID, err := image.ParseRef(container.Image)
 			if err != nil {
 				// We may hope never to find a malformed image ID, but
 				// anything is possible.
 				return nil, err
 			}
 
-			latestImage := images.LatestImage(currentImageID.Name(), "*")
+			latestImage := images.LatestImage(currentImageID.Name, "*")
 			if latestImage == nil {
 				if currentImageID.CanonicalName() != singleRepo {
 					ignoredOrSkipped = ReleaseStatusIgnored
@@ -327,12 +328,12 @@ func ParseImageSpec(s string) (ImageSpec, error) {
 		return ImageSpecLatest, nil
 	}
 
-	id, err := flux.ParseImageRef(s)
+	id, err := image.ParseRef(s)
 	if err != nil {
 		return "", err
 	}
 	if id.Tag == "" {
-		return "", errors.Wrap(flux.ErrInvalidImageID, "blank tag (if you want latest, explicitly state the tag :latest)")
+		return "", errors.Wrap(image.ErrInvalidImageID, "blank tag (if you want latest, explicitly state the tag :latest)")
 	}
 	return ImageSpec(id.String()), err
 }
@@ -341,10 +342,10 @@ func (s ImageSpec) String() string {
 	return string(s)
 }
 
-func (s ImageSpec) AsRef() (flux.ImageRef, error) {
-	return flux.ParseImageRef(s.String())
+func (s ImageSpec) AsRef() (image.Ref, error) {
+	return image.ParseRef(s.String())
 }
 
-func ImageSpecFromRef(id flux.ImageRef) ImageSpec {
+func ImageSpecFromRef(id image.Ref) ImageSpec {
 	return ImageSpec(id.String())
 }

--- a/update/result.go
+++ b/update/result.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 )
 
 type ControllerUpdateStatus string
@@ -30,7 +31,7 @@ func (r Result) ServiceIDs() []string {
 }
 
 func (r Result) ImageIDs() []string {
-	images := map[flux.ImageRef]struct{}{}
+	images := map[image.Ref]struct{}{}
 	for _, serviceResult := range r {
 		for _, containerResult := range serviceResult.PerContainer {
 			images[containerResult.Target] = struct{}{}
@@ -76,6 +77,6 @@ func (fr ControllerResult) Msg(id flux.ResourceID) string {
 
 type ContainerUpdate struct {
 	Container string
-	Current   flux.ImageRef
-	Target    flux.ImageRef
+	Current   image.Ref
+	Target    image.Ref
 }

--- a/update/result.go
+++ b/update/result.go
@@ -30,7 +30,7 @@ func (r Result) ServiceIDs() []string {
 }
 
 func (r Result) ImageIDs() []string {
-	images := map[flux.ImageID]struct{}{}
+	images := map[flux.ImageRef]struct{}{}
 	for _, serviceResult := range r {
 		for _, containerResult := range serviceResult.PerContainer {
 			images[containerResult.Target] = struct{}{}
@@ -76,6 +76,6 @@ func (fr ControllerResult) Msg(id flux.ResourceID) string {
 
 type ContainerUpdate struct {
 	Container string
-	Current   flux.ImageID
-	Target    flux.ImageID
+	Current   flux.ImageRef
+	Target    flux.ImageRef
 }


### PR DESCRIPTION
An image name (e.g., "alpine") is used for different things than an
image ref (e.g., "alpine:3.5"). So, be clear about which we're using.

For some purposes we want to use the canonical form of an image name
or ref; so, make those distinct types as well.

 - [x] Rearrange the types
 - [x] Move into their own package and rename (drop `Image` from the start, basically)
