### PR TITLE
Use the exact credentials collected for the image domain

### DIFF
--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -346,7 +346,7 @@ func mergeCredentials(c *Cluster, namespace string, podTemplate apiv1.PodTemplat
 		}
 
 		// Parse secret
-		crd, err := registry.ParseCredentials(decoded)
+		crd, err := registry.ParseCredentials(fmt.Sprintf("%s:secret/%s", namespace, imagePullSecret.Name), decoded)
 		if err != nil {
 			c.logger.Log("err", err.Error())
 			continue

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -93,6 +93,7 @@ func main() {
 		registryPollInterval = fs.Duration("registry-poll-interval", 5*time.Minute, "period at which to check for updated images")
 		registryRPS          = fs.Int("registry-rps", 200, "maximum registry requests per second per host")
 		registryBurst        = fs.Int("registry-burst", defaultRemoteConnections, "maximum number of warmer connections to remote and memcache")
+		registryTrace        = fs.Bool("registry-trace", false, "output trace of image registry requests to log")
 
 		// k8s-secret backed ssh keyring configuration
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "Name of the k8s secret used to store the private SSH key")
@@ -257,6 +258,7 @@ func main() {
 		remoteFactory := &registry.RemoteClientFactory{
 			Logger:   registryLogger,
 			Limiters: registryLimits,
+			Trace:    *registryTrace,
 		}
 
 		// Warmer

--- a/registry/credentials_test.go
+++ b/registry/credentials_test.go
@@ -83,7 +83,7 @@ func TestRemoteFactory_ParseHost(t *testing.T) {
 		},
 	} {
 		stringCreds := fmt.Sprintf(tmpl, v.host, okCreds)
-		creds, err := ParseCredentials([]byte(stringCreds))
+		creds, err := ParseCredentials("test", []byte(stringCreds))
 		time.Sleep(100 * time.Millisecond)
 		if (err != nil) != v.error {
 			t.Fatalf("For test %q, expected error = %v but got %v", v.host, v.error, err != nil)
@@ -99,7 +99,7 @@ func TestRemoteFactory_ParseHost(t *testing.T) {
 
 func TestParseCreds_k8s(t *testing.T) {
 	k8sCreds := []byte(`{"localhost:5000":{"username":"testuser","password":"testpassword","email":"foo@bar.com","auth":"dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"}}`)
-	c, err := ParseCredentials(k8sCreds)
+	c, err := ParseCredentials("test", k8sCreds)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/gcp.go
+++ b/registry/gcp.go
@@ -16,7 +16,7 @@ type gceToken struct {
 	TokenType   string `json:"token_type"`
 }
 
-func GetGCPOauthToken() (creds, error) {
+func GetGCPOauthToken(host string) (creds, error) {
 	request, err := http.NewRequest("GET", gcpDefaultTokenURL, nil)
 	if err != nil {
 		return creds{}, err
@@ -44,5 +44,9 @@ func GetGCPOauthToken() (creds, error) {
 		return creds{}, err
 	}
 
-	return creds{"oauth2accesstoken", token.AccessToken}, nil
+	return creds{
+		registry:   host,
+		provenance: "",
+		username:   "oauth2accesstoken",
+		password:   token.AccessToken}, nil
 }


### PR DESCRIPTION
1. add an argument for enabling request tracing in the registry client
2. put a bit of extra logging in to report the nature of credentials being used in the registry client
3. ask for credentials using the image's name, rather than the auth domain, since those can differ (e.g., index.docker.io vs auth.docker.io).

Fixes #896.