### PR TITLE
Tidy CircleCI build re NATS, dep, git version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,14 +4,13 @@ jobs:
     working_directory: /go/src/github.com/weaveworks/flux
     docker:
       - image: circleci/golang:1.8
-      - image: nats
       - image: memcached
     steps:
       - checkout
       - setup_remote_docker
 
       - run: go get github.com/golang/dep/cmd/dep
-      - run: dep ensure
+      - run: dep ensure -vendor-only
       - run: make test TEST_FLAGS="-race -tags integration -timeout 30s"
       - run: make all
 

--- a/git/operations.go
+++ b/git/operations.go
@@ -52,7 +52,7 @@ func checkPush(ctx context.Context, workingDir, upstream string) error {
 	if err := execGitCmd(ctx, workingDir, nil, "push", "--force", upstream, "tag", CheckPushTag); err != nil {
 		return errors.Wrap(err, "attempt to push tag")
 	}
-	return execGitCmd(ctx, workingDir, nil, "push", "-d", upstream, "tag", CheckPushTag)
+	return execGitCmd(ctx, workingDir, nil, "push", "--delete", upstream, "tag", CheckPushTag)
 }
 
 func commit(ctx context.Context, workingDir string, commitAction *CommitAction) error {

--- a/git/operations_test.go
+++ b/git/operations_test.go
@@ -206,6 +206,24 @@ func TestOnelinelog_WithGitpath(t *testing.T) {
 	}
 }
 
+func TestCheckPush(t *testing.T) {
+	upstreamDir, upstreamCleanup := testfiles.TempDir(t)
+	defer upstreamCleanup()
+	err := createRepo(upstreamDir, []string{"config"})
+
+	cloneDir, cloneCleanup := testfiles.TempDir(t)
+	defer cloneCleanup()
+
+	working, err := clone(context.Background(), cloneDir, upstreamDir, "master")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = checkPush(context.Background(), working, upstreamDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func createRepo(dir string, subdirs []string) error {
 	var (
 		err      error


### PR DESCRIPTION
 * Remove mention of NATS, which migrated a while ago
 * Use `dep ensure -vendor-only` so binaries are built with what's specified in `Gopkg.lock`

And slightly obliquely,
 * Use an older form of `git push`, since we use an image with an older git, in CircleCI
