### PR TITLE
Update gorilla/mux vendorage and adjust

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -172,7 +172,8 @@
 [[projects]]
   name = "github.com/gorilla/mux"
   packages = ["."]
-  revision = "780415097119f6f61c55475fe59b66f3c3e9ea53"
+  revision = "7f08801859139f86dfafd1c296e2cba9a80d292e"
+  version = "v1.6.0"
 
 [[projects]]
   name = "github.com/gorilla/websocket"

--- a/http/transport.go
+++ b/http/transport.go
@@ -67,7 +67,7 @@ func MakeURL(endpoint string, router *mux.Router, routeName string, urlParams ..
 		return nil, errors.Wrapf(err, "parsing endpoint %s", endpoint)
 	}
 
-	routeURL, err := router.Get(routeName).URL()
+	routeURL, err := router.Get(routeName).URLPath()
 	if err != nil {
 		return nil, errors.Wrapf(err, "retrieving route path %s", routeName)
 	}


### PR DESCRIPTION
To bring things in line with weaveworks/service, where these packages
are themselves vendored, update gorilla mux.

There is one hiccough: `MakeURL` no longer works as it is, since
Route.URL() now complains if it doesn't get all the parameters given
in the route, including query parameters. To work around this for the
time being, use Route.URLPath() instead, relying on the coincidence
that our routes don't contain parameters in the path.

Fixes #828, though not as described there. The problem is that `transport.MakeURL(...)` accepts both mandatory and optional query parameters alike, with no way to distinguish which to give to `Route.URL(...)`.