### PR TITLE
Image metadata lookup and automation for push hooks

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -419,6 +419,7 @@ func main() {
 	shutdownWg.Add(1)
 	go daemon.GitPollLoop(shutdown, shutdownWg, log.With(logger, "component", "sync-loop"))
 
+	cacheWarmer.Notify = daemon.AskForImagePoll
 	shutdownWg.Add(1)
 	go cacheWarmer.Loop(shutdown, shutdownWg, image_creds)
 

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -264,11 +264,11 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) DaemonJo
 			// On the chance pushing failed because it was not
 			// possible to fast-forward, ask for a sync so the
 			// next attempt is more likely to succeed.
-			d.askForSync()
+			d.AskForSync()
 			return nil, err
 		}
 		if anythingAutomated {
-			d.askForImagePoll()
+			d.AskForImagePoll()
 		}
 
 		var err error
@@ -303,7 +303,7 @@ func (d *Daemon) release(spec update.Spec, c release.Changes) DaemonJobFunc {
 				// On the chance pushing failed because it was not
 				// possible to fast-forward, ask for a sync so the
 				// next attempt is more likely to succeed.
-				d.askForSync()
+				d.AskForSync()
 				return nil, err
 			}
 			revision, err = working.HeadRevision(ctx)
@@ -324,7 +324,7 @@ func (d *Daemon) release(spec update.Spec, c release.Changes) DaemonJobFunc {
 // may be comms difficulties or other sources of problems; here, we
 // always succeed because it's just bookkeeping.
 func (d *Daemon) SyncNotify(ctx context.Context) error {
-	d.askForSync()
+	d.AskForSync()
 	return nil
 }
 

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -66,8 +66,8 @@ func (d *Daemon) GitPollLoop(stop chan struct{}, wg *sync.WaitGroup, logger log.
 	imagePollTimer := time.NewTimer(d.RegistryPollInterval)
 
 	// Ask for a sync, and to poll images, straight away
-	d.askForSync()
-	d.askForImagePoll()
+	d.AskForSync()
+	d.AskForImagePoll()
 	for {
 		select {
 		case <-stop:
@@ -78,13 +78,13 @@ func (d *Daemon) GitPollLoop(stop chan struct{}, wg *sync.WaitGroup, logger log.
 			imagePollTimer.Stop()
 			imagePollTimer = time.NewTimer(d.RegistryPollInterval)
 		case <-imagePollTimer.C:
-			d.askForImagePoll()
+			d.AskForImagePoll()
 		case <-d.syncSoon:
 			pullThen(d.doSync)
 		case <-gitPollTimer.C:
 			// Time to poll for new commits (unless we're already
 			// about to do that)
-			d.askForSync()
+			d.AskForSync()
 		case job := <-d.Jobs.Ready():
 			queueLength.Set(float64(d.Jobs.Len()))
 			jobLogger := log.With(logger, "jobID", job.ID)
@@ -108,7 +108,7 @@ func (d *Daemon) GitPollLoop(stop chan struct{}, wg *sync.WaitGroup, logger log.
 }
 
 // Ask for a sync, or if there's one waiting, let that happen.
-func (d *LoopVars) askForSync() {
+func (d *LoopVars) AskForSync() {
 	d.ensureInit()
 	select {
 	case d.syncSoon <- struct{}{}:
@@ -117,7 +117,7 @@ func (d *LoopVars) askForSync() {
 }
 
 // Ask for an image poll, or if there's one waiting, let that happen.
-func (d *LoopVars) askForImagePoll() {
+func (d *LoopVars) AskForImagePoll() {
 	d.ensureInit()
 	select {
 	case d.pollImagesSoon <- struct{}{}:


### PR DESCRIPTION
1. To process image push hooks, we need to be able to pre-empt the cache
warming loop.

This commit introduces a priority channel, as a field of the warmer,
and changes the loop such that it looks up image data from the
priority channel in preference to refreshing image data from the
cluster.

It is possible to be notified about an image for which the loop does
not have credentials. This means the priority lookup will be skipped,
and is otherwise harmless. The credentials are only requested at the
start, and when the regular refresh is run. A refinement which
improves on this would be to plumb through a means of getting a
specific image's credentials from the cluster.

2. Add a "new image notification" to the warmer, and plumb it through to the daemon so that it prompts the daemon to do an automation run.

This is done as a callback, and the daemon method (newly exported) `AskForImagePoll` supplied. This is the simplest way, given that we want to keep the image polling (and other things) running on a ticker as well.

The code that attempts to figure out if there's a new image comes with a couple of caveats:
 * it only checks tags as strings, so it won't notice if a tag has moved (but in general, we don't really deal with that anyway)
 * if there's no prior record of the image (no tags value in memcached), it'll fire the new image notification; if memcached has restarted, that means it'll be called for each image. This doesn't necessarily result in as many automation runs, though, since the `AskForImagePoll` will discard duplicate requests.
