### PR TITLE
Add NotifyChange method to remote.Platform

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
+	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/update"
 )
@@ -152,8 +153,8 @@ func TestDaemon_ListImages(t *testing.T) {
 	}
 }
 
-// When I call sync notify, it should cause a sync
-func TestDaemon_SyncNotify(t *testing.T) {
+// When I call notify, it should cause a sync
+func TestDaemon_NotifyChange(t *testing.T) {
 	d, clean, mockK8s, events := mockDaemon(t)
 	defer clean()
 	w := newWait(t)
@@ -171,7 +172,7 @@ func TestDaemon_SyncNotify(t *testing.T) {
 		return nil
 	}
 
-	d.SyncNotify(ctx)
+	d.NotifyChange(ctx, remote.Change{Kind: remote.GitChange, Source: remote.GitUpdate{}})
 	w.Eventually(func() bool {
 		syncMu.Lock()
 		defer syncMu.Unlock()

--- a/daemon/notready.go
+++ b/daemon/notready.go
@@ -7,6 +7,7 @@ import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/job"
+	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -68,7 +69,7 @@ func (nrd *NotReadyDaemon) UpdateManifests(context.Context, update.Spec) (job.ID
 	return id, nrd.Reason()
 }
 
-func (nrd *NotReadyDaemon) SyncNotify(context.Context) error {
+func (nrd *NotReadyDaemon) NotifyChange(context.Context, remote.Change) error {
 	return nrd.Reason()
 }
 

--- a/daemon/ref.go
+++ b/daemon/ref.go
@@ -58,8 +58,8 @@ func (pr *Ref) UpdateManifests(ctx context.Context, spec update.Spec) (job.ID, e
 	return pr.Platform().UpdateManifests(ctx, spec)
 }
 
-func (pr *Ref) SyncNotify(ctx context.Context) error {
-	return pr.Platform().SyncNotify(ctx)
+func (pr *Ref) NotifyChange(ctx context.Context, change remote.Change) error {
+	return pr.Platform().NotifyChange(ctx, change)
 }
 
 func (pr *Ref) JobStatus(ctx context.Context, id job.ID) (job.Status, error) {

--- a/http/transport.go
+++ b/http/transport.go
@@ -34,7 +34,6 @@ func NewAPIRouter() *mux.Router {
 
 	r.NewRoute().Name("UpdateImages").Methods("POST").Path("/v6/update-images").Queries("service", "{service}", "image", "{image}", "kind", "{kind}")
 	r.NewRoute().Name("UpdatePolicies").Methods("PATCH").Path("/v6/policies")
-	r.NewRoute().Name("SyncNotify").Methods("POST").Path("/v6/sync")
 	r.NewRoute().Name("JobStatus").Methods("GET").Path("/v6/jobs").Queries("id", "{id}")
 	r.NewRoute().Name("SyncStatus").Methods("GET").Path("/v6/sync").Queries("ref", "{ref}")
 	r.NewRoute().Name("Export").Methods("HEAD", "GET").Path("/v6/export")

--- a/remote/logging.go
+++ b/remote/logging.go
@@ -61,13 +61,13 @@ func (p *ErrorLoggingPlatform) ListImages(ctx context.Context, spec update.Resou
 	return p.Platform.ListImages(ctx, spec)
 }
 
-func (p *ErrorLoggingPlatform) SyncNotify(ctx context.Context) (err error) {
+func (p *ErrorLoggingPlatform) NotifyChange(ctx context.Context, change Change) (err error) {
 	defer func() {
 		if err != nil {
-			p.Logger.Log("method", "SyncNotify", "error", err)
+			p.Logger.Log("method", "NotifyChange", "error", err)
 		}
 	}()
-	return p.Platform.SyncNotify(ctx)
+	return p.Platform.NotifyChange(ctx, change)
 }
 
 func (p *ErrorLoggingPlatform) JobStatus(ctx context.Context, jobID job.ID) (_ job.Status, err error) {

--- a/remote/metrics.go
+++ b/remote/metrics.go
@@ -92,14 +92,14 @@ func (i *instrumentedPlatform) UpdateManifests(ctx context.Context, spec update.
 	return i.p.UpdateManifests(ctx, spec)
 }
 
-func (i *instrumentedPlatform) SyncNotify(ctx context.Context) (err error) {
+func (i *instrumentedPlatform) NotifyChange(ctx context.Context, change Change) (err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
-			fluxmetrics.LabelMethod, "SyncNotify",
+			fluxmetrics.LabelMethod, "NotifyChange",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.p.SyncNotify(ctx)
+	return i.p.NotifyChange(ctx, change)
 }
 
 func (i *instrumentedPlatform) JobStatus(ctx context.Context, id job.ID) (_ job.Status, err error) {

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -34,7 +34,7 @@ type MockPlatform struct {
 	UpdateManifestsAnswer  job.ID
 	UpdateManifestsError   error
 
-	SyncNotifyError error
+	NotifyChangeError error
 
 	SyncStatusAnswer []string
 	SyncStatusError  error
@@ -75,8 +75,8 @@ func (p *MockPlatform) UpdateManifests(ctx context.Context, s update.Spec) (job.
 	return p.UpdateManifestsAnswer, p.UpdateManifestsError
 }
 
-func (p *MockPlatform) SyncNotify(ctx context.Context) error {
-	return p.SyncNotifyError
+func (p *MockPlatform) NotifyChange(ctx context.Context, change Change) error {
+	return p.NotifyChangeError
 }
 
 func (p *MockPlatform) SyncStatus(context.Context, string) ([]string, error) {
@@ -215,7 +215,8 @@ func PlatformTestBattery(t *testing.T, wrap func(mock Platform) Platform) {
 		t.Error("expected error from UpdateManifests, got nil")
 	}
 
-	if err := client.SyncNotify(ctx); err != nil {
+	change := Change{Kind: GitChange, Source: GitUpdate{URL: "git@example.com:foo/bar"}}
+	if err := client.NotifyChange(ctx, change); err != nil {
 		t.Error(err)
 	}
 

--- a/remote/notify.go
+++ b/remote/notify.go
@@ -1,0 +1,61 @@
+package remote
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/weaveworks/flux/image"
+)
+
+type ChangeKind string
+
+const (
+	GitChange   ChangeKind = "git"
+	ImageChange ChangeKind = "image"
+)
+
+func (k ChangeKind) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(k))
+}
+
+var ErrUnknownChange = errors.New("unknown kind of change")
+
+type Change struct {
+	Kind   ChangeKind  // essentially a type tag
+	Source interface{} // what changed
+}
+
+func (c *Change) UnmarshalJSON(bs []byte) error {
+	type raw struct {
+		Kind   ChangeKind
+		Source json.RawMessage
+	}
+	var r raw
+	var err error
+	if err = json.Unmarshal(bs, &r); err != nil {
+		return err
+	}
+	c.Kind = r.Kind
+
+	switch r.Kind {
+	case GitChange:
+		var git GitUpdate
+		err = json.Unmarshal(r.Source, &git)
+		c.Source = git
+	case ImageChange:
+		var image ImageUpdate
+		err = json.Unmarshal(r.Source, &image)
+		c.Source = image
+	default:
+		return ErrUnknownChange
+	}
+	return err
+}
+
+type ImageUpdate struct {
+	Name image.Name
+}
+
+type GitUpdate struct {
+	URL string
+}

--- a/remote/notify_test.go
+++ b/remote/notify_test.go
@@ -1,0 +1,31 @@
+package remote
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/weaveworks/flux/image"
+)
+
+func TestChangeEncoding(t *testing.T) {
+	ref, _ := image.ParseRef("quay.io/weaveworks/flux")
+	name := ref.Name
+
+	for _, update := range []Change{
+		{Kind: GitChange, Source: GitUpdate{URL: "git@github.com:weaveworks/flux"}},
+		{Kind: ImageChange, Source: ImageUpdate{Name: name}},
+	} {
+		bytes, err := json.Marshal(update)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var update2 Change
+		if err = json.Unmarshal(bytes, &update2); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(update, update2) {
+			t.Errorf("unmarshaled != original.\nExpected: %#v\nGot: %#v", update, update2)
+		}
+	}
+}

--- a/remote/platform.go
+++ b/remote/platform.go
@@ -30,19 +30,22 @@ type PlatformV5 interface {
 	//	Sync(SyncDef) error
 }
 
+type PlatformV6Deprecated interface {
+	// Poke the daemon to sync with git
+	SyncNotify(context.Context) error
+}
+
 // In which we move functionality that refers to the Git repo or image
 // registry into the platform. Methods that we no longer use are
 // deprecated, so this does not include the previous definitions,
 // though it does include some their methods.
-type PlatformV6 interface {
+type PlatformV6NotDeprecated interface {
 	PlatformV5
 	// These are new, or newly moved to this interface
 	ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error)
 	ListImages(context.Context, update.ResourceSpec) ([]flux.ImageStatus, error)
 	// Send a spec for updating config to the daemon
 	UpdateManifests(context.Context, update.Spec) (job.ID, error)
-	// Poke the daemon to sync with git
-	SyncNotify(context.Context) error
 	// Ask the daemon where it's up to with syncing
 	SyncStatus(ctx context.Context, ref string) ([]string, error)
 	// Ask the daemon where it's up to with job processing
@@ -51,10 +54,31 @@ type PlatformV6 interface {
 	GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error)
 }
 
+type PlatformV6 interface {
+	PlatformV6Deprecated
+	PlatformV6NotDeprecated
+}
+
+// PlatformV7 was a change to argument types, rather than methods
+// PlatformV8 was a change to argument domains (ServiceSpec was
+// broadened to ResourceSpec, to refer to controllers in general)
+
+// PlatformV9 effectively replaces the SyncNotify with the more
+// generic ChangeNotify, so we can use it to inform the daemon of new
+// images (or rather, a change to an image repo that is _probably_ a
+// new image being pushed)
+type PlatformV9 interface {
+	PlatformV6NotDeprecated
+	// ChangeNotify tells the daemon that we've noticed a change in
+	// e.g., the git repo, or image registry, and now would be a good
+	// time to update its state.
+	NotifyChange(context.Context, Change) error
+}
+
 // Platform is the SPI for the daemon; i.e., it's all the things we
 // have to ask to the daemon, rather than the service.
 type Platform interface {
-	PlatformV6
+	PlatformV9
 }
 
 // Wrap errors in this to indicate that the platform should be

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -40,8 +40,8 @@ func (bc baseClient) UpdateManifests(context.Context, update.Spec) (job.ID, erro
 	return id, remote.UpgradeNeededError(errors.New("UpdateManifests method not implemented"))
 }
 
-func (bc baseClient) SyncNotify(context.Context) error {
-	return remote.UpgradeNeededError(errors.New("SyncNotify method not implemented"))
+func (bc baseClient) NotifyChange(context.Context, remote.Change) error {
+	return remote.UpgradeNeededError(errors.New("NotifyChange method not implemented"))
 }
 
 func (bc baseClient) JobStatus(context.Context, job.ID) (job.Status, error) {

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -6,6 +6,7 @@ import (
 	"net/rpc"
 
 	"github.com/weaveworks/flux"
+	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/update"
@@ -87,6 +88,10 @@ func (p *RPCClientV7) UpdateManifests(ctx context.Context, u update.Spec) (job.I
 		err = resp.ApplicationError
 	}
 	return resp.Result, err
+}
+
+type SyncNotifyResponse struct {
+	ApplicationError *fluxerr.Error
 }
 
 func (p *RPCClientV7) SyncNotify(ctx context.Context) error {

--- a/remote/rpc/clientV9.go
+++ b/remote/rpc/clientV9.go
@@ -1,0 +1,30 @@
+package rpc
+
+import (
+	"context"
+	"io"
+	"net/rpc"
+
+	"github.com/weaveworks/flux/remote"
+)
+
+type RPCClientV9 struct {
+	*RPCClientV8
+}
+
+func NewClientV9(conn io.ReadWriteCloser) *RPCClientV9 {
+	return &RPCClientV9{NewClientV8(conn)}
+}
+
+func (p *RPCClientV9) NotifyChange(ctx context.Context, c remote.Change) error {
+	var resp NotifyChangeResponse
+	err := p.client.Call("RPCServer.NotifyChange", c, &resp)
+	if err != nil {
+		if _, ok := err.(rpc.ServerError); !ok && err != nil {
+			err = remote.FatalError{err}
+		}
+	} else if resp.ApplicationError != nil {
+		err = resp.ApplicationError
+	}
+	return err
+}

--- a/remote/rpc/doc.go
+++ b/remote/rpc/doc.go
@@ -18,9 +18,9 @@ transmission).
 To send application errors, we construct response values that are
 effectively a union of the actual response type, and the error type.
 
-At the client end, we also need to transmission errors -- e.g., a
-response timing out, or the connection closing abruptly. These are
-treated as "Fatal" errors; that is, they should result in a
+At the client end, we also need to deal with transmission errors --
+e.g., a response timing out, or the connection closing abruptly. These
+are treated as "Fatal" errors; that is, they should result in a
 disconnection of the daemon as well as being returned to the caller.
 
 On versions:

--- a/remote/rpc/rpc_test.go
+++ b/remote/rpc/rpc_test.go
@@ -30,7 +30,7 @@ func TestRPC(t *testing.T) {
 			t.Fatal(err)
 		}
 		go server.ServeConn(serverConn)
-		return NewClientV7(clientConn)
+		return NewClientV9(clientConn)
 	}
 	remote.PlatformTestBattery(t, wrap)
 }
@@ -66,7 +66,7 @@ func TestBadRPC(t *testing.T) {
 	}
 	go server.ServeConn(serverConn)
 
-	client := NewClientV6(clientConn)
+	client := NewClientV9(clientConn)
 	if err = client.Ping(ctx); err == nil {
 		t.Error("expected error from RPC system, got nil")
 	}

--- a/remote/rpc/server.go
+++ b/remote/rpc/server.go
@@ -117,12 +117,12 @@ func (p *RPCServer) UpdateManifests(spec update.Spec, resp *UpdateManifestsRespo
 	return err
 }
 
-type SyncNotifyResponse struct {
+type NotifyChangeResponse struct {
 	ApplicationError *fluxerr.Error
 }
 
-func (p *RPCServer) SyncNotify(_ struct{}, resp *SyncNotifyResponse) error {
-	err := p.p.SyncNotify(context.Background())
+func (p *RPCServer) NotifyChange(c remote.Change, resp *NotifyChangeResponse) error {
+	err := p.p.NotifyChange(context.Background(), c)
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {
 			resp.ApplicationError = err


### PR DESCRIPTION
This method is to support being told when webhooks are tweaked.
As usual adding a method to Platform involves a lot of upheaval!

Two extra routes are added to the daemon API to act as hooks, one for
each of the kinds of update.