### PR TITLE
Test HTTP server implementation(s)

### DIFF
--- a/http/client/client.go
+++ b/http/client/client.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/api"
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/event"
 	transport "github.com/weaveworks/flux/http"
@@ -29,6 +30,8 @@ type Client struct {
 	router   *mux.Router
 	endpoint string
 }
+
+var _ api.Server = &Client{}
 
 func New(c *http.Client, router *mux.Router, endpoint string, t flux.Token) *Client {
 	return &Client{

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -44,47 +44,47 @@ func New(c *http.Client, router *mux.Router, endpoint string, t flux.Token) *Cli
 
 func (c *Client) ListServices(ctx context.Context, namespace string) ([]flux.ControllerStatus, error) {
 	var res []flux.ControllerStatus
-	err := c.Get(ctx, &res, "ListServices", "namespace", namespace)
+	err := c.Get(ctx, &res, transport.ListServices, "namespace", namespace)
 	return res, err
 }
 
 func (c *Client) ListImages(ctx context.Context, s update.ResourceSpec) ([]flux.ImageStatus, error) {
 	var res []flux.ImageStatus
-	err := c.Get(ctx, &res, "ListImages", "service", string(s))
+	err := c.Get(ctx, &res, transport.ListImages, "service", string(s))
 	return res, err
 }
 
 func (c *Client) JobStatus(ctx context.Context, jobID job.ID) (job.Status, error) {
 	var res job.Status
-	err := c.Get(ctx, &res, "JobStatus", "id", string(jobID))
+	err := c.Get(ctx, &res, transport.JobStatus, "id", string(jobID))
 	return res, err
 }
 
 func (c *Client) SyncStatus(ctx context.Context, ref string) ([]string, error) {
 	var res []string
-	err := c.Get(ctx, &res, "SyncStatus", "ref", ref)
+	err := c.Get(ctx, &res, transport.SyncStatus, "ref", ref)
 	return res, err
 }
 
 func (c *Client) UpdateManifests(ctx context.Context, spec update.Spec) (job.ID, error) {
 	var res job.ID
-	err := c.methodWithResp(ctx, "POST", &res, "UpdateManifests", spec)
+	err := c.methodWithResp(ctx, "POST", &res, transport.UpdateManifests, spec)
 	return res, err
 }
 
 func (c *Client) LogEvent(ctx context.Context, event event.Event) error {
-	return c.PostWithBody(ctx, "LogEvent", event)
+	return c.PostWithBody(ctx, transport.LogEvent, event)
 }
 
 func (c *Client) Export(ctx context.Context) ([]byte, error) {
 	var res []byte
-	err := c.Get(ctx, &res, "Export")
+	err := c.Get(ctx, &res, transport.Export)
 	return res, err
 }
 
 func (c *Client) GitRepoConfig(ctx context.Context, regenerate bool) (flux.GitConfig, error) {
 	var res flux.GitConfig
-	err := c.methodWithResp(ctx, "POST", &res, "GitRepoConfig", regenerate)
+	err := c.methodWithResp(ctx, "POST", &res, transport.GitRepoConfig, regenerate)
 	return res, err
 }
 

--- a/http/daemon/server_test.go
+++ b/http/daemon/server_test.go
@@ -1,0 +1,17 @@
+package daemon
+
+import (
+	"testing"
+
+	"github.com/weaveworks/flux/http"
+)
+
+func TestRouterImplementsServer(t *testing.T) {
+	router := NewRouter()
+	// Calling NewHandler attaches handlers to the router
+	NewHandler(nil, router)
+	err := http.ImplementsServer(router)
+	if err != nil {
+		t.Error(err)
+	}
+}

--- a/http/routes.go
+++ b/http/routes.go
@@ -1,0 +1,24 @@
+package http
+
+const (
+	ListServices    = "ListServices"
+	ListImages      = "ListImages"
+	UpdateManifests = "UpdateManifests"
+	JobStatus       = "JobStatus"
+	SyncStatus      = "SyncStatus"
+	Export          = "Export"
+	GitRepoConfig   = "GitRepoConfig"
+
+	UpdateImages           = "UpdateImages"
+	UpdatePolicies         = "UpdatePolicies"
+	GetPublicSSHKey        = "GetPublicSSHKey"
+	RegeneratePublicSSHKey = "RegeneratePublicSSHKey"
+)
+
+var (
+	RegisterDaemonV6 = "RegisterDaemonV6"
+	RegisterDaemonV7 = "RegisterDaemonV7"
+	RegisterDaemonV8 = "RegisterDaemonV8"
+	RegisterDaemonV9 = "RegisterDaemonV9"
+	LogEvent         = "LogEvent"
+)

--- a/http/transport.go
+++ b/http/transport.go
@@ -29,31 +29,31 @@ func DeprecateVersions(r *mux.Router, versions ...string) {
 func NewAPIRouter() *mux.Router {
 	r := mux.NewRouter()
 
-	r.NewRoute().Name("ListServices").Methods("GET").Path("/v6/services").Queries("namespace", "{namespace}") // optional namespace!
-	r.NewRoute().Name("ListImages").Methods("GET").Path("/v6/images").Queries("service", "{service}")
+	r.NewRoute().Name(ListServices).Methods("GET").Path("/v6/services").Queries("namespace", "{namespace}") // optional namespace!
+	r.NewRoute().Name(ListImages).Methods("GET").Path("/v6/images").Queries("service", "{service}")
 
-	r.NewRoute().Name("UpdateManifests").Methods("POST").Path("/v9/update-manifests")
-	r.NewRoute().Name("JobStatus").Methods("GET").Path("/v6/jobs").Queries("id", "{id}")
-	r.NewRoute().Name("SyncStatus").Methods("GET").Path("/v6/sync").Queries("ref", "{ref}")
-	r.NewRoute().Name("Export").Methods("HEAD", "GET").Path("/v6/export")
-	r.NewRoute().Name("GitRepoConfig").Methods("POST").Path("/v9/git-repo-config")
+	r.NewRoute().Name(UpdateManifests).Methods("POST").Path("/v9/update-manifests")
+	r.NewRoute().Name(JobStatus).Methods("GET").Path("/v6/jobs").Queries("id", "{id}")
+	r.NewRoute().Name(SyncStatus).Methods("GET").Path("/v6/sync").Queries("ref", "{ref}")
+	r.NewRoute().Name(Export).Methods("HEAD", "GET").Path("/v6/export")
+	r.NewRoute().Name(GitRepoConfig).Methods("POST").Path("/v9/git-repo-config")
 
 	// These routes persist to support requests from older fluxctls. In general we
 	// should avoid adding references to them so that they can eventually be removed.
-	r.NewRoute().Name("UpdateImages").Methods("POST").Path("/v6/update-images").Queries("service", "{service}", "image", "{image}", "kind", "{kind}")
-	r.NewRoute().Name("UpdatePolicies").Methods("PATCH").Path("/v6/policies")
-	r.NewRoute().Name("GetPublicSSHKey").Methods("GET").Path("/v6/identity.pub")
-	r.NewRoute().Name("RegeneratePublicSSHKey").Methods("POST").Path("/v6/identity.pub")
+	r.NewRoute().Name(UpdateImages).Methods("POST").Path("/v6/update-images").Queries("service", "{service}", "image", "{image}", "kind", "{kind}")
+	r.NewRoute().Name(UpdatePolicies).Methods("PATCH").Path("/v6/policies")
+	r.NewRoute().Name(GetPublicSSHKey).Methods("GET").Path("/v6/identity.pub")
+	r.NewRoute().Name(RegeneratePublicSSHKey).Methods("POST").Path("/v6/identity.pub")
 
 	return r // TODO 404 though?
 }
 
 func UpstreamRoutes(r *mux.Router) {
-	r.NewRoute().Name("RegisterDaemonV6").Methods("GET").Path("/v6/daemon")
-	r.NewRoute().Name("RegisterDaemonV7").Methods("GET").Path("/v7/daemon")
-	r.NewRoute().Name("RegisterDaemonV8").Methods("GET").Path("/v8/daemon")
-	r.NewRoute().Name("RegisterDaemonV9").Methods("GET").Path("/v9/daemon")
-	r.NewRoute().Name("LogEvent").Methods("POST").Path("/v6/events")
+	r.NewRoute().Name(RegisterDaemonV6).Methods("GET").Path("/v6/daemon")
+	r.NewRoute().Name(RegisterDaemonV7).Methods("GET").Path("/v7/daemon")
+	r.NewRoute().Name(RegisterDaemonV8).Methods("GET").Path("/v8/daemon")
+	r.NewRoute().Name(RegisterDaemonV9).Methods("GET").Path("/v9/daemon")
+	r.NewRoute().Name(LogEvent).Methods("POST").Path("/v6/events")
 }
 
 func NewUpstreamRouter() *mux.Router {

--- a/http/validate.go
+++ b/http/validate.go
@@ -1,0 +1,40 @@
+package http
+
+import (
+	"fmt"
+
+	"github.com/gorilla/mux"
+)
+
+// ImplementsServer verifies that a given `*mux.Router` has handlers for
+// all routes specified in `NewAPIRouter()`.
+//
+// We can't easily check whether a router implements the `api.Server`
+// interface, as would be desired, so we rely on the knowledge that
+// `*client.Client` implements `api.Server` while also depending on
+// route name strings defined in this package.
+//
+// Returns an error if router doesn't fully implement `NewAPIRouter()`,
+// nil otherwise.
+func ImplementsServer(router *mux.Router) error {
+	apiRouter := NewAPIRouter()
+	return apiRouter.Walk(makeWalkFunc(router))
+}
+
+// makeWalkFunc creates a function which verifies that the route passed
+// to it both exists in the router under test and has a handler attached.
+func makeWalkFunc(router *mux.Router) mux.WalkFunc {
+	return mux.WalkFunc(func(r *mux.Route, _ *mux.Router, _ []*mux.Route) error {
+		// Does a route with this name exist in router?
+		route := router.Get(r.GetName())
+		if route == nil {
+			return fmt.Errorf("no route by name %q in router", r.GetName())
+		}
+		// Goes the route have a handler?
+		handler := route.GetHandler()
+		if handler == nil {
+			return fmt.Errorf("no handler for route %q in router", r.GetName())
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
It's quite easy in the current flux codebase to add something to either the `api.Server` interface or the `NewAPIRouter` router without the corresponding changes. This PR improves the state of affairs by enforcing the following constraints:

- `*http.Client` explicitly must implement the `api.Server` interface. This means that for every API method that a Flux daemon must implement, it's possible to call it from `fluxctl`. (This was already [implicitly true](https://github.com/weaveworks/flux/blob/3074b28cd18f5a66d9bcb2b27bbffbbe03fccda2/cmd/fluxctl/root_cmd.go#L82))
- HTTP implementations of the `api.Server` interface must define all routes required by `*http.Client` and have a handler for all required routes.

Together these constraints mean it's not possible to add a method to `api.Server` without adding a method to `*http.Client`, or the build will fail. The build won't fail if there's not a corresponding handler on the other side, but the tests will.