### PR TITLE
Make sure the given route exists before trying to build a URL

### DIFF
--- a/http/transport.go
+++ b/http/transport.go
@@ -71,8 +71,11 @@ func MakeURL(endpoint string, router *mux.Router, routeName string, urlParams ..
 	if err != nil {
 		return nil, errors.Wrapf(err, "parsing endpoint %s", endpoint)
 	}
-
-	routeURL, err := router.Get(routeName).URLPath()
+	route := router.Get(routeName)
+	if route == nil {
+		return nil, errors.New("no route with name " + routeName)
+	}
+	routeURL, err := route.URLPath()
 	if err != nil {
 		return nil, errors.Wrapf(err, "retrieving route path %s", routeName)
 	}


### PR DESCRIPTION
I noticed that this bit of code has the potential to panic because `router.Get` returns nil, rather than an error, when the named route doesn't exist.