### PR TITLE
Don't use canonicalised image refs when updating

### DIFF
--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -63,14 +63,14 @@ spec:
         name: helloworld
     spec:
       containers:
-      - name: goodbyeworld
+      - name: greeter
         image: quay.io/weaveworks/helloworld:master-a000001
         args:
         - -msg=Ahoy
         ports:
         - containerPort: 80
       - name: sidecar
-        image: quay.io/weaveworks/sidecar:master-a000002
+        image: weaveworks/sidecar:master-a000001
         args:
         - -addr=:8080
         ports:
@@ -134,14 +134,14 @@ spec:
         name: helloworld
     spec:
       containers:
-      - name: goodbyeworld
+      - name: greeter
         image: quay.io/weaveworks/helloworld:master-a000001
         args:
         - -msg=Ahoy2
         ports:
         - containerPort: 80
       - name: sidecar
-        image: quay.io/weaveworks/sidecar:master-a000002
+        image: weaveworks/sidecar:master-a000002
         args:
         - -addr=:8080
         ports:

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -57,8 +57,9 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 			logger.Log("repo", repo, "pattern", pattern)
 
 			if latest := imageMap.LatestImage(repo, pattern); latest != nil && latest.ID != currentImageID {
-				changes.Add(service.ID, container, latest.ID)
-				logger.Log("msg", "added image to changes", "newimage", latest.ID)
+				newImage := currentImageID.WithNewTag(latest.ID.Tag)
+				changes.Add(service.ID, container, newImage)
+				logger.Log("msg", "added image to changes", "newimage", newImage)
 			}
 		}
 	}

--- a/update/automated.go
+++ b/update/automated.go
@@ -117,7 +117,8 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 					continue
 				}
 
-				u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, change.ImageID)
+				newImageID := currentImageID.WithNewTag(change.ImageID.Tag)
+				u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, newImageID)
 				if err != nil {
 					return nil, err
 				}
@@ -125,7 +126,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 				containerUpdates = append(containerUpdates, ContainerUpdate{
 					Container: container.Name,
 					Current:   currentImageID,
-					Target:    change.ImageID,
+					Target:    newImageID,
 				})
 			}
 		}

--- a/update/release.go
+++ b/update/release.go
@@ -253,7 +253,12 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 				continue
 			}
 
-			u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, latestImage.ID)
+			// We want to update the image with respect to the form it
+			// appears in the manifest, whereas what we have is the
+			// canonical form.
+			newImageID := currentImageID.WithNewTag(latestImage.ID.Tag)
+
+			u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, newImageID)
 			if err != nil {
 				return nil, err
 			}
@@ -261,7 +266,7 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 			containerUpdates = append(containerUpdates, ContainerUpdate{
 				Container: container.Name,
 				Current:   currentImageID,
-				Target:    latestImage.ID,
+				Target:    newImageID,
 			})
 		}
 


### PR DESCRIPTION
When we collect image metadata, it's stored with the canonicalised
image name, so that different forms referring to the same repo will
get the same metadata.

However, when updating manifests, we want to adapt to the form that is
in use in the manifest.

Otherwise, the changes (and the notifications) will use canonical names -- which is mostly harmless, but looks odd, especially if the change is just a change in the form of the image ref.