### PR TITLE
Denormalise image refs from registry cache

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -480,13 +480,12 @@ func containers2containers(cs []cluster.Container) []flux.Container {
 
 func containersWithAvailable(service cluster.Controller, images update.ImageMap) (res []flux.Container) {
 	for _, c := range service.ContainersOrNil() {
-		id, _ := image.ParseRef(c.Image)
-		repo := id.CanonicalName()
-		available := images[repo]
+		im, _ := image.ParseRef(c.Image)
+		available := images.Available(im.Name)
 		res = append(res, flux.Container{
 			Name: c.Name,
 			Current: image.Info{
-				ID: id,
+				ID: im,
 			},
 			Available: available,
 		})

--- a/update/images.go
+++ b/update/images.go
@@ -14,7 +14,11 @@ import (
 	"github.com/weaveworks/flux/registry"
 )
 
-type ImageMap map[image.CanonicalName][]image.Info
+type infoMap map[image.CanonicalName][]image.Info
+
+type ImageMap struct {
+	images infoMap
+}
 
 // LatestImage returns the latest releasable image for a repository for
 // which the tag matches a given pattern. A releasable image is one that
@@ -22,20 +26,37 @@ type ImageMap map[image.CanonicalName][]image.Info
 // descending order of latestness.) If no such image exists, returns nil,
 // and the caller can decide whether that's an error or not.
 func (m ImageMap) LatestImage(repo image.Name, tagGlob string) *image.Info {
-	for _, image := range m[repo.CanonicalName()] {
-		_, _, tag := image.ID.Components()
+	for _, available := range m.images[repo.CanonicalName()] {
+		tag := available.ID.Tag
 		// Ignore latest if and only if it's not what the user wants.
 		if !strings.EqualFold(tagGlob, "latest") && strings.EqualFold(tag, "latest") {
 			continue
 		}
 		if glob.Glob(tagGlob, tag) {
-			return &image
+			var im image.Info
+			im = available
+			im.ID = repo.ToRef(tag)
+			return &im
 		}
 	}
 	return nil
 }
 
-// CollectUpdateImages is a convenient shim to
+// Available returns image.Info entries for all the images in the
+// named image repository.
+func (m ImageMap) Available(repo image.Name) []image.Info {
+	if canon, ok := m.images[repo.CanonicalName()]; ok {
+		infos := make([]image.Info, len(canon))
+		for i := range canon {
+			infos[i] = canon[i]
+			infos[i].ID = repo.ToRef(infos[i].ID.Tag)
+		}
+		return infos
+	}
+	return nil
+}
+
+// collectUpdateImages is a convenient shim to
 // `CollectAvailableImages`.
 func collectUpdateImages(registry registry.Registry, updateable []*ControllerUpdate, logger log.Logger) (ImageMap, error) {
 	var servicesToCheck []cluster.Controller
@@ -45,17 +66,16 @@ func collectUpdateImages(registry registry.Registry, updateable []*ControllerUpd
 	return CollectAvailableImages(registry, servicesToCheck, logger)
 }
 
-// Get the images available for the services given. An image may be
-// mentioned more than once in the services, but will only be fetched
-// once.
+// CollectAvailableImages finds all the known image metadata for
+// containers in the controllers given.
 func CollectAvailableImages(reg registry.Registry, services []cluster.Controller, logger log.Logger) (ImageMap, error) {
-	images := ImageMap{}
+	images := infoMap{}
 	for _, service := range services {
 		for _, container := range service.ContainersOrNil() {
 			id, err := image.ParseRef(container.Image)
 			if err != nil {
 				// container is running an invalid image id? what?
-				return nil, err
+				return ImageMap{}, err
 			}
 			images[id.CanonicalName()] = nil
 		}
@@ -71,24 +91,24 @@ func CollectAvailableImages(reg registry.Registry, services []cluster.Controller
 		}
 		images[name] = imageRepo
 	}
-	return images, nil
+	return ImageMap{images}, nil
 }
 
 // Create a map of images. It will check that each image exists.
 func exactImages(reg registry.Registry, images []image.Ref) (ImageMap, error) {
-	m := ImageMap{}
+	m := infoMap{}
 	for _, id := range images {
 		// We must check that the exact images requested actually exist. Otherwise we risk pushing invalid images to git.
 		exist, err := imageExists(reg, id)
 		if err != nil {
-			return m, errors.Wrap(image.ErrInvalidImageID, err.Error())
+			return ImageMap{}, errors.Wrap(image.ErrInvalidImageID, err.Error())
 		}
 		if !exist {
-			return m, errors.Wrap(image.ErrInvalidImageID, fmt.Sprintf("image %q does not exist", id))
+			return ImageMap{}, errors.Wrap(image.ErrInvalidImageID, fmt.Sprintf("image %q does not exist", id))
 		}
 		m[id.CanonicalName()] = []image.Info{{ID: id}}
 	}
-	return m, nil
+	return ImageMap{m}, nil
 }
 
 // Checks whether the given image exists in the repository.


### PR DESCRIPTION
When fetching image metadata, we canonicalise the image name, so that
we can fetch it using any of its possible names (e.g., alpine,
library/alpine, index.docker.io/library/alpine).

When fetching though, we must remember to reconstruct the image refs
as though they used the original form of name.

To guard against getting this wrong again, I've put the
`ImageMap` (map of image name to image metadata, effectively) in a
struct so it can't be indexed directly.