### PR TITLE
Rewrite some FAQ answers and mention Flux Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Get started by browsing through the documentation below.
 
 [Introduction to Flux](/site/introduction.md)
 
+[FAQ](/site/faq.md)
+
 [How it works](/site/how-it-works.md)
 
 [Installing Flux](/site/installing.md)
@@ -27,8 +29,6 @@ Get started by browsing through the documentation below.
 [Using Flux](/site/using.md)
 
 [Upgrading to Flux v1](/site/upgrading-to-1.0.md)
-
-[FAQ](/site/faq.md)
 
 [Troubleshooting](/site/troubleshooting.md)
 


### PR DESCRIPTION
Someone asked on twitter what happened to what we call Flux Classic (a
prototype we did of staged deployments with charts and so on). This
provides an answer in the FAQ.

I also tidied up some of the other answers.
