### PR TITLE
Fix failure to complete syncing due to --git-path

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -84,7 +84,9 @@ func (d *Daemon) Loop(stop chan struct{}, wg *sync.WaitGroup, logger log.Logger)
 				default:
 				}
 			}
-			d.doSync(logger)
+			if err := d.doSync(logger); err != nil {
+				logger.Log("err", err)
+			}
 			syncTimer.Reset(d.SyncInterval)
 		case <-syncTimer.C:
 			d.AskForSync()

--- a/git/operations.go
+++ b/git/operations.go
@@ -16,6 +16,9 @@ import (
 	"github.com/pkg/errors"
 )
 
+// If true, every git invocation will be echoed to stdout
+const trace = false
+
 func config(ctx context.Context, workingDir, user, email string) error {
 	for k, v := range map[string]string{
 		"user.name":  user,
@@ -194,7 +197,7 @@ func onelinelog(ctx context.Context, path, refspec, subdir string) ([]Commit, er
 	// because supplying an empty string to execGitCmd results in git complaining about
 	// >> ambiguous argument '' <<
 	if subdir != "" {
-		if err := execGitCmd(ctx, path, out, "log", "--oneline", "--no-abbrev-commit", refspec, subdir); err != nil {
+		if err := execGitCmd(ctx, path, out, "log", "--oneline", "--no-abbrev-commit", refspec, "--", subdir); err != nil {
 			return nil, err
 		}
 		return splitLog(out.String())
@@ -253,6 +256,13 @@ func changedFiles(ctx context.Context, path, subPath, ref string) ([]string, err
 }
 
 func execGitCmd(ctx context.Context, dir string, out io.Writer, args ...string) error {
+	if trace {
+		print("TRACE: git")
+		for _, arg := range args {
+			print(` "`, arg, `"`)
+		}
+		println()
+	}
 	c := exec.CommandContext(ctx, "git", args...)
 
 	if dir != "" {


### PR DESCRIPTION
The repo methods CommitsBetween and CommitsBefore use `git log
--oneline`, but hitherto did not separate the path argument (used to
restrict the commits of interest to those affecting that path) from
the arguments with `--`.

While we were using a local git clone with a working directory, this
didn't matter, because the path argument was recognisable as such. But
since we're now using a bare git clone, `git` will complain about any
path that looks a bit like a ref, and thereby fail to report syncs
after it's applied them to the cluster, as well as failing to respond
to SyncStatus.

We were also throwing away the error returned from doSync, so it was
more difficult to see what was the matter.

So:
 - use `--` to distinguish the path argument to `git log`
 - log errors returned from `doSync`
 - I found it helpful to trace the `git` invocations; I've left that
 in as a compile-time possibility.

Fixes #967.