### PR TITLE
Increase max token size in multidoc yaml parser

### DIFF
--- a/cluster/kubernetes/resource/load.go
+++ b/cluster/kubernetes/resource/load.go
@@ -52,6 +52,8 @@ func Load(roots ...string) (map[string]resource.Resource, error) {
 func ParseMultidoc(multidoc []byte, source string) (map[string]resource.Resource, error) {
 	objs := map[string]resource.Resource{}
 	chunks := bufio.NewScanner(bytes.NewReader(multidoc))
+	initialBuffer := make([]byte, 4096)     // Matches startBufSize in bufio/scan.go
+	chunks.Buffer(initialBuffer, 1024*1024) // Allow growth to 1MB
 	chunks.Split(splitYAMLDocument)
 
 	var obj resource.Resource

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
@@ -93,6 +94,26 @@ metadata:
 		if !reflect.DeepEqual(obj, debyte(objs[id])) {
 			t.Errorf("At %+v expected:\n%#v\ngot:\n%#v", id, obj, objs[id])
 		}
+	}
+}
+
+func TestParseSomeLong(t *testing.T) {
+	doc := `---
+kind: ConfigMap
+metadata:
+  name: bigmap
+data:
+  bigdata: |
+`
+	buffer := bytes.NewBufferString(doc)
+	line := "    The quick brown fox jumps over the lazy dog.\n"
+	for buffer.Len()+len(line) < 1024*1024 {
+		buffer.WriteString(line)
+	}
+
+	_, err := ParseMultidoc(buffer.Bytes(), "test")
+	if err != nil {
+		t.Error(err)
 	}
 }
 


### PR DESCRIPTION
Temporary fix for configmaps > 64k