### PR TITLE
Log more details on cache warming errors

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -230,6 +230,12 @@
   version = "v0.8.0"
 
 [[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
   name = "github.com/prometheus/client_golang"
   packages = ["prometheus","prometheus/promhttp"]
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
@@ -276,6 +282,12 @@
   packages = ["."]
   revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
   version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = ["assert"]
+  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
+  version = "v1.2.0"
 
 [[projects]]
   branch = "master"
@@ -376,6 +388,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "34df08675550de897967373573c4c8d6d515afb8184badc4e3e44dcec32a2561"
+  inputs-digest = "699f719c7fee3ff35223d87e731309ab44768787a2f8a5145a1df9724c75d0f4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/registry/cache/warming.go
+++ b/registry/cache/warming.go
@@ -111,9 +111,10 @@ func imageCredsToBacklog(imageCreds registry.ImageCreds) []backlogItem {
 }
 
 func (w *Warmer) warm(ctx context.Context, logger log.Logger, id image.Name, creds registry.Credentials) {
+	errorLogger := log.With(logger, "canonical_name", id.CanonicalName(), "auth", creds)
 	client, err := w.clientFactory.ClientFor(id.CanonicalName(), creds)
 	if err != nil {
-		logger.Log("err", err.Error())
+		errorLogger.Log("err", err.Error())
 		return
 	}
 
@@ -128,10 +129,9 @@ func (w *Warmer) warm(ctx context.Context, logger log.Logger, id image.Name, cre
 	}
 
 	if err != nil {
-		logger.Log("err", errors.Wrap(err, "fetching previous result from cache"))
+		errorLogger.Log("err", errors.Wrap(err, "fetching previous result from cache"))
 		return
 	}
-
 	// Save for comparison later
 	oldImages := repo.Images
 
@@ -144,14 +144,14 @@ func (w *Warmer) warm(ctx context.Context, logger log.Logger, id image.Name, cre
 			err = w.cache.SetKey(repoKey, bytes)
 		}
 		if err != nil {
-			logger.Log("err", errors.Wrap(err, "writing result to cache"))
+			errorLogger.Log("err", errors.Wrap(err, "writing result to cache"))
 		}
 	}()
 
 	tags, err := client.Tags(ctx)
 	if err != nil {
 		if !strings.Contains(err.Error(), context.DeadlineExceeded.Error()) && !strings.Contains(err.Error(), "net/http: request canceled") {
-			logger.Log("err", errors.Wrap(err, "requesting tags"))
+			errorLogger.Log("err", errors.Wrap(err, "requesting tags"))
 			repo.LastError = err.Error()
 		}
 		return
@@ -212,7 +212,7 @@ func (w *Warmer) warm(ctx context.Context, logger log.Logger, id image.Name, cre
 						// This was due to a context timeout, don't bother logging
 						return
 					}
-					logger.Log("err", errors.Wrap(err, "requesting manifests"))
+					errorLogger.Log("err", errors.Wrap(err, "requesting manifests"))
 					return
 				}
 
@@ -220,12 +220,12 @@ func (w *Warmer) warm(ctx context.Context, logger log.Logger, id image.Name, cre
 				// Write back to memcached
 				val, err := json.Marshal(img)
 				if err != nil {
-					logger.Log("err", errors.Wrap(err, "serializing tag to store in cache"))
+					errorLogger.Log("err", errors.Wrap(err, "serializing tag to store in cache"))
 					return
 				}
 				err = w.cache.SetKey(key, val)
 				if err != nil {
-					logger.Log("err", errors.Wrap(err, "storing manifests in cache"))
+					errorLogger.Log("err", errors.Wrap(err, "storing manifests in cache"))
 					return
 				}
 				successMx.Lock()

--- a/registry/cache/warming.go
+++ b/registry/cache/warming.go
@@ -46,8 +46,8 @@ type backlogItem struct {
 	registry.Credentials
 }
 
-// Continuously get the images to populate the cache with, and
-// populate the cache with them.
+// Loop continuously gets the images to populate the cache with,
+// and populate the cache with them.
 func (w *Warmer) Loop(logger log.Logger, stop <-chan struct{}, wg *sync.WaitGroup, imagesToFetchFunc func() registry.ImageCreds) {
 	defer wg.Done()
 

--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -123,3 +123,7 @@ func (cs Credentials) Merge(c Credentials) {
 		cs.m[k] = v
 	}
 }
+
+func (cs Credentials) String() string {
+	return fmt.Sprintf("{%v}", cs.m)
+}

--- a/registry/credentials_test.go
+++ b/registry/credentials_test.go
@@ -110,3 +110,11 @@ func TestParseCreds_k8s(t *testing.T) {
 	assert.Equal(t, "testuser", c.credsFor(host).username, "User is incorrect")
 	assert.Equal(t, "testpassword", c.credsFor(host).password, "Password is incorrect")
 }
+
+func TestStringShouldNotLeakPasswords(t *testing.T) {
+	k8sCreds := []byte(`{"localhost:5000":{"username":"testuser","password":"testpassword","email":"foo@bar.com","auth":"dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"}}`)
+	c, err := ParseCredentials("test", k8sCreds)
+	assert.NoError(t, err)
+	assert.Equal(t, "{map[localhost:5000:<registry creds for testuser@localhost:5000, from test>]}", fmt.Sprintf("%v", c)) // In comparison standard String() method typically yields: "{map[localhost:5000:{testuser testpassword localhost:5000 test}]}".
+	assert.Equal(t, "testpassword", c.credsFor("localhost:5000").password, "Password is incorrect")                        // Actual password is left untouched.
+}

--- a/registry/credentials_test.go
+++ b/registry/credentials_test.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -91,25 +93,20 @@ func TestRemoteFactory_ParseHost(t *testing.T) {
 		if v.error {
 			continue
 		}
-		if u := creds.credsFor(v.imagePrefix).username; u != user {
-			t.Fatalf("For test %q, expected %q but got %v", v.host, user, u)
-		}
+		actualUser := creds.credsFor(v.imagePrefix).username
+		assert.Equal(t, user, actualUser, "For test %q, expected %q but got %v", v.host, user, actualUser)
+		actualPass := creds.credsFor(v.imagePrefix).password
+		assert.Equal(t, pass, actualPass, "For test %q, expected %q but got %v", v.host, user, actualPass)
 	}
 }
 
 func TestParseCreds_k8s(t *testing.T) {
 	k8sCreds := []byte(`{"localhost:5000":{"username":"testuser","password":"testpassword","email":"foo@bar.com","auth":"dGVzdHVzZXI6dGVzdHBhc3N3b3Jk"}}`)
 	c, err := ParseCredentials("test", k8sCreds)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(c.Hosts()) != 1 {
-		t.Fatal("Invalid number of hosts", len(c.Hosts()))
-	} else if c.Hosts()[0] != "localhost:5000" {
-		t.Fatal("Host is incorrect: ", c.Hosts()[0])
-	} else if c.credsFor("localhost:5000").username != "testuser" {
-		t.Fatal("Invalid user", c.credsFor("localhost:5000").username)
-	} else if c.credsFor("localhost:5000").password != "testpassword" {
-		t.Fatal("Invalid user", c.credsFor("localhost:5000").password)
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(c.Hosts()), "Invalid number of hosts")
+	host := c.Hosts()[0]
+	assert.Equal(t, "localhost:5000", host, "Host is incorrect")
+	assert.Equal(t, "testuser", c.credsFor(host).username, "User is incorrect")
+	assert.Equal(t, "testpassword", c.credsFor(host).password, "Password is incorrect")
 }


### PR DESCRIPTION
Fixes #895.

With this PR, Flux now logs:
```
ts=2018-01-25T11:39:40.147644595Z \
  auth="{map[index.docker.io:<registry creds for marccarrecicd@index.docker.io, from default:secret/dockerhub-secret>]}" \
  caller=warming.go:154 \
  component=warmer \
  canonical_name=index.docker.io/marccarre/go-hello-world \
  err="requesting tags: Get https://index.docker.io/v2/marccarre/go-hello-world/tags/list: unauthorized: incorrect username or password"
```

Note that password is completely masked.

Not sure if we still want this PR though, given [this comment](https://github.com/weaveworks/flux/issues/895#issuecomment-357019949) and #897.