### PR TITLE
[WIP] Support releasing all controllers in namespace

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -38,6 +38,7 @@ func (opts *controllerReleaseOpts) Command() *cobra.Command {
 			"fluxctl release -n default --controller=deployment/foo --update-image=library/hello:v2",
 			"fluxctl release --all --update-image=library/hello:v2",
 			"fluxctl release --controller=default:deployment/foo --update-all-images",
+			"fluxctl release --controller=default:deployment/*,other:deployment/* --update--all-images",
 		),
 		RunE: opts.RunE,
 	}
@@ -122,9 +123,9 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 	}
 
 	if opts.dryRun {
-		fmt.Fprintf(cmd.OutOrStderr(), "Submitting dry-run release...\n")
+		fmt.Fprint(cmd.OutOrStderr(), "Submitting dry-run release...\n")
 	} else {
-		fmt.Fprintf(cmd.OutOrStderr(), "Submitting release ...\n")
+		fmt.Fprint(cmd.OutOrStderr(), "Submitting release ...\n")
 	}
 
 	ctx := context.Background()

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -81,11 +81,15 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		controllers = []update.ResourceSpec{update.ResourceSpecAll}
 	} else {
 		for _, controller := range opts.controllers {
-			id, err := flux.ParseResourceIDOptionalNamespace(opts.namespace, controller)
-			if err != nil {
-				return err
+			if ns := update.ParseResourceSpecNamespace(controller); ns != "" {
+				controllers = append(controllers, update.MakeResourceSpecNamespace(ns))
+			} else {
+				id, err := flux.ParseResourceIDOptionalNamespace(opts.namespace, controller)
+				if err != nil {
+					return err
+				}
+				controllers = append(controllers, update.MakeResourceSpec(id))
 			}
-			controllers = append(controllers, update.MakeResourceSpec(id))
 		}
 	}
 

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -81,8 +81,8 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		controllers = []update.ResourceSpec{update.ResourceSpecAll}
 	} else {
 		for _, controller := range opts.controllers {
-			if ns := update.ParseResourceSpecNamespace(controller); ns != "" {
-				controllers = append(controllers, update.MakeResourceSpecNamespace(ns))
+			if ns, kind := update.ParseResourceSpecNamespace(controller); ns != "" {
+				controllers = append(controllers, update.MakeResourceSpecNamespace(ns, kind))
 			} else {
 				id, err := flux.ParseResourceIDOptionalNamespace(opts.namespace, controller)
 				if err != nil {

--- a/update/filter.go
+++ b/update/filter.go
@@ -8,6 +8,7 @@ import (
 const (
 	Locked          = "locked"
 	NotIncluded     = "not included"
+	OtherNamespace  = "other namespace"
 	Excluded        = "excluded"
 	DifferentImage  = "a different image"
 	NotInCluster    = "not running in cluster"
@@ -90,4 +91,19 @@ func (f *LockedFilter) Filter(u ControllerUpdate) ControllerResult {
 		}
 	}
 	return ControllerResult{}
+}
+
+type NamespaceFilter struct {
+	Namespace string
+}
+
+func (f *NamespaceFilter) Filter(u ControllerUpdate) ControllerResult {
+	ns, _, _ := u.ResourceID.Components()
+	if ns == f.Namespace {
+		return ControllerResult{}
+	}
+	return ControllerResult{
+		Status: ReleaseStatusIgnored,
+		Error:  OtherNamespace,
+	}
 }

--- a/update/release.go
+++ b/update/release.go
@@ -127,6 +127,10 @@ func (s ReleaseSpec) filters(rc ReleaseContext) ([]ControllerFilter, []Controlle
 			ids = []flux.ResourceID{}
 			break
 		}
+		if ns := ParseResourceSpecNamespace(string(s)); ns != "" {
+			prefilters = append(prefilters, &NamespaceFilter{Namespace: ns})
+			break
+		}
 		id, err := flux.ParseResourceID(string(s))
 		if err != nil {
 			return nil, nil, err
@@ -297,6 +301,18 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 }
 
 type ResourceSpec string // ResourceID or "<all>"
+
+func MakeResourceSpecNamespace(namespace string) ResourceSpec {
+	return ResourceSpec(fmt.Sprintf("%s/*", namespace))
+}
+
+func ParseResourceSpecNamespace(s string) string {
+	if strings.HasSuffix(s, "/*") {
+		return s[0 : len(s)-2]
+	}
+
+	return ""
+}
 
 func ParseResourceSpec(s string) (ResourceSpec, error) {
 	if s == string(ResourceSpecAll) {

--- a/update/service_test.go
+++ b/update/service_test.go
@@ -1,0 +1,97 @@
+package update_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/update"
+)
+
+func TestControllerUpdate_Filter(t *testing.T) {
+	include, _ := flux.ParseResourceID("ns:kind/include")
+	exclude, _ := flux.ParseResourceID("ns:kind/exclude")
+	locked, _ := flux.ParseResourceID("ns:kind/locked")
+	unknown, _ := flux.ParseResourceID("ns:kind/unknown")
+	fs := []update.ControllerFilter{
+		&update.IncludeFilter{IDs: []flux.ResourceID{include, locked}},
+		&update.ExcludeFilter{IDs: []flux.ResourceID{exclude}},
+		&update.LockedFilter{IDs: []flux.ResourceID{locked}},
+	}
+
+	{ // include
+		u := &update.ControllerUpdate{ResourceID: include}
+		res := u.Filter(fs...)
+		assert.Equal(t, update.ControllerResult{}, res)
+	}
+	{ // exclude
+		u := &update.ControllerUpdate{ResourceID: exclude}
+		res := u.Filter(fs...)
+		assert.Equal(t, update.ControllerResult{
+			Status: "ignored",
+			Error: "not included",
+		}, res)
+	}
+	{ // not mentioned
+		u := &update.ControllerUpdate{ResourceID: unknown}
+		res := u.Filter(fs...)
+		assert.Equal(t, update.ControllerResult{
+			Status: "ignored",
+			Error: "not included",
+		}, res)
+	}
+	{ // locked
+		u := &update.ControllerUpdate{ResourceID: locked}
+		res := u.Filter(fs...)
+		assert.Equal(t, update.ControllerResult{
+			Status: "skipped",
+			Error: "locked",
+		}, res)
+
+	}
+}
+
+func TestControllerUpdate_NamespacesFilter(t *testing.T) {
+	id, _ := flux.ParseResourceID("ns:kind/one")
+
+	{ // single namespace filter
+		nsf := &update.NamespacesFilter{}
+		nsf.Add("ns", "kind")
+		fs := []update.ControllerFilter{nsf}
+
+		u := &update.ControllerUpdate{ResourceID: id}
+		res := u.Filter(fs...)
+		assert.Equal(t, update.ControllerResult{}, res)
+	}
+	{ // multi namespace filter
+		nsf := &update.NamespacesFilter{}
+		nsf.Add("ns", "kind")
+		nsf.Add("ns2", "kind")
+		fs := []update.ControllerFilter{nsf}
+
+		u := &update.ControllerUpdate{ResourceID: id}
+		res := u.Filter(fs...)
+		assert.Equal(t, update.ControllerResult{}, res)
+	}
+}
+
+func TestControllerUpdate_IncludeFilter(t *testing.T) {
+	{ // match
+		id, _ := flux.ParseResourceID("ns:kind/name")
+		u := &update.ControllerUpdate{ResourceID: id}
+		res := u.Filter(&update.IncludeFilter{IDs: []flux.ResourceID{id}})
+		assert.Empty(t, res.Error)
+	}
+	{ // no match
+		id, _ := flux.ParseResourceID("ns:kind/name")
+		filtered := []flux.ResourceID{
+			flux.MakeResourceID("nsX", "kind", "name"),
+			flux.MakeResourceID("ns", "kindX", "name"),
+			flux.MakeResourceID("ns", "kind", "nameX"),
+		}
+		u := &update.ControllerUpdate{ResourceID: id}
+		res := u.Filter(&update.IncludeFilter{IDs: filtered})
+		assert.NotEmpty(t, res.Error)
+	}
+}


### PR DESCRIPTION
While trying to get familiar with the source, I took #902 as a chance to figure out how things work.
With #959 in mind, I started adding a wildcard controller spec that allows filtering by namespace.

This is a work in progress and before I continue the todos listed below I'd appreciate to get some input.
/cc @squaremo @sambooo 

---
This currently allows using `release --controller=foo/*` as a means to
only deploy controllers in the given namespace.

TODOs

- [x] also support `kind` filter `--controller=foo:deployment/*`
- [x] tests
- [x] cli help examples
- add support to other commands (list-images, ...) [other PR]
- expand other cli args to support format (`--exclude`) [other PR]