### PR TITLE
Register daemon with V9 endpoint

### DIFF
--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -53,7 +53,7 @@ func NewUpstream(client *http.Client, ua string, t flux.Token, router *mux.Route
 		return nil, errors.Wrap(err, "inferring WS/HTTP endpoints")
 	}
 
-	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemonV8")
+	u, err := transport.MakeURL(wsEndpoint, router, "RegisterDaemonV9")
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
 	}


### PR DESCRIPTION
This ensures fluxd registers itself as a daemon capable of receiving image push notifications from flux-api.

[service/#1524](https://github.com/weaveworks/service/pull/1524) should be merged before this, otherwise flux will fail to connect in dev.