### PR TITLE
Log on startup

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -128,6 +128,7 @@ func main() {
 		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 		logger = log.With(logger, "caller", log.DefaultCaller)
 	}
+	logger.Log("started", true)
 
 	// Sort out values for the git tag and notes ref. There are
 	// running deployments that assume the defaults as given, so don't


### PR DESCRIPTION
This log message should be printed almost instantly after fluxd starts, allowing
us to debug slow startup issues.