### PR TITLE
AskForSync only when GitChange matches what we have

### DIFF
--- a/api/change.go
+++ b/api/change.go
@@ -57,5 +57,5 @@ type ImageUpdate struct {
 }
 
 type GitUpdate struct {
-	URL string
+	URL, Branch string
 }


### PR DESCRIPTION
This requires that the upstream tell Flux both the repo and branch that got updated so that we can avoid constantly syncing on events that will have no effect.