### PR TITLE
Supply a reason for "available images" being blank

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -90,7 +91,11 @@ func (opts *controllerShowOpts) RunE(cmd *cobra.Command, args []string) error {
 				reg += "/"
 			}
 			if len(container.Available) == 0 {
-				fmt.Fprintf(out, "%s\t%s\t%s%s\twaiting for cache\n", controllerName, containerName, reg, repo)
+				availableErr := container.AvailableError
+				if availableErr == "" {
+					availableErr = registry.ErrNoImageData.Error()
+				}
+				fmt.Fprintf(out, "%s\t%s\t%s%s\t%s\n", controllerName, containerName, reg, repo, availableErr)
 			} else {
 				fmt.Fprintf(out, "%s\t%s\t%s%s\t\n", controllerName, containerName, reg, repo)
 			}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -482,12 +482,17 @@ func containersWithAvailable(service cluster.Controller, images update.ImageMap)
 	for _, c := range service.ContainersOrNil() {
 		im, _ := image.ParseRef(c.Image)
 		available := images.Available(im.Name)
+		availableErr := ""
+		if available == nil {
+			availableErr = registry.ErrNoImageData.Error()
+		}
 		res = append(res, flux.Container{
 			Name: c.Name,
 			Current: image.Info{
 				ID: im,
 			},
-			Available: available,
+			Available:      available,
+			AvailableError: availableErr,
 		})
 	}
 	return res

--- a/flux.go
+++ b/flux.go
@@ -263,9 +263,10 @@ type ControllerStatus struct {
 }
 
 type Container struct {
-	Name      string
-	Current   image.Info
-	Available []image.Info
+	Name           string
+	Current        image.Info
+	Available      []image.Info
+	AvailableError string `json:",omitempty"`
 }
 
 // --- config types

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,13 +1,13 @@
 package registry
 
 import (
-	"time"
+	"errors"
 
 	"github.com/weaveworks/flux/image"
 )
 
-const (
-	requestTimeout = 10 * time.Second
+var (
+	ErrNoImageData = errors.New("image data not available")
 )
 
 // Registry is a store of image metadata.


### PR DESCRIPTION
When flux has not managed to fetch the image metadata, it will supply
a null in the "available images" field. But usually, we can figure out
why there's no result -- it could be because we didn't have
credentials for the registry, or perhaps because we just haven't tried
to fetch them yet.

This commit effectively adds a field to the API return value to hold
that reason, and gives a placeholder reason in the case that available
images weren't found.

More work is needed to plumb through the _actual_ reasons from the
registry. But it's probably worth waiting for #851 to be merged before
doing that.
