### PR TITLE
Downgrade non-specific errors to application-level

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -78,9 +78,9 @@ func (e *Error) UnmarshalJSON(data []byte) error {
 
 func CoverAllError(err error) *Error {
 	return &Error{
-		Type: Server,
+		Type: User,
 		Err:  err,
-		Help: `Internal error: ` + err.Error() + `
+		Help: `Error: ` + err.Error() + `
 
 We don't have a specific help message for the error above.
 


### PR DESCRIPTION
Usually we try to provide a helpful error message, by wrapping it in
our own `Error` struct, if something has gone wrong which can be fixed
by the intervention of the user.

If we see an error that hasn't been wrapped in this struct, as a last
resort, the HTTP API wraps it with a cover-all message. These are
translated to a "500 Internal Server Error" status.

However, since new code brings with it new errors, mostly not
accompanied by help text, which means many quite common scenarios (no
git config provided, for example) result in a cover-all error and
therefore a 500 status code. In light of this it is better to reverse
the default, and treat unwrapped errors as application-level unless
explicitly marked as internal errors.