### PR TITLE
Move Upstream interface out of api.Server

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,14 +8,12 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-type ServerV4 interface {
+type UpstreamV4 interface {
 	Ping(context.Context) error
 	Version(context.Context) (string, error)
 }
 
 type ServerV5 interface {
-	ServerV4
-
 	Export(context.Context) ([]byte, error)
 }
 
@@ -41,6 +39,10 @@ type ServerV6 interface {
 
 type ServerV9 interface {
 	ServerV6NotDeprecated
+}
+
+type UpstreamV9 interface {
+	UpstreamV4
 
 	// ChangeNotify tells the daemon that we've noticed a change in
 	// e.g., the git repo, or image registry, and now would be a good
@@ -48,7 +50,16 @@ type ServerV9 interface {
 	NotifyChange(context.Context, Change) error
 }
 
-// API for clients connecting to the service
+// Server defines the minimal interface a Flux must satisfy to adequately serve a
+// connecting fluxctl. This interface specifically does not facilitate connecting
+// to Weave Cloud.
 type Server interface {
 	ServerV9
+}
+
+// UpstreamServer is the interface a Flux must satisfy in order to communicate with
+// Weave Cloud.
+type UpstreamServer interface {
+	Server
+	UpstreamV9
 }

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -294,7 +294,7 @@ func main() {
 				flux.Token(*token),
 				transport.NewUpstreamRouter(),
 				*upstreamURL,
-				remote.NewErrorLoggingServer(daemonRef, upstreamLogger),
+				remote.NewErrorLoggingUpstreamServer(daemonRef, upstreamLogger),
 				upstreamLogger,
 			)
 			if err != nil {

--- a/daemon/ref.go
+++ b/daemon/ref.go
@@ -16,20 +16,20 @@ import (
 // state changes.
 type Ref struct {
 	sync.RWMutex
-	server api.Server
+	server api.UpstreamServer
 }
 
-func NewRef(server api.Server) *Ref {
+func NewRef(server api.UpstreamServer) *Ref {
 	return &Ref{server: server}
 }
 
-func (r *Ref) Server() api.Server {
+func (r *Ref) Server() api.UpstreamServer {
 	r.RLock()
 	defer r.RUnlock()
 	return r.server
 }
 
-func (r *Ref) UpdateServer(server api.Server) {
+func (r *Ref) UpdateServer(server api.UpstreamServer) {
 	r.Lock()
 	r.server = server
 	r.Unlock()

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
-	"github.com/weaveworks/flux/api"
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/event"
 	transport "github.com/weaveworks/flux/http"
@@ -84,18 +83,6 @@ func (c *Client) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitCo
 	var res flux.GitConfig
 	err := c.methodWithResp(ctx, "POST", &res, "GitRepoConfig", regenerate)
 	return res, err
-}
-
-func (c *Client) Ping(context.Context) error {
-	return errNotImplemented
-}
-
-func (c *Client) Version(context.Context) (string, error) {
-	return "", errNotImplemented
-}
-
-func (c *Client) NotifyChange(context.Context, api.Change) error {
-	return errNotImplemented
 }
 
 // --- Request helpers

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/weaveworks/flux/api"
 	transport "github.com/weaveworks/flux/http"
-	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/job"
 	fluxmetrics "github.com/weaveworks/flux/metrics"
 	"github.com/weaveworks/flux/policy"
@@ -31,9 +30,6 @@ var (
 // An API server for the daemon
 func NewRouter() *mux.Router {
 	r := transport.NewAPIRouter()
-
-	r.NewRoute().Methods("POST").Name("GitPushHook").Path("/v9/hook/git").Queries("repo", "{repo}")
-	r.NewRoute().Methods("POST").Name("ImagePushHook").Path("/v9/hook/image").Queries("name", "{name}")
 
 	// All old versions are deprecated in the daemon. Use an up to
 	// date client!
@@ -57,9 +53,6 @@ func NewHandler(s api.Server, r *mux.Router) http.Handler {
 	r.Get("Export").HandlerFunc(handle.Export)
 	r.Get("GitRepoConfig").HandlerFunc(handle.GitRepoConfig)
 
-	r.Get("GitPushHook").HandlerFunc(handle.GitPushHook)
-	r.Get("ImagePushHook").HandlerFunc(handle.ImagePushHook)
-
 	// These handlers persist to support requests from older fluxctls. In general we
 	// should avoid adding references to them so that they can eventually be removed.
 	r.Get("UpdateImages").HandlerFunc(handle.UpdateImages)
@@ -75,37 +68,6 @@ func NewHandler(s api.Server, r *mux.Router) http.Handler {
 
 type HTTPServer struct {
 	server api.Server
-}
-
-func (s HTTPServer) GitPushHook(w http.ResponseWriter, r *http.Request) {
-	repo := mux.Vars(r)["repo"]
-	err := s.server.NotifyChange(r.Context(), api.Change{
-		Kind:   api.GitChange,
-		Source: api.GitUpdate{URL: repo},
-	})
-	if err != nil {
-		transport.ErrorResponse(w, r, err)
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-	return
-}
-
-func (s HTTPServer) ImagePushHook(w http.ResponseWriter, r *http.Request) {
-	nameString := mux.Vars(r)["name"]
-	ref, err := image.ParseRef(nameString)
-	if err == nil {
-		err = s.server.NotifyChange(r.Context(), api.Change{
-			Kind:   api.ImageChange,
-			Source: api.ImageUpdate{Name: ref.Name},
-		})
-	}
-	if err != nil {
-		transport.ErrorResponse(w, r, err)
-		return
-	}
-	w.WriteHeader(http.StatusNoContent)
-	return
 }
 
 func (s HTTPServer) JobStatus(w http.ResponseWriter, r *http.Request) {

--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -30,7 +30,7 @@ type Upstream struct {
 	url       *url.URL
 	endpoint  string
 	apiClient *fluxclient.Client
-	server    api.Server
+	server    api.UpstreamServer
 	logger    log.Logger
 	quit      chan struct{}
 
@@ -47,7 +47,7 @@ var (
 	}, []string{"target"})
 )
 
-func NewUpstream(client *http.Client, ua string, t flux.Token, router *mux.Router, endpoint string, s api.Server, logger log.Logger) (*Upstream, error) {
+func NewUpstream(client *http.Client, ua string, t flux.Token, router *mux.Router, endpoint string, s api.UpstreamServer, logger log.Logger) (*Upstream, error) {
 	httpEndpoint, wsEndpoint, err := inferEndpoints(endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "inferring WS/HTTP endpoints")

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -92,13 +92,13 @@ func (p *MockServer) GitRepoConfig(ctx context.Context, regenerate bool) (flux.G
 	return p.GitRepoConfigAnswer, p.GitRepoConfigError
 }
 
-var _ api.Server = &MockServer{}
+var _ api.UpstreamServer = &MockServer{}
 
 // -- Battery of tests for an api.Server implementation. Since these
 // essentially wrap the server in various transports, we expect
 // arguments and answers to be preserved.
 
-func ServerTestBattery(t *testing.T, wrap func(mock api.Server) api.Server) {
+func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.UpstreamServer) {
 	// set up
 	namespace := "the-space-of-names"
 	serviceID := flux.MustParseResourceID(namespace + "/service")

--- a/remote/mock_test.go
+++ b/remote/mock_test.go
@@ -8,5 +8,5 @@ import (
 
 // Just test that the mock does its job.
 func TestMock(t *testing.T) {
-	ServerTestBattery(t, func(mock api.Server) api.Server { return mock })
+	ServerTestBattery(t, func(mock api.UpstreamServer) api.UpstreamServer { return mock })
 }

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -14,7 +14,7 @@ import (
 
 type baseClient struct{}
 
-var _ api.Server = baseClient{}
+var _ api.UpstreamServer = baseClient{}
 
 func (bc baseClient) Version(context.Context) (string, error) {
 	return "", remote.UpgradeNeededError(errors.New("Version method not implemented"))

--- a/remote/rpc/clientV4.go
+++ b/remote/rpc/clientV4.go
@@ -17,7 +17,11 @@ type RPCClientV4 struct {
 	client *rpc.Client
 }
 
-var _ api.ServerV4 = &RPCClientV4{}
+type clientV4 interface {
+	api.UpstreamV4
+}
+
+var _ clientV4 = &RPCClientV4{}
 
 // NewClient creates a new rpc-backed implementation of the server.
 func NewClientV4(conn io.ReadWriteCloser) *RPCClientV4 {

--- a/remote/rpc/clientV5.go
+++ b/remote/rpc/clientV5.go
@@ -15,7 +15,12 @@ type RPCClientV5 struct {
 	*RPCClientV4
 }
 
-var _ api.ServerV5 = &RPCClientV5{}
+type clientV5 interface {
+	api.ServerV5
+	api.UpstreamV4
+}
+
+var _ clientV5 = &RPCClientV5{}
 
 // NewClient creates a new rpc-backed implementation of the server.
 func NewClientV5(conn io.ReadWriteCloser) *RPCClientV5 {

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -19,6 +19,11 @@ type RPCClientV6 struct {
 	*RPCClientV5
 }
 
+type clientV6 interface {
+	api.ServerV6
+	api.UpstreamV4
+}
+
 // We don't get proper application error structs back from v6, but we
 // do know that anything that's not considered a fatal error can be
 // translated into an application error.
@@ -36,7 +41,7 @@ attempting to fulfil your request:
 	}
 }
 
-var _ api.ServerV6 = &RPCClientV6{}
+var _ clientV6 = &RPCClientV6{}
 
 var supportedKindsV6 = []string{"service"}
 

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -21,7 +21,12 @@ type RPCClientV7 struct {
 	*RPCClientV6
 }
 
-var _ api.ServerV6 = &RPCClientV7{}
+type clientV7 interface {
+	api.ServerV6
+	api.UpstreamV4
+}
+
+var _ clientV7 = &RPCClientV7{}
 
 var supportedKindsV7 = []string{"service"}
 

--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -19,7 +19,12 @@ type RPCClientV8 struct {
 	*RPCClientV7
 }
 
-var _ api.ServerV6 = &RPCClientV8{}
+type clientV8 interface {
+	api.ServerV6
+	api.UpstreamV4
+}
+
+var _ clientV8 = &RPCClientV8{}
 
 var supportedKindsV8 = []string{"deployment", "daemonset", "statefulset", "cronjob"}
 

--- a/remote/rpc/clientV9.go
+++ b/remote/rpc/clientV9.go
@@ -13,6 +13,11 @@ type RPCClientV9 struct {
 	*RPCClientV8
 }
 
+type clientV9 interface {
+	api.ServerV9
+	api.UpstreamV9
+}
+
 func NewClientV9(conn io.ReadWriteCloser) *RPCClientV9 {
 	return &RPCClientV9{NewClientV8(conn)}
 }

--- a/remote/rpc/rpc_test.go
+++ b/remote/rpc/rpc_test.go
@@ -23,7 +23,7 @@ func pipes() (io.ReadWriteCloser, io.ReadWriteCloser) {
 }
 
 func TestRPC(t *testing.T) {
-	wrap := func(mock api.Server) api.Server {
+	wrap := func(mock api.UpstreamServer) api.UpstreamServer {
 		clientConn, serverConn := pipes()
 
 		server, err := NewServer(mock)

--- a/remote/rpc/server.go
+++ b/remote/rpc/server.go
@@ -22,7 +22,7 @@ type Server struct {
 
 // NewServer instantiates a new RPC server, handling requests on the
 // conn by invoking methods on the underlying (assumed local) server.
-func NewServer(s api.Server) (*Server, error) {
+func NewServer(s api.UpstreamServer) (*Server, error) {
 	server := rpc.NewServer()
 	if err := server.Register(&RPCServer{s}); err != nil {
 		return nil, err
@@ -35,7 +35,7 @@ func (c *Server) ServeConn(conn io.ReadWriteCloser) {
 }
 
 type RPCServer struct {
-	s api.Server
+	s api.UpstreamServer
 }
 
 func (p *RPCServer) Ping(_ struct{}, _ *struct{}) error {


### PR DESCRIPTION
Some methods on api.Server (Ping, Version, NotifyChange) only make sense in the
case that a Flux is connected to an Upstream (Weave Cloud). The result of this
was that the HTTP client ended up with 'not implemented' implementations of
methods which are out of place.

Since api.UpstreamServer is a superset of api.Server and struct embedding
exists, there luckily isn't a huge amount of change the the boilerplatey stuff.

Type assertions of the form `var _ api.Server = Foo{}` have been updated to make
sure things that should implement UpstreamServer do so.