### PR TITLE
Separate filtering into pre- and post- phases

### DIFF
--- a/update/automated.go
+++ b/update/automated.go
@@ -25,13 +25,12 @@ func (a *Automated) Add(service flux.ResourceID, container cluster.Container, im
 }
 
 func (a *Automated) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*ControllerUpdate, Result, error) {
-	filters, err := a.filters(rc)
-	if err != nil {
-		return nil, nil, err
+	prefilters := []ControllerFilter{
+		&IncludeFilter{a.serviceIDs()},
 	}
 
 	result := Result{}
-	updates, err := rc.SelectServices(result, filters...)
+	updates, err := rc.SelectServices(result, prefilters, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -71,12 +70,6 @@ func (a *Automated) Images() []image.Ref {
 		images = append(images, image)
 	}
 	return images
-}
-
-func (a *Automated) filters(rc ReleaseContext) ([]ControllerFilter, error) {
-	return []ControllerFilter{
-		&IncludeFilter{a.serviceIDs()},
-	}, nil
 }
 
 func (a *Automated) markSkipped(results Result) {


### PR DESCRIPTION
When selecting controllers to be updated, we find all those defined in
the repo, then ask the cluster for each one of those, before
subjecting any of them to filtering.

In the case of updating a single controller, this means we do a lot of
calculation that will be redundant, since we don't care about anything
but that controller. It also means any problem with some other
controller in the cluster will prevent that controller being updated.

Instead, use a prefilter to select only the controllers we're going to
ask the cluster about, *then* apply filters on the information we got
from the cluster*.

An exeption is the treatment of Locked resources -- we have this
information from the repo, but look at it _after_ everything
else. I've kept this, somewhat artificially, to be consistent for now.

*Technically we shouldn't be asking the cluster anything, just
updating the controllers defined in the repo. But one thing at a time.