### PR TITLE
Make release output quieter

### DIFF
--- a/cmd/fluxctl/await.go
+++ b/cmd/fluxctl/await.go
@@ -18,13 +18,13 @@ var ErrTimeout = errors.New("timeout")
 
 // await polls for a job to complete, then for the resulting commit to
 // be applied
-func await(ctx context.Context, stdout, stderr io.Writer, client api.Client, jobID job.ID, apply, verbose bool) error {
+func await(ctx context.Context, stdout, stderr io.Writer, client api.Client, jobID job.ID, apply bool, verbosity int) error {
 	metadata, err := awaitJob(ctx, client, jobID)
 	if err != nil && err.Error() != git.ErrNoChanges.Error() {
 		return err
 	}
 	if metadata.Result != nil {
-		update.PrintResults(stdout, metadata.Result, verbose)
+		update.PrintResults(stdout, metadata.Result, verbosity)
 	}
 	if metadata.Revision != "" {
 		fmt.Fprintf(stderr, "Commit pushed:\t%s\n", metadata.ShortRevision())

--- a/cmd/fluxctl/format.go
+++ b/cmd/fluxctl/format.go
@@ -11,11 +11,11 @@ import (
 )
 
 type outputOpts struct {
-	verbose bool
+	verbosity int
 }
 
 func AddOutputFlags(cmd *cobra.Command, opts *outputOpts) {
-	cmd.Flags().BoolVarP(&opts.verbose, "verbose", "v", false, "include ignored controllers in output")
+	cmd.Flags().CountVarP(&opts.verbosity, "verbose", "v", "include skipped (and ignored, with -vv) controllers in output")
 }
 
 func newTabwriter() *tabwriter.Writer {

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -110,7 +110,7 @@ func (opts *controllerPolicyOpts) RunE(cmd *cobra.Command, args []string) error 
 	if err != nil {
 		return err
 	}
-	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, false, opts.verbose)
+	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, false, opts.verbosity)
 }
 
 func calculatePolicyChanges(opts *controllerPolicyOpts) (policy.Update, error) {

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -135,5 +135,5 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbose)
+	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbosity)
 }

--- a/update/print.go
+++ b/update/print.go
@@ -8,14 +8,23 @@ import (
 	"github.com/weaveworks/flux"
 )
 
-func PrintResults(out io.Writer, results Result, verbose bool) {
+// PrintResults outputs a result set to the `io.Writer` provided, at
+// the given level of verbosity:
+//  - 2 = include skipped and ignored resources
+//  - 1 = include skipped resources, exclude ignored resources
+//  - 0 = exclude skipped and ignored resources
+func PrintResults(out io.Writer, results Result, verbosity int) {
 	w := tabwriter.NewWriter(out, 0, 2, 2, ' ', 0)
 	fmt.Fprintln(w, "CONTROLLER \tSTATUS \tUPDATES")
 	for _, serviceID := range results.ServiceIDs() {
 		result := results[flux.MustParseResourceID(serviceID)]
 		switch result.Status {
 		case ReleaseStatusIgnored:
-			if !verbose {
+			if verbosity < 2 {
+				continue
+			}
+		case ReleaseStatusSkipped:
+			if verbosity < 1 {
 				continue
 			}
 		}

--- a/update/print_test.go
+++ b/update/print_test.go
@@ -18,10 +18,10 @@ func mustParseRef(s string) image.Ref {
 
 func TestPrintResults(t *testing.T) {
 	for _, example := range []struct {
-		name     string
-		result   Result
-		verbose  bool
-		expected string
+		name      string
+		result    Result
+		verbosity int
+		expected  string
 	}{
 		{
 			name: "basic, just results",
@@ -85,13 +85,13 @@ default/d    success
 	} {
 		out := &bytes.Buffer{}
 		out.WriteString("\n") // All our "expected" values start with a newline, to make maintaining them easier.
-		PrintResults(out, example.result, example.verbose)
+		PrintResults(out, example.result, example.verbosity)
 		if out.String() != example.expected {
 			t.Errorf(
 				"Name: %s\nPrintResults(out, %#v, %v)\nExpected\n-------%s-------\nGot\n-------%s-------",
 				example.name,
 				example.result,
-				example.verbose,
+				example.verbosity,
 				example.expected,
 				out.String(),
 			)


### PR DESCRIPTION
One doesn't usually care about skipped or ignored things, so exclude
them from output by default. Change the `--verbose` flag (shortcut
`-v`) to be a level of verbosity, s.t. `-vv` gives all output (skipped
and ignored things as well as successes and errors).