### PR TITLE
Fix incorrect Errorf calls

### DIFF
--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -307,6 +307,6 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 	} else if len(revs) <= 0 {
 		t.Errorf("Should have moved sync tag forward")
 	} else if revs[len(revs)-1].Revision != newRevision {
-		t.Errorf("Should have moved sync tag to HEAD (%s), but was moved to: %s")
+		t.Errorf("Should have moved sync tag to HEAD (%s), but was moved to: %s", newRevision, revs[len(revs)-1].Revision)
 	}
 }

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -226,6 +226,6 @@ func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.Upst
 		t.Error(err)
 	}
 	if !reflect.DeepEqual(mock.SyncStatusAnswer, syncSt) {
-		t.Error(fmt.Errorf("expected: %#v\ngot: %#v"), mock.SyncStatusAnswer, syncSt)
+		t.Errorf("expected: %#v\ngot: %#v", mock.SyncStatusAnswer, syncSt)
 	}
 }


### PR DESCRIPTION
Running `make test` after upgrading from Go 1.9 to 1.10 causes it to complain
about these. I guess we didn't notice before because the tests kept passing.