### PR TITLE
CLI help cleanup

### DIFF
--- a/cmd/fluxctl/automate_cmd.go
+++ b/cmd/fluxctl/automate_cmd.go
@@ -26,7 +26,7 @@ func (opts *controllerAutomateOpts) Command() *cobra.Command {
 		Use:   "automate",
 		Short: "Turn on automatic deployment for a controller.",
 		Example: makeExample(
-			"fluxctl automate --controller=deployment/helloworld",
+			"fluxctl automate --controller=default:deployment/helloworld",
 		),
 		RunE: opts.RunE,
 	}

--- a/cmd/fluxctl/deautomate_cmd.go
+++ b/cmd/fluxctl/deautomate_cmd.go
@@ -26,7 +26,7 @@ func (opts *controllerDeautomateOpts) Command() *cobra.Command {
 		Use:   "deautomate",
 		Short: "Turn off automatic deployment for a controller.",
 		Example: makeExample(
-			"fluxctl deautomate --controller=deployment/helloworld",
+			"fluxctl deautomate --controller=default:deployment/helloworld",
 		),
 		RunE: opts.RunE,
 	}

--- a/cmd/fluxctl/lock_cmd.go
+++ b/cmd/fluxctl/lock_cmd.go
@@ -26,7 +26,7 @@ func (opts *controllerLockOpts) Command() *cobra.Command {
 		Use:   "lock",
 		Short: "Lock a controller, so it cannot be deployed.",
 		Example: makeExample(
-			"fluxctl lock --controller=deployment/helloworld",
+			"fluxctl lock --controller=default:deployment/helloworld",
 		),
 		RunE: opts.RunE,
 	}

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -48,10 +48,10 @@ If both --tag-all and --tag are specified, --tag-all will apply to all
 containers which aren't explicitly named.
         `,
 		Example: makeExample(
-			"fluxctl policy --controller=deployment/foo --automate",
-			"fluxctl policy --controller=deployment/foo --lock",
-			"fluxctl policy --controller=deployment/foo --tag='bar=1.*' --tag='baz=2.*'",
-			"fluxctl policy --controller=deployment/foo --tag-all='master-*' --tag='bar=1.*'",
+			"fluxctl policy --controller=default:deployment/foo --automate",
+			"fluxctl policy --controller=default:deployment/foo --lock",
+			"fluxctl policy --controller=default:deployment/foo --tag='bar=1.*' --tag='baz=2.*'",
+			"fluxctl policy --controller=default:deployment/foo --tag-all='master-*' --tag='bar=1.*'",
 		),
 		RunE: opts.RunE,
 	}

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -44,16 +44,16 @@ func (opts *controllerReleaseOpts) Command() *cobra.Command {
 
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "controller namespace")
-	cmd.Flags().StringSliceVarP(&opts.controllers, "controller", "c", []string{}, "list of controllers to release <namespace>:<kind>/<name>")
-	cmd.Flags().BoolVar(&opts.allControllers, "all", false, "release all controllers")
-	cmd.Flags().StringVarP(&opts.image, "update-image", "i", "", "update a specific image")
-	cmd.Flags().BoolVar(&opts.allImages, "update-all-images", false, "update all images to latest versions")
-	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "list of controllers to exclude <namespace>:<kind>/<name>")
-	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "do not release anything; just report back what would have been done")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Controller namespace")
+	cmd.Flags().StringSliceVarP(&opts.controllers, "controller", "c", []string{}, "List of controllers to release <namespace>:<kind>/<name>")
+	cmd.Flags().BoolVar(&opts.allControllers, "all", false, "Release all controllers")
+	cmd.Flags().StringVarP(&opts.image, "update-image", "i", "", "Update a specific image")
+	cmd.Flags().BoolVar(&opts.allImages, "update-all-images", false, "Update all images to latest versions")
+	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "List of controllers to exclude")
+	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Do not release anything; just report back what would have been done")
 
 	// Deprecated
-	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", []string{}, "service to release")
+	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", []string{}, "Service to release")
 	cmd.Flags().MarkHidden("service")
 
 	return cmd

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -45,11 +45,11 @@ func (opts *controllerReleaseOpts) Command() *cobra.Command {
 	AddOutputFlags(cmd, &opts.outputOpts)
 	AddCauseFlags(cmd, &opts.cause)
 	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "controller namespace")
-	cmd.Flags().StringSliceVarP(&opts.controllers, "controller", "c", []string{}, "list of controllers to release <kind>/<name>")
+	cmd.Flags().StringSliceVarP(&opts.controllers, "controller", "c", []string{}, "list of controllers to release <namespace>:<kind>/<name>")
 	cmd.Flags().BoolVar(&opts.allControllers, "all", false, "release all controllers")
 	cmd.Flags().StringVarP(&opts.image, "update-image", "i", "", "update a specific image")
 	cmd.Flags().BoolVar(&opts.allImages, "update-all-images", false, "update all images to latest versions")
-	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "exclude a controller")
+	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "list of controllers to exclude <namespace>:<kind>/<name>")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "do not release anything; just report back what would have been done")
 
 	// Deprecated

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -31,9 +31,9 @@ var rootLongHelp = strings.TrimSpace(`
 fluxctl helps you deploy your code.
 
 Workflow:
