### PR TITLE
Move repo syncing into repo

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -229,7 +229,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 		changedResources = allResources
 	} else {
 		ctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
-		changedFiles, err := working.ChangedFiles(ctx, working.SyncTag)
+		changedFiles, err := working.ChangedFiles(ctx, oldTagRev)
 		if err == nil {
 			// We had some changed files, we're syncing a diff
 			changedResources, err = d.Manifests.LoadManifests(changedFiles...)
@@ -374,7 +374,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 	// Move the tag and push it so we know how far we've gotten.
 	{
 		ctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
-		err := working.MoveTagAndPush(ctx, "HEAD", "Sync pointer")
+		err := working.MoveSyncTagAndPush(ctx, newTagRev, "Sync pointer")
 		cancel()
 		if err != nil {
 			return err
@@ -382,7 +382,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 	}
 
 	if oldTagRev != newTagRev {
-		logger.Log("tag", working.SyncTag, "old", oldTagRev, "new", newTagRev)
+		logger.Log("tag", d.GitConfig.SyncTag, "old", oldTagRev, "new", newTagRev)
 		ctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
 		err := d.Repo.Refresh(ctx)
 		cancel()

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 const (
+	gitPath     = ""
 	gitSyncTag  = "flux-sync"
 	gitNotesRef = "flux"
 	gitUser     = "Weave Flux"
@@ -39,15 +40,6 @@ var (
 
 func daemon(t *testing.T) (*Daemon, func()) {
 	repo, repoCleanup := gittest.Repo(t)
-	working, err := repo.Clone(context.Background(), git.Config{
-		SyncTag:   gitSyncTag,
-		NotesRef:  gitNotesRef,
-		UserName:  gitUser,
-		UserEmail: gitEmail,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	k8s = &cluster.Mock{}
 	k8s.LoadManifestsFunc = kresource.Load
@@ -62,12 +54,26 @@ func daemon(t *testing.T) (*Daemon, func()) {
 
 	wg := &sync.WaitGroup{}
 	shutdown := make(chan struct{})
+
+	wg.Add(1)
+	go repo.Start(shutdown, wg)
+	gittest.WaitForRepoReady(repo, t)
+
+	gitConfig := git.Config{
+		Branch:    "master",
+		SyncTag:   gitSyncTag,
+		NotesRef:  gitNotesRef,
+		UserName:  gitUser,
+		UserEmail: gitEmail,
+	}
+
 	jobs := job.NewQueue(shutdown, wg)
 	d := &Daemon{
 		Cluster:        k8s,
 		Manifests:      k8s,
 		Registry:       &registryMock.Registry{},
-		Checkout:       working,
+		Repo:           repo,
+		GitConfig:      gitConfig,
 		Jobs:           jobs,
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
@@ -129,9 +135,9 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 		}
 	}
 	// It creates the tag at HEAD
-	if err := d.Checkout.Pull(context.Background()); err != nil {
+	if err := d.Repo.Refresh(context.Background()); err != nil {
 		t.Errorf("pulling sync tag: %v", err)
-	} else if revs, err := d.Checkout.CommitsBefore(context.Background(), gitSyncTag); err != nil {
+	} else if revs, err := d.Repo.CommitsBefore(context.Background(), gitSyncTag, gitPath); err != nil {
 		t.Errorf("finding revisions before sync tag: %v", err)
 	} else if len(revs) <= 0 {
 		t.Errorf("Found no revisions before the sync tag")
@@ -139,11 +145,23 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 }
 
 func TestDoSync_NoNewCommits(t *testing.T) {
-	// Tag exists
 	d, cleanup := daemon(t)
 	defer cleanup()
-	if err := d.Checkout.MoveTagAndPush(context.Background(), "HEAD", "Sync pointer"); err != nil {
+
+	ctx := context.Background()
+	err := d.WithClone(ctx, func(co *git.Checkout) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		return co.MoveTagAndPush(ctx, "HEAD", "Sync pointer")
+	})
+	if err != nil {
 		t.Fatal(err)
+	}
+
+	// NB this would usually trigger a sync in a running loop; but we
+	// have not run the loop.
+	if err = d.Repo.Refresh(ctx); err != nil {
+		t.Error(err)
 	}
 
 	syncCalled := 0
@@ -159,7 +177,9 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 		return nil
 	}
 
-	d.doSync(log.NewLogfmtLogger(ioutil.Discard))
+	if err := d.doSync(log.NewLogfmtLogger(ioutil.Discard)); err != nil {
+		t.Error(err)
+	}
 
 	// It applies everything
 	if syncCalled != 1 {
@@ -179,13 +199,12 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 	}
 
 	// It doesn't move the tag
-	oldRevs, err := d.Checkout.CommitsBefore(context.Background(), gitSyncTag)
+	oldRevs, err := d.Repo.CommitsBefore(ctx, gitSyncTag, gitPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := d.Checkout.Pull(context.Background()); err != nil {
-		t.Errorf("pulling sync tag: %v", err)
-	} else if revs, err := d.Checkout.CommitsBefore(context.Background(), gitSyncTag); err != nil {
+
+	if revs, err := d.Repo.CommitsBefore(ctx, gitSyncTag, gitPath); err != nil {
 		t.Errorf("finding revisions before sync tag: %v", err)
 	} else if !reflect.DeepEqual(revs, oldRevs) {
 		t.Errorf("Should have kept the sync tag at HEAD")
@@ -193,32 +212,49 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 }
 
 func TestDoSync_WithNewCommit(t *testing.T) {
-	// Tag exists
 	d, cleanup := daemon(t)
 	defer cleanup()
+
+	ctx := context.Background()
 	// Set the sync tag to head
-	if err := d.Checkout.MoveTagAndPush(context.Background(), "HEAD", "Sync pointer"); err != nil {
-		t.Fatal(err)
-	}
-	oldRevision, err := d.Checkout.HeadRevision(context.Background())
+	var oldRevision, newRevision string
+	err := d.WithClone(ctx, func(checkout *git.Checkout) error {
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		var err error
+		err = checkout.MoveTagAndPush(ctx, "HEAD", "Sync pointer")
+		if err != nil {
+			return err
+		}
+		oldRevision, err = checkout.HeadRevision(ctx)
+		if err != nil {
+			return err
+		}
+		// Push some new changes
+		err = cluster.UpdateManifest(k8s, checkout.ManifestDir(), flux.MustParseResourceID("default:deployment/helloworld"), func(def []byte) ([]byte, error) {
+			// A simple modification so we have changes to push
+			return []byte(strings.Replace(string(def), "replicas: 5", "replicas: 4", -1)), nil
+		})
+		if err != nil {
+			return err
+		}
+
+		commitAction := &git.CommitAction{Author: "", Message: "test commit"}
+		err = checkout.CommitAndPush(ctx, commitAction, nil)
+		if err != nil {
+			return err
+		}
+		newRevision, err = checkout.HeadRevision(ctx)
+		return err
+	})
 	if err != nil {
-		t.Fatal(err)
-	}
-	// Push some new changes
-	if err := cluster.UpdateManifest(k8s, d.Checkout.ManifestDir(), flux.MustParseResourceID("default:deployment/helloworld"), func(def []byte) ([]byte, error) {
-		// A simple modification so we have changes to push
-		return []byte(strings.Replace(string(def), "replicas: 5", "replicas: 4", -1)), nil
-	}); err != nil {
 		t.Fatal(err)
 	}
 
-	commitAction := &git.CommitAction{Author: "", Message: "test commit"}
-	if err := d.Checkout.CommitAndPush(context.Background(), commitAction, nil); err != nil {
-		t.Fatal(err)
-	}
-	newRevision, err := d.Checkout.HeadRevision(context.Background())
+	err = d.Repo.Refresh(ctx)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
 	}
 
 	syncCalled := 0
@@ -262,9 +298,11 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 		}
 	}
 	// It moves the tag
-	if err := d.Checkout.Pull(context.Background()); err != nil {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	if err := d.Repo.Refresh(ctx); err != nil {
 		t.Errorf("pulling sync tag: %v", err)
-	} else if revs, err := d.Checkout.CommitsBetween(context.Background(), oldRevision, gitSyncTag); err != nil {
+	} else if revs, err := d.Repo.CommitsBetween(ctx, oldRevision, gitSyncTag, gitPath); err != nil {
 		t.Errorf("finding revisions before sync tag: %v", err)
 	} else if len(revs) <= 0 {
 		t.Errorf("Should have moved sync tag forward")

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -152,7 +152,7 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 	err := d.WithClone(ctx, func(co *git.Checkout) error {
 		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 		defer cancel()
-		return co.MoveTagAndPush(ctx, "HEAD", "Sync pointer")
+		return co.MoveSyncTagAndPush(ctx, "HEAD", "Sync pointer")
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -223,7 +223,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 		defer cancel()
 
 		var err error
-		err = checkout.MoveTagAndPush(ctx, "HEAD", "Sync pointer")
+		err = checkout.MoveSyncTagAndPush(ctx, "HEAD", "Sync pointer")
 		if err != nil {
 			return err
 		}

--- a/flux.go
+++ b/flux.go
@@ -271,17 +271,6 @@ type Container struct {
 
 // --- config types
 
-func NewGitRemoteConfig(url, branch, path string) (GitRemoteConfig, error) {
-	if len(path) > 0 && path[0] == '/' {
-		return GitRemoteConfig{}, errors.New("git subdirectory (--git-path) should not have leading forward slash")
-	}
-	return GitRemoteConfig{
-		URL:    url,
-		Branch: branch,
-		Path:   path,
-	}, nil
-}
-
 type GitRemoteConfig struct {
 	URL    string `json:"url"`
 	Branch string `json:"branch"`

--- a/git/operations.go
+++ b/git/operations.go
@@ -28,7 +28,7 @@ func config(ctx context.Context, workingDir, user, email string) error {
 	return nil
 }
 
-func clone(ctx context.Context, workingDir string, repoURL, repoBranch string) (path string, err error) {
+func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path string, err error) {
 	repoPath := filepath.Join(workingDir, "repo")
 	args := []string{"clone"}
 	if repoBranch != "" {
@@ -41,9 +41,19 @@ func clone(ctx context.Context, workingDir string, repoURL, repoBranch string) (
 	return repoPath, nil
 }
 
-// checkPush sanity-checks that we can write to the upstream repo with
-// the given keyring (being able to `clone` is an adequate check that
-// we can read the upstream).
+func mirror(ctx context.Context, workingDir, repoURL string) (path string, err error) {
+	repoPath := filepath.Join(workingDir, "repo")
+	args := []string{"clone", "--mirror"}
+	args = append(args, repoURL, repoPath)
+	if err := execGitCmd(ctx, workingDir, nil, args...); err != nil {
+		return "", errors.Wrap(err, "git clone --mirror")
+	}
+	return repoPath, nil
+}
+
+// checkPush sanity-checks that we can write to the upstream repo
+// (being able to `clone` is an adequate check that we can read the
+// upstream).
 func checkPush(ctx context.Context, workingDir, upstream string) error {
 	// --force just in case we fetched the tag from upstream when cloning
 	if err := execGitCmd(ctx, workingDir, nil, "tag", "--force", CheckPushTag); err != nil {
@@ -86,16 +96,10 @@ func push(ctx context.Context, workingDir, upstream string, refs []string) error
 	return nil
 }
 
-// pull the specific ref from upstream
-func pull(ctx context.Context, workingDir, upstream, ref string) error {
-	if err := execGitCmd(ctx, workingDir, nil, "pull", "--ff-only", upstream, ref); err != nil {
-		return errors.Wrap(err, fmt.Sprintf("git pull --ff-only %s %s", upstream, ref))
-	}
-	return nil
-}
-
-func fetch(ctx context.Context, workingDir, upstream, refspec string) error {
-	if err := execGitCmd(ctx, workingDir, nil, "fetch", "--tags", upstream, refspec); err != nil &&
+// fetch updates refs from the upstream.
+func fetch(ctx context.Context, workingDir, upstream string, refspec ...string) error {
+	args := append([]string{"fetch", "--tags", upstream}, refspec...)
+	if err := execGitCmd(ctx, workingDir, nil, args...); err != nil &&
 		!strings.Contains(err.Error(), "Couldn't find remote ref") {
 		return errors.Wrap(err, fmt.Sprintf("git fetch --tags %s %s", upstream, refspec))
 	}

--- a/git/repo.go
+++ b/git/repo.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"sync"
 
 	"context"
@@ -14,253 +13,256 @@ import (
 )
 
 const (
+	interval  = 5 * time.Minute
+	opTimeout = 20 * time.Second
+
 	DefaultCloneTimeout = 2 * time.Minute
 	CheckPushTag        = "flux-write-check"
 )
 
 var (
 	ErrNoChanges = errors.New("no changes made in repo")
+	ErrNotReady  = errors.New("git repo not ready")
+	ErrNoConfig  = errors.New("git repo has not valid config")
 )
 
-// Repo represents a (remote) git repo.
+// Remote points at a git repo somewhere.
+type Remote struct {
+	URL string // clone from here
+}
+
 type Repo struct {
-	flux.GitRemoteConfig
+	// As supplied to constructor
+	origin Remote
+
+	// State
+	mu     sync.RWMutex
+	status flux.GitRepoStatus
+	err    error
+	dir    string
+
+	notify chan struct{}
+	C      chan struct{}
 }
 
-// Checkout is a local clone of the remote repo.
-type Checkout struct {
-	repo Repo
-	Dir  string
-	Config
-	realNotesRef string
-	sync.RWMutex
+// NewRepo constructs a repo mirror which will sync itself.
+func NewRepo(origin Remote) *Repo {
+	r := &Repo{
+		origin: origin,
+		status: flux.RepoNew,
+		err:    nil,
+		notify: make(chan struct{}, 1), // `1` so that Notify doesn't block
+		C:      make(chan struct{}, 1), // `1` so we don't block on completing a refresh
+	}
+	return r
 }
 
-// Config holds some values we use when working in the local copy of
-// the repo
-type Config struct {
-	SyncTag   string
-	NotesRef  string
-	UserName  string
-	UserEmail string
-	SetAuthor bool
+// Origin returns the Remote with which the Repo was constructed.
+func (r *Repo) Origin() Remote {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.origin
 }
 
-type Commit struct {
-	Revision string
-	Message  string
+// Dir returns the local directory into which the repo has been
+// cloned, if it has been cloned.
+func (r *Repo) Dir() string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.dir
 }
 
-// CommitAction - struct holding commit information
-type CommitAction struct {
-	Author  string
-	Message string
+// Status reports that readiness status of this Git repo: whether it
+// has been cloned, whether it is writable, and if not, the error
+// stopping it getting to the next state.
+func (r *Repo) Status() (flux.GitRepoStatus, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.status, r.err
 }
 
-// Get a local clone of the upstream repo, and use the config given.
-func (r Repo) Clone(ctx context.Context, c Config) (*Checkout, error) {
-	if r.URL == "" {
-		return nil, NoRepoError
-	}
-
-	workingDir, err := ioutil.TempDir(os.TempDir(), "flux-gitclone")
-	if err != nil {
-		return nil, err
-	}
-
-	repoDir, err := clone(ctx, workingDir, r.URL, r.Branch)
-	if err != nil {
-		return nil, CloningError(r.URL, err)
-	}
-
-	if err := config(ctx, repoDir, c.UserName, c.UserEmail); err != nil {
-		return nil, err
-	}
-
-	notesRef, err := getNotesRef(ctx, repoDir, c.NotesRef)
-	if err != nil {
-		return nil, err
-	}
-
-	// this fetches and updates the local ref, so we'll see notes
-	if err := fetch(ctx, repoDir, r.URL, notesRef+":"+notesRef); err != nil {
-		return nil, err
-	}
-
-	return &Checkout{
-		repo:         r,
-		Dir:          repoDir,
-		Config:       c,
-		realNotesRef: notesRef,
-	}, nil
+func (r *Repo) setStatus(s flux.GitRepoStatus, err error) {
+	r.mu.Lock()
+	r.status = s
+	r.err = err
+	r.mu.Unlock()
 }
 
-// WorkingClone makes a(nother) clone of the repository to use for
-// e.g., rewriting files, so we can keep a pristine clone for reading
-// out of.
-func (c *Checkout) WorkingClone(ctx context.Context) (*Checkout, error) {
-	c.Lock()
-	defer c.Unlock()
-	workingDir, err := ioutil.TempDir(os.TempDir(), "flux-working")
-	if err != nil {
-		return nil, err
-	}
-
-	repoDir, err := clone(ctx, workingDir, c.Dir, c.repo.Branch)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := config(ctx, repoDir, c.UserName, c.UserEmail); err != nil {
-		return nil, err
-	}
-
-	// this fetches and updates the local ref, so we'll see notes
-	if err := fetch(ctx, repoDir, c.Dir, c.realNotesRef+":"+c.realNotesRef); err != nil {
-		return nil, err
-	}
-
-	return &Checkout{
-		repo:         c.repo,
-		Dir:          repoDir,
-		Config:       c.Config,
-		realNotesRef: c.realNotesRef,
-	}, nil
-}
-
-// Clean a Checkout up (remove the clone)
-func (c *Checkout) Clean() {
-	if c.Dir != "" {
-		os.RemoveAll(c.Dir)
+// Notify tells the repo that it should fetch from the origin as soon
+// as possible. It does not block.
+func (r *Repo) Notify() {
+	select {
+	case r.notify <- struct{}{}:
+		// duly notified
+	default:
+		// notification already pending
 	}
 }
 
-// ManifestDir returns a path to where the files are
-func (c *Checkout) ManifestDir() string {
-	return filepath.Join(c.Dir, c.repo.Path)
+// Revision returns the revision (SHA1) of the ref passed in
+func (r *Repo) Revision(ctx context.Context, ref string) (string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	if r.dir == "" {
+		return "", errors.New("git repo not initialised")
+	}
+	return refRevision(ctx, r.dir, ref)
 }
 
-// CheckOriginWritable tests that we can write to the origin
-// repository; we need to be able to do this to push the sync tag, for
-// example.
-func (c *Checkout) CheckOriginWritable(ctx context.Context) error {
-	c.Lock()
-	defer c.Unlock()
-	if err := checkPush(ctx, c.Dir, c.repo.URL); err != nil {
-		return ErrUpstreamNotWritable(c.repo.URL, err)
+func (r *Repo) CommitsBefore(ctx context.Context, ref, path string) ([]Commit, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return onelinelog(ctx, r.dir, ref, path)
+}
+
+func (r *Repo) CommitsBetween(ctx context.Context, ref1, ref2, path string) ([]Commit, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return onelinelog(ctx, r.dir, ref1+".."+ref2, path)
+}
+
+// Start begins synchronising the repo by cloning it, then fetching
+// the required tags and so on.
+func (r *Repo) Start(shutdown <-chan struct{}, done *sync.WaitGroup) error {
+	defer done.Done()
+
+	for {
+
+		r.mu.RLock()
+		url := r.origin.URL
+		dir := r.dir
+		status := r.status
+		r.mu.RUnlock()
+
+		bg := context.Background()
+
+		switch status {
+
+		// TODO(michael): I don't think this is a real status; perhaps
+		// have a no-op repo instead.
+		case flux.RepoNoConfig:
+			// this is not going to change in the lifetime of this
+			// process
+			return ErrNoConfig
+		case flux.RepoNew:
+
+			rootdir, err := ioutil.TempDir(os.TempDir(), "flux-gitclone")
+			if err != nil {
+				return err
+			}
+
+			ctx, cancel := context.WithTimeout(bg, opTimeout)
+			dir, err = mirror(ctx, rootdir, url)
+			cancel()
+			if err == nil {
+				r.mu.Lock()
+				r.dir = dir
+				ctx, cancel := context.WithTimeout(bg, opTimeout)
+				err = r.fetch(ctx)
+				cancel()
+				r.mu.Unlock()
+			}
+			if err == nil {
+				r.setStatus(flux.RepoCloned, nil)
+				continue // with new status, skipping timer
+			}
+			dir = ""
+			os.RemoveAll(rootdir)
+			r.setStatus(flux.RepoNew, err)
+
+		case flux.RepoCloned:
+			ctx, cancel := context.WithTimeout(bg, opTimeout)
+			err := checkPush(ctx, dir, url)
+			cancel()
+			if err == nil {
+				r.setStatus(flux.RepoReady, nil)
+				continue // with new status, skipping timer
+			}
+			r.setStatus(flux.RepoCloned, err)
+
+		case flux.RepoReady:
+			if err := r.refreshLoop(shutdown); err != nil {
+				r.setStatus(flux.RepoNew, err)
+				continue // with new status, skipping timer
+			}
+		}
+
+		tryAgain := time.NewTimer(10 * time.Second)
+		select {
+		case <-shutdown:
+			if !tryAgain.Stop() {
+				<-tryAgain.C
+			}
+			return nil
+		case <-tryAgain.C:
+			continue
+		}
+	}
+}
+
+func (r *Repo) Refresh(ctx context.Context) error {
+	// the lock here and below is difficult to avoid; possibly we
+	// could clone to another repo and pull there, then swap when complete.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.status != flux.RepoReady {
+		return ErrNotReady
+	}
+	if err := r.fetch(ctx); err != nil {
+		return err
+	}
+	select {
+	case r.C <- struct{}{}:
+	default:
 	}
 	return nil
 }
 
-// CommitAndPush commits changes made in this checkout, along with any
-// extra data as a note, and pushes the commit and note to the remote repo.
-func (c *Checkout) CommitAndPush(ctx context.Context, commitAction *CommitAction, note *Note) error {
-	c.Lock()
-	defer c.Unlock()
-	if !check(ctx, c.Dir, c.repo.Path) {
-		return ErrNoChanges
-	}
-	if err := commit(ctx, c.Dir, commitAction); err != nil {
-		return err
-	}
-
-	if note != nil {
-		rev, err := refRevision(ctx, c.Dir, "HEAD")
-		if err != nil {
-			return err
+func (r *Repo) refreshLoop(shutdown <-chan struct{}) error {
+	gitPoll := time.NewTimer(interval)
+	for {
+		select {
+		case <-shutdown:
+			if !gitPoll.Stop() {
+				<-gitPoll.C
+			}
+			return nil
+		case <-gitPoll.C:
+			r.Notify()
+		case <-r.notify:
+			if !gitPoll.Stop() {
+				select {
+				case <-gitPoll.C:
+				default:
+				}
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), interval)
+			err := r.Refresh(ctx)
+			cancel()
+			if err != nil {
+				return err
+			}
+			gitPoll.Reset(interval)
 		}
-		if err := addNote(ctx, c.Dir, rev, c.realNotesRef, note); err != nil {
-			return err
-		}
 	}
+}
 
-	refs := []string{c.repo.Branch}
-	ok, err := refExists(ctx, c.Dir, c.realNotesRef)
-	if ok {
-		refs = append(refs, c.realNotesRef)
-	} else if err != nil {
+// fetch gets updated refs, and associated objects, from the upstream.
+func (r *Repo) fetch(ctx context.Context) error {
+	if err := fetch(ctx, r.dir, "origin"); err != nil {
 		return err
-	}
-
-	if err := push(ctx, c.Dir, c.repo.URL, refs); err != nil {
-		return PushError(c.repo.URL, err)
 	}
 	return nil
 }
 
-// GetNote gets a note for the revision specified, or nil if there is no such note.
-func (c *Checkout) GetNote(ctx context.Context, rev string) (*Note, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return getNote(ctx, c.Dir, c.realNotesRef, rev)
-}
-
-// Pull fetches the latest commits on the branch we're using, and the latest notes
-func (c *Checkout) Pull(ctx context.Context) error {
-	c.Lock()
-	defer c.Unlock()
-	if err := pull(ctx, c.Dir, c.repo.URL, c.repo.Branch); err != nil {
-		return err
+// workingClone makes a non-bare clone, at `ref` (probably a branch),
+// and returns the filesystem path to it.
+func (r *Repo) workingClone(ctx context.Context, ref string) (string, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	working, err := ioutil.TempDir(os.TempDir(), "flux-working")
+	if err != nil {
+		return "", err
 	}
-	for _, ref := range []string{
-		c.realNotesRef + ":" + c.realNotesRef,
-		c.SyncTag,
-	} {
-		// this fetches and updates the local ref, so we'll see the new
-		// notes; but it's possible that the upstream doesn't have this
-		// ref.
-		if err := fetch(ctx, c.Dir, c.repo.URL, ref); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return refRevision(ctx, c.Dir, "HEAD")
-}
-
-func (c *Checkout) TagRevision(ctx context.Context, tag string) (string, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return refRevision(ctx, c.Dir, tag)
-}
-
-func (c *Checkout) CommitsBetween(ctx context.Context, ref1, ref2 string) ([]Commit, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return onelinelog(ctx, c.Dir, ref1+".."+ref2, c.repo.GitRemoteConfig.Path)
-}
-
-func (c *Checkout) CommitsBefore(ctx context.Context, ref string) ([]Commit, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return onelinelog(ctx, c.Dir, ref, c.repo.GitRemoteConfig.Path)
-}
-
-func (c *Checkout) MoveTagAndPush(ctx context.Context, ref, msg string) error {
-	c.Lock()
-	defer c.Unlock()
-	return moveTagAndPush(ctx, c.Dir, c.SyncTag, ref, msg, c.repo.URL)
-}
-
-// ChangedFiles does a git diff listing changed files
-func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, error) {
-	c.Lock()
-	defer c.Unlock()
-	list, err := changedFiles(ctx, c.Dir, c.repo.Path, ref)
-	if err == nil {
-		for i, file := range list {
-			list[i] = filepath.Join(c.Dir, file)
-		}
-	}
-	return list, err
-}
-
-func (c *Checkout) NoteRevList(ctx context.Context) (map[string]struct{}, error) {
-	c.Lock()
-	defer c.Unlock()
-	return noteRevList(ctx, c.Dir, c.realNotesRef)
+	return clone(ctx, working, r.dir, ref)
 }

--- a/git/working.go
+++ b/git/working.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-	"sync"
 )
 
 // Config holds some values we use when working in the working clone of
@@ -19,14 +18,14 @@ type Config struct {
 	SetAuthor bool
 }
 
-// Checkout is a local working clone of the remote repo.
+// Checkout is a local working clone of the remote repo. It is
+// intended to be used for one-off "transactions", e.g,. committing
+// changes then pushing upstream. It has no locking.
 type Checkout struct {
-	Dir string
-	Config
-
+	dir          string
+	config       Config
 	upstream     Remote
 	realNotesRef string // cache the notes ref, since we use it to push as well
-	sync.RWMutex        // the release code at least needs to lock/unlock the checkout
 }
 
 type Commit struct {
@@ -71,56 +70,54 @@ func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
 	r.mu.RUnlock()
 
 	return &Checkout{
+		dir:          repoDir,
 		upstream:     upstream,
 		realNotesRef: realNotesRef,
-		Dir:          repoDir,
-		Config:       conf,
+		config:       conf,
 	}, nil
 }
 
 // Clean a Checkout up (remove the clone)
 func (c *Checkout) Clean() {
-	if c.Dir != "" {
-		os.RemoveAll(c.Dir)
+	if c.dir != "" {
+		os.RemoveAll(c.dir)
 	}
 }
 
 // ManifestDir returns a path to where the files are
 func (c *Checkout) ManifestDir() string {
-	return filepath.Join(c.Dir, c.Config.Path)
+	return filepath.Join(c.dir, c.config.Path)
 }
 
 // CommitAndPush commits changes made in this checkout, along with any
 // extra data as a note, and pushes the commit and note to the remote repo.
 func (c *Checkout) CommitAndPush(ctx context.Context, commitAction *CommitAction, note *Note) error {
-	c.Lock()
-	defer c.Unlock()
-	if !check(ctx, c.Dir, c.Config.Path) {
+	if !check(ctx, c.dir, c.config.Path) {
 		return ErrNoChanges
 	}
-	if err := commit(ctx, c.Dir, commitAction); err != nil {
+	if err := commit(ctx, c.dir, commitAction); err != nil {
 		return err
 	}
 
 	if note != nil {
-		rev, err := refRevision(ctx, c.Dir, "HEAD")
+		rev, err := refRevision(ctx, c.dir, "HEAD")
 		if err != nil {
 			return err
 		}
-		if err := addNote(ctx, c.Dir, rev, c.Config.NotesRef, note); err != nil {
+		if err := addNote(ctx, c.dir, rev, c.config.NotesRef, note); err != nil {
 			return err
 		}
 	}
 
-	refs := []string{c.Config.Branch}
-	ok, err := refExists(ctx, c.Dir, c.realNotesRef)
+	refs := []string{c.config.Branch}
+	ok, err := refExists(ctx, c.dir, c.realNotesRef)
 	if ok {
 		refs = append(refs, c.realNotesRef)
 	} else if err != nil {
 		return err
 	}
 
-	if err := push(ctx, c.Dir, c.upstream.URL, refs); err != nil {
+	if err := push(ctx, c.dir, c.upstream.URL, refs); err != nil {
 		return PushError(c.upstream.URL, err)
 	}
 	return nil
@@ -128,44 +125,32 @@ func (c *Checkout) CommitAndPush(ctx context.Context, commitAction *CommitAction
 
 // GetNote gets a note for the revision specified, or nil if there is no such note.
 func (c *Checkout) GetNote(ctx context.Context, rev string) (*Note, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return getNote(ctx, c.Dir, c.realNotesRef, rev)
+	return getNote(ctx, c.dir, c.realNotesRef, rev)
 }
 
 func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return refRevision(ctx, c.Dir, "HEAD")
+	return refRevision(ctx, c.dir, "HEAD")
 }
 
 func (c *Checkout) SyncRevision(ctx context.Context) (string, error) {
-	c.RLock()
-	defer c.RUnlock()
-	return refRevision(ctx, c.Dir, c.SyncTag)
+	return refRevision(ctx, c.dir, c.config.SyncTag)
 }
 
-func (c *Checkout) MoveTagAndPush(ctx context.Context, ref, msg string) error {
-	c.Lock()
-	defer c.Unlock()
-	return moveTagAndPush(ctx, c.Dir, c.SyncTag, ref, msg, c.upstream.URL)
+func (c *Checkout) MoveSyncTagAndPush(ctx context.Context, ref, msg string) error {
+	return moveTagAndPush(ctx, c.dir, c.config.SyncTag, ref, msg, c.upstream.URL)
 }
 
 // ChangedFiles does a git diff listing changed files
 func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, error) {
-	c.Lock()
-	defer c.Unlock()
-	list, err := changedFiles(ctx, c.Dir, c.Config.Path, ref)
+	list, err := changedFiles(ctx, c.dir, c.config.Path, ref)
 	if err == nil {
 		for i, file := range list {
-			list[i] = filepath.Join(c.Dir, file)
+			list[i] = filepath.Join(c.dir, file)
 		}
 	}
 	return list, err
 }
 
 func (c *Checkout) NoteRevList(ctx context.Context) (map[string]struct{}, error) {
-	c.Lock()
-	defer c.Unlock()
-	return noteRevList(ctx, c.Dir, c.realNotesRef)
+	return noteRevList(ctx, c.dir, c.realNotesRef)
 }

--- a/git/working.go
+++ b/git/working.go
@@ -1,0 +1,171 @@
+package git
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Config holds some values we use when working in the working clone of
+// a repo.
+type Config struct {
+	Branch    string // branch we're syncing to
+	Path      string // path within the repo containing files we care about
+	SyncTag   string
+	NotesRef  string
+	UserName  string
+	UserEmail string
+	SetAuthor bool
+}
+
+// Checkout is a local working clone of the remote repo.
+type Checkout struct {
+	Dir string
+	Config
+
+	upstream     Remote
+	realNotesRef string // cache the notes ref, since we use it to push as well
+	sync.RWMutex        // the release code at least needs to lock/unlock the checkout
+}
+
+type Commit struct {
+	Revision string
+	Message  string
+}
+
+// CommitAction - struct holding commit information
+type CommitAction struct {
+	Author  string
+	Message string
+}
+
+// Clone returns a local working clone of the sync'ed `*Repo`, using
+// the config given.
+func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
+	upstream := r.Origin()
+	repoDir, err := r.workingClone(ctx, conf.Branch)
+	if err != nil {
+		return nil, CloningError(upstream.URL, err)
+	}
+
+	if err := config(ctx, repoDir, conf.UserName, conf.UserEmail); err != nil {
+		os.RemoveAll(repoDir)
+		return nil, err
+	}
+
+	// We'll need the notes ref for pushing it, so make sure we have
+	// it. This assumes we're syncing it (otherwise we'll likely get conflicts)
+	realNotesRef, err := getNotesRef(ctx, repoDir, conf.NotesRef)
+	if err != nil {
+		os.RemoveAll(repoDir)
+		return nil, err
+	}
+
+	r.mu.RLock()
+	if err := fetch(ctx, repoDir, r.dir, realNotesRef+":"+realNotesRef); err != nil {
+		os.RemoveAll(repoDir)
+		r.mu.RUnlock()
+		return nil, err
+	}
+	r.mu.RUnlock()
+
+	return &Checkout{
+		upstream:     upstream,
+		realNotesRef: realNotesRef,
+		Dir:          repoDir,
+		Config:       conf,
+	}, nil
+}
+
+// Clean a Checkout up (remove the clone)
+func (c *Checkout) Clean() {
+	if c.Dir != "" {
+		os.RemoveAll(c.Dir)
+	}
+}
+
+// ManifestDir returns a path to where the files are
+func (c *Checkout) ManifestDir() string {
+	return filepath.Join(c.Dir, c.Config.Path)
+}
+
+// CommitAndPush commits changes made in this checkout, along with any
+// extra data as a note, and pushes the commit and note to the remote repo.
+func (c *Checkout) CommitAndPush(ctx context.Context, commitAction *CommitAction, note *Note) error {
+	c.Lock()
+	defer c.Unlock()
+	if !check(ctx, c.Dir, c.Config.Path) {
+		return ErrNoChanges
+	}
+	if err := commit(ctx, c.Dir, commitAction); err != nil {
+		return err
+	}
+
+	if note != nil {
+		rev, err := refRevision(ctx, c.Dir, "HEAD")
+		if err != nil {
+			return err
+		}
+		if err := addNote(ctx, c.Dir, rev, c.Config.NotesRef, note); err != nil {
+			return err
+		}
+	}
+
+	refs := []string{c.Config.Branch}
+	ok, err := refExists(ctx, c.Dir, c.realNotesRef)
+	if ok {
+		refs = append(refs, c.realNotesRef)
+	} else if err != nil {
+		return err
+	}
+
+	if err := push(ctx, c.Dir, c.upstream.URL, refs); err != nil {
+		return PushError(c.upstream.URL, err)
+	}
+	return nil
+}
+
+// GetNote gets a note for the revision specified, or nil if there is no such note.
+func (c *Checkout) GetNote(ctx context.Context, rev string) (*Note, error) {
+	c.RLock()
+	defer c.RUnlock()
+	return getNote(ctx, c.Dir, c.realNotesRef, rev)
+}
+
+func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
+	c.RLock()
+	defer c.RUnlock()
+	return refRevision(ctx, c.Dir, "HEAD")
+}
+
+func (c *Checkout) TagRevision(ctx context.Context, tag string) (string, error) {
+	c.RLock()
+	defer c.RUnlock()
+	return refRevision(ctx, c.Dir, tag)
+}
+
+func (c *Checkout) MoveTagAndPush(ctx context.Context, ref, msg string) error {
+	c.Lock()
+	defer c.Unlock()
+	return moveTagAndPush(ctx, c.Dir, c.Config.SyncTag, ref, msg, c.upstream.URL)
+}
+
+// ChangedFiles does a git diff listing changed files
+func (c *Checkout) ChangedFiles(ctx context.Context, ref string) ([]string, error) {
+	c.Lock()
+	defer c.Unlock()
+	list, err := changedFiles(ctx, c.Dir, c.Config.Path, ref)
+	if err == nil {
+		for i, file := range list {
+			list[i] = filepath.Join(c.Dir, file)
+		}
+	}
+	return list, err
+}
+
+func (c *Checkout) NoteRevList(ctx context.Context) (map[string]struct{}, error) {
+	c.Lock()
+	defer c.Unlock()
+	return noteRevList(ctx, c.Dir, c.realNotesRef)
+}

--- a/git/working.go
+++ b/git/working.go
@@ -139,16 +139,16 @@ func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
 	return refRevision(ctx, c.Dir, "HEAD")
 }
 
-func (c *Checkout) TagRevision(ctx context.Context, tag string) (string, error) {
+func (c *Checkout) SyncRevision(ctx context.Context) (string, error) {
 	c.RLock()
 	defer c.RUnlock()
-	return refRevision(ctx, c.Dir, tag)
+	return refRevision(ctx, c.Dir, c.SyncTag)
 }
 
 func (c *Checkout) MoveTagAndPush(ctx context.Context, ref, msg string) error {
 	c.Lock()
 	defer c.Unlock()
-	return moveTagAndPush(ctx, c.Dir, c.Config.SyncTag, ref, msg, c.upstream.URL)
+	return moveTagAndPush(ctx, c.Dir, c.SyncTag, ref, msg, c.upstream.URL)
 }
 
 // ChangedFiles does a git diff listing changed files

--- a/release/context.go
+++ b/release/context.go
@@ -39,8 +39,6 @@ func (rc *ReleaseContext) Manifests() cluster.Manifests {
 }
 
 func (rc *ReleaseContext) WriteUpdates(updates []*update.ControllerUpdate) error {
-	rc.repo.Lock()
-	defer rc.repo.Unlock()
 	err := func() error {
 		for _, update := range updates {
 			fi, err := os.Stat(update.ManifestPath)
@@ -121,8 +119,6 @@ func (rc *ReleaseContext) SelectServices(results update.Result, prefilters, post
 }
 
 func (rc *ReleaseContext) FindDefinedServices() (map[flux.ResourceID]*update.ControllerUpdate, error) {
-	rc.repo.RLock()
-	defer rc.repo.RUnlock()
 	services, err := rc.manifests.FindDefinedServices(rc.repo.ManifestDir())
 	if err != nil {
 		return nil, err
@@ -150,7 +146,5 @@ func (rc *ReleaseContext) FindDefinedServices() (map[flux.ResourceID]*update.Con
 
 // Shortcut for this
 func (rc *ReleaseContext) ServicesWithPolicies() (policy.ResourceMap, error) {
-	rc.repo.RLock()
-	defer rc.repo.RUnlock()
 	return rc.manifests.ServicesWithPolicies(rc.repo.ManifestDir())
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -188,20 +188,7 @@ var gitconf = git.Config{
 }
 
 func setup(t *testing.T) (*git.Checkout, func()) {
-	// All the mocks, mockity mock.
-	repo, cleanupRepo := gittest.Repo(t)
-
-	// Clone the repo so we can mess with the files
-	working, err := repo.Clone(context.Background(), gitconf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	cleanup := func() {
-		cleanupRepo()
-		working.Clean()
-	}
-
-	return working, cleanup
+	return gittest.Checkout(t)
 }
 
 func execCommand(cmd string, args ...string) error {


### PR DESCRIPTION
To ease the transition into supporting zero git repos, and later supporting more than one repo, this PR moves the periodic `git fetch` loop into the git package.

The effect is to make a git repo a state machine; it starts uncloned, then is mirrored, and finally tested to see if it's writable. Treating it as a state machine has a couple of benefits:

 1. We will be better able to cope with intermediate states -- for example, to give results that don't need write access when we don't have write access. This will matter the more so when we're dealing with more than one repo.
 2. It decouples the git repo polling from the daemon's "main loop", so not as many things are rolled up in the one place.

This PR doesn't change how the daemon works, in the main -- it will still wait for the repo to be ready before proceeding. To support zero git repos, we can remove that gate and respond to each API method by checking whether there's a git repo ready or not, and acting accordingly.

Tasting notes:
 * there's still a need for the git mirror to tell the daemon that there are fresh commits; and for the daemon to tell the git mirror that it has pushed something upstream. These are accomplished with a non-blocking channel send in each direction.
 * there's also a synchronous `*Repo.Refresh(...)` for when the daemon needs to wait for the repo to be up to date before proceeding.
 * the `Repo` is a mirror, which means it doesn't have a working directory to look around in; the downside is you have to clone it every time you want to look at the files (a cache could be done in the daemon loop, if necessary). The upside (aside from some convenience in the git operations) is that there's no confusion over which things you can write to -- if you want to make a commit, you have to clone first.
