### PR TITLE
Report the status of the git repo when asked

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -34,8 +34,8 @@ const (
 	defaultJobTimeout = 60 * time.Second
 )
 
-// Combine these things to form Devasta^Wan implementation of
-// Platform.
+// Daemon is the fully-functional state of a daemon (compare to
+// `NotReadyDaemon`).
 type Daemon struct {
 	V              string
 	Cluster        cluster.Cluster
@@ -421,6 +421,7 @@ func (d *Daemon) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitCo
 	return flux.GitConfig{
 		Remote:       d.Repo.GitRemoteConfig,
 		PublicSSHKey: publicSSHKey,
+		Status:       flux.RepoReady,
 	}, nil
 }
 

--- a/daemon/ref.go
+++ b/daemon/ref.go
@@ -10,6 +10,10 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
+// Ref is a cell containing a platform implementation, that we can
+// update atomically. The point of this is to be able to have a
+// platform in use (e.g., answering RPCs), and swap it later when the
+// state changes.
 type Ref struct {
 	sync.RWMutex
 	platform remote.Platform

--- a/flux.go
+++ b/flux.go
@@ -287,7 +287,20 @@ type GitRemoteConfig struct {
 	Path   string `json:"path"`
 }
 
+// GitRepoStatus represents the progress made synchronising with a git
+// repo. These are given below in expected order, but the status may
+// go backwards if e.g., a deploy key is deleted.
+type GitRepoStatus string
+
+const (
+	RepoNoConfig GitRepoStatus = "unconfigured" // configuration is empty
+	RepoNew                    = "new"          // no attempt made to clone it yet
+	RepoCloned                 = "cloned"       // has been read (cloned); no attempt made to write
+	RepoReady                  = "ready"        // has been written to, so ready to sync
+)
+
 type GitConfig struct {
 	Remote       GitRemoteConfig `json:"remote"`
 	PublicSSHKey ssh.PublicKey   `json:"publicSSHKey"`
+	Status       GitRepoStatus   `json:"status"`
 }


### PR DESCRIPTION
It's helpful to be able to tell where the git clone got up to, since
there's a bunch of ways it can fail. This commit adds a git status
field in the return value of `GitRepoConfig`.

There's a couple of other tidies:

 - If there's no git URL given, cloning can never succeed, so just go
   and wait quietly to be shut down.

 - The loop attempting to clone the repo was not interruptable, so
   typically, rolling out a daemon with updated config would have to
   wait for Kubernetes to run out of patience (30s) and kill the old
   pod. Instead, check if we've had a shutdown signal, after each
   attempt.