-  fluxctl list-controllers                                           # Which controllers are running?
-  fluxctl list-images --controller=deployment/foo                    # Which images are running/available?
-  fluxctl release --controller=deployment/foo --update-image=bar:v2  # Release new version.
+  fluxctl list-controllers                                                   # Which controllers are running?
+  fluxctl list-images --controller=default:deployment/foo                    # Which images are running/available?
+  fluxctl release --controller=default:deployment/foo --update-image=bar:v2  # Release new version.
 `)
 
 const (

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -51,7 +51,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		PersistentPreRunE: opts.PersistentPreRunE,
 	}
 	cmd.PersistentFlags().StringVarP(&opts.URL, "url", "u", "https://cloud.weave.works/api/flux",
-		fmt.Sprintf("base URL of the flux service; you can also set the environment variable %s", envVariableURL))
+		fmt.Sprintf("Base URL of the flux service; you can also set the environment variable %s", envVariableURL))
 	cmd.PersistentFlags().StringVarP(&opts.Token, "token", "t", "",
 		fmt.Sprintf("Weave Cloud service token; you can also set the environment variable %s or %s", envVariableCloudToken, envVariableToken))
 

--- a/cmd/fluxctl/save_cmd.go
+++ b/cmd/fluxctl/save_cmd.go
@@ -32,7 +32,7 @@ func (opts *saveOpts) Command() *cobra.Command {
 		),
 		RunE: opts.RunE,
 	}
-	cmd.Flags().StringVarP(&opts.path, "out", "o", "-", "output path for exported config; the default. '-' indicates stdout; if a directory is given, each item will be saved in a file under the directory")
+	cmd.Flags().StringVarP(&opts.path, "out", "o", "-", "Output path for exported config; the default. '-' indicates stdout; if a directory is given, each item will be saved in a file under the directory")
 	return cmd
 }
 

--- a/cmd/fluxctl/unlock_cmd.go
+++ b/cmd/fluxctl/unlock_cmd.go
@@ -26,7 +26,7 @@ func (opts *controllerUnlockOpts) Command() *cobra.Command {
 		Use:   "unlock",
 		Short: "Unlock a controller, so it can be deployed.",
 		Example: makeExample(
-			"fluxctl unlock --controller=deployment/helloworld",
+			"fluxctl unlock --controller=default:deployment/helloworld",
 		),
 		RunE: opts.RunE,
 	}

--- a/update/release.go
+++ b/update/release.go
@@ -29,7 +29,7 @@ type ReleaseType string
 
 const (
 	ReleaseKindPlan    ReleaseKind = "plan"
-	ReleaseKindExecute             = "execute"
+	ReleaseKindExecute ReleaseKind = "execute"
 )
 
 func ParseReleaseKind(s string) (ReleaseKind, error) {


### PR DESCRIPTION
This PR cleans up the CLI help text to use the new namespace:kind/name format. It also uppercases `release` help descriptions for consistency. Additionally, it fixes the type of the `ReleaseKindExecute` constant.