### PR TITLE
Check for a .gcr.io suffix too.

### DIFF
--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -90,7 +90,7 @@ func (cs Credentials) credsFor(host string) creds {
 	if cred, found := cs.m[host]; found {
 		return cred
 	}
-	if host == "gcr.io" {
+	if host == "gcr.io" || strings.HasSuffix(host, ".gcr.io") {
 		if cred, err := GetGCPOauthToken(); err == nil {
 			return cred
 		}


### PR DESCRIPTION
Closes #878.

There doesn't seem to be unit test coverage of this code path, but I have tested the fix manually in my cluster and it works. (Open to suggestions about how I could add tests, if relevant)