### PR TITLE
Make sure multi-yamels are delimited

### DIFF
--- a/cluster/kubernetes/release.go
+++ b/cluster/kubernetes/release.go
@@ -58,6 +58,7 @@ func (c *Kubectl) apply(logger log.Logger, cs changeSet, errs cluster.SyncError)
 		if len(objs) == 0 {
 			return
 		}
+		logger.Log("cmd", cmd, "args", strings.Join(args, " "), "count", len(objs))
 		args = append(args, cmd)
 		if err := c.doCommand(logger, makeMultidoc(objs), args...); err != nil {
 			for _, obj := range objs {
@@ -103,7 +104,7 @@ func (c *Kubectl) doCommand(logger log.Logger, r io.Reader, args ...string) erro
 func makeMultidoc(objs []obj) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	for _, obj := range objs {
-		buf.WriteString("---\n" + string(obj.bytes))
+		buf.WriteString("\n---\n" + string(obj.bytes))
 	}
 	return buf
 }


### PR DESCRIPTION
We concatenate multiple manifest files into a YAML multidoc, so that
we can `kubectl apply` it all at once. The string `"---\n"` was used
to put a YAML document delimiter betwen each file's contents; however,
if a file does not end in a newline, this doens't end up on its own
line, and it interpreted as part of the preceeding document.

-> use `"\n---\n"`, on the basis that blank lines (if the file _does_
have a trailing newline) are harmless.

This commit also adds a bit more detail of what's being applied, to
the log.

Fixes #916.