### PR TITLE
Register daemon with RegisterDaemonV9 endpoint

### DIFF
--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -53,7 +53,7 @@ func NewUpstream(client *http.Client, ua string, t flux.Token, router *mux.Route
 		return nil, errors.Wrap(err, "inferring WS/HTTP endpoints")
 	}
 
-	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemonV8")
+	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemonV9")
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
 	}


### PR DESCRIPTION
Follow on from #845, in order for flux-api to be able to call NotifyChange on a daemon.