### PR TITLE
Include individual resource sync errors in Sync events

### DIFF
--- a/cluster/kubernetes/files.go
+++ b/cluster/kubernetes/files.go
@@ -1,10 +1,11 @@
 package kubernetes
 
 import (
+	"path/filepath"
+
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
-
 	"github.com/weaveworks/flux/cluster/kubernetes/resource"
 )
 
@@ -13,7 +14,7 @@ import (
 // specified namespace and name) to the paths of resource definition
 // files.
 func (c *Manifests) FindDefinedServices(path string) (map[flux.ResourceID][]string, error) {
-	objects, err := resource.Load(path)
+	objects, err := resource.Load(path, path)
 	if err != nil {
 		return nil, errors.Wrap(err, "loading resources")
 	}
@@ -23,7 +24,7 @@ func (c *Manifests) FindDefinedServices(path string) (map[flux.ResourceID][]stri
 		id := obj.ResourceID()
 		_, kind, _ := id.Components()
 		if _, ok := resourceKinds[kind]; ok {
-			result[id] = append(result[id], obj.Source())
+			result[id] = append(result[id], filepath.Join(path, obj.Source()))
 		}
 	}
 	return result, nil

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -114,7 +114,7 @@ func (c *changeSet) stage(cmd string, o *apiObject) {
 }
 
 type Applier interface {
-	apply(log.Logger, changeSet) cluster.SyncErrors
+	apply(log.Logger, changeSet) cluster.SyncError
 }
 
 // Cluster is a handle to a Kubernetes API server.
@@ -221,7 +221,7 @@ func (c *Cluster) Sync(spec cluster.SyncDef) error {
 	logger := log.With(c.logger, "method", "Sync")
 
 	cs := makeChangeSet()
-	var errs cluster.SyncErrors
+	var errs cluster.SyncError
 	for _, action := range spec.Actions {
 		stages := []struct {
 			res resource.Resource
@@ -239,7 +239,7 @@ func (c *Cluster) Sync(spec cluster.SyncDef) error {
 				obj.Resource = stage.res
 				cs.stage(stage.cmd, obj)
 			} else {
-				errs = append(errs, cluster.SyncError{Resource: stage.res, Error: err})
+				errs = append(errs, cluster.ResourceError{Resource: stage.res, Error: err})
 				break
 			}
 		}

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry"
+	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/ssh"
 )
 
@@ -40,13 +41,21 @@ type extendedClient struct {
 	v1beta1batch.CronJobsGetter
 }
 
+// --- internal types for keeping track of syncing
+
 type apiObject struct {
-	bytes    []byte
+	resource.Resource
 	Kind     string `yaml:"kind"`
 	Metadata struct {
 		Name      string `yaml:"name"`
 		Namespace string `yaml:"namespace"`
 	} `yaml:"metadata"`
+}
+
+// A convenience for getting an minimal object from some bytes.
+func parseObj(def []byte) (*apiObject, error) {
+	obj := apiObject{}
+	return &obj, yaml.Unmarshal(def, &obj)
 }
 
 func (o *apiObject) hasNamespace() bool {
@@ -85,32 +94,27 @@ func isAddon(obj namespacedLabeled) bool {
 // --- /add ons
 
 type changeSet struct {
-	nsObjs   map[string][]obj
-	noNsObjs map[string][]obj
+	nsObjs   map[string][]*apiObject
+	noNsObjs map[string][]*apiObject
 }
 
 func makeChangeSet() changeSet {
 	return changeSet{
-		nsObjs:   make(map[string][]obj),
-		noNsObjs: make(map[string][]obj),
+		nsObjs:   make(map[string][]*apiObject),
+		noNsObjs: make(map[string][]*apiObject),
 	}
 }
 
-func (c *changeSet) stage(cmd, id string, o *apiObject) {
+func (c *changeSet) stage(cmd string, o *apiObject) {
 	if o.hasNamespace() {
-		c.nsObjs[cmd] = append(c.nsObjs[cmd], obj{id, o})
+		c.nsObjs[cmd] = append(c.nsObjs[cmd], o)
 	} else {
-		c.noNsObjs[cmd] = append(c.noNsObjs[cmd], obj{id, o})
+		c.noNsObjs[cmd] = append(c.noNsObjs[cmd], o)
 	}
-}
-
-type obj struct {
-	id string
-	*apiObject
 }
 
 type Applier interface {
-	apply(log.Logger, changeSet, cluster.SyncError)
+	apply(log.Logger, changeSet) cluster.SyncErrors
 }
 
 // Cluster is a handle to a Kubernetes API server.
@@ -217,25 +221,25 @@ func (c *Cluster) Sync(spec cluster.SyncDef) error {
 	logger := log.With(c.logger, "method", "Sync")
 
 	cs := makeChangeSet()
-	errs := cluster.SyncError{}
+	var errs cluster.SyncErrors
 	for _, action := range spec.Actions {
 		stages := []struct {
-			b   []byte
+			res resource.Resource
 			cmd string
 		}{
 			{action.Delete, "delete"},
 			{action.Apply, "apply"},
 		}
 		for _, stage := range stages {
-			if len(stage.b) == 0 {
+			if stage.res == nil {
 				continue
 			}
-			obj, err := definitionObj(stage.b)
-			id := action.ResourceID
+			obj, err := parseObj(stage.res.Bytes())
 			if err == nil {
-				cs.stage(stage.cmd, id, obj)
+				obj.Resource = stage.res
+				cs.stage(stage.cmd, obj)
 			} else {
-				errs[id] = err
+				errs = append(errs, cluster.SyncError{Resource: stage.res, Error: err})
 				break
 			}
 		}
@@ -243,8 +247,12 @@ func (c *Cluster) Sync(spec cluster.SyncDef) error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.applier.apply(logger, cs, errs)
-	if len(errs) != 0 {
+	if applyErrs := c.applier.apply(logger, cs); len(applyErrs) > 0 {
+		errs = append(errs, applyErrs...)
+	}
+
+	// If `nil`, errs is a cluster.SyncError(nil) rather than error(nil)
+	if errs != nil {
 		return errs
 	}
 	return nil
@@ -407,12 +415,4 @@ func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 	}
 
 	return allImageCreds
-}
-
-// --- end cluster.Cluster
-
-// A convenience for getting an minimal object from some bytes.
-func definitionObj(bytes []byte) (*apiObject, error) {
-	obj := apiObject{bytes: bytes}
-	return &obj, yaml.Unmarshal(bytes, &obj)
 }

--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -14,7 +14,7 @@ type mockApplier struct {
 	commandRun bool
 }
 
-func (m *mockApplier) apply(_ log.Logger, c changeSet) cluster.SyncErrors {
+func (m *mockApplier) apply(_ log.Logger, c changeSet) cluster.SyncError {
 	if len(c.nsObjs) != 0 || len(c.noNsObjs) != 0 {
 		m.commandRun = true
 	}

--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -5,24 +5,41 @@ import (
 
 	"github.com/go-kit/kit/log"
 
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/policy"
 )
 
 type mockApplier struct {
 	commandRun bool
 }
 
-func (m *mockApplier) apply(_ log.Logger, c changeSet, _ cluster.SyncError) {
+func (m *mockApplier) apply(_ log.Logger, c changeSet) cluster.SyncErrors {
 	if len(c.nsObjs) != 0 || len(c.noNsObjs) != 0 {
 		m.commandRun = true
 	}
+	return nil
 }
 
-func deploymentDef(name string) []byte {
-	return []byte(`---
-kind: Deployment
-metadata:
-  name: ` + name)
+type rsc struct {
+	id    string
+	bytes []byte
+}
+
+func (r rsc) ResourceID() flux.ResourceID {
+	return flux.MustParseResourceID(r.id)
+}
+
+func (r rsc) Bytes() []byte {
+	return r.bytes
+}
+
+func (r rsc) Policy() policy.Set {
+	return nil
+}
+
+func (r rsc) Source() string {
+	return "test"
 }
 
 // ---
@@ -39,7 +56,7 @@ func setup(t *testing.T) (*Cluster, *mockApplier) {
 func TestSyncNop(t *testing.T) {
 	kube, mock := setup(t)
 	if err := kube.Sync(cluster.SyncDef{}); err != nil {
-		t.Error(err)
+		t.Errorf("%#v", err)
 	}
 	if mock.commandRun {
 		t.Error("expected no commands run")
@@ -51,8 +68,7 @@ func TestSyncMalformed(t *testing.T) {
 	err := kube.Sync(cluster.SyncDef{
 		Actions: []cluster.SyncAction{
 			cluster.SyncAction{
-				ResourceID: "foobar",
-				Apply:      []byte("garbage"),
+				Apply: rsc{"id", []byte("garbage")},
 			},
 		},
 	})

--- a/cluster/kubernetes/manifests.go
+++ b/cluster/kubernetes/manifests.go
@@ -11,8 +11,8 @@ type Manifests struct {
 
 // FindDefinedServices implementation in files.go
 
-func (c *Manifests) LoadManifests(paths ...string) (map[string]resource.Resource, error) {
-	return kresource.Load(paths...)
+func (c *Manifests) LoadManifests(base, first string, rest ...string) (map[string]resource.Resource, error) {
+	return kresource.Load(base, first, rest...)
 }
 
 func (c *Manifests) ParseManifests(allDefs []byte) (map[string]resource.Resource, error) {

--- a/cluster/kubernetes/release.go
+++ b/cluster/kubernetes/release.go
@@ -52,7 +52,7 @@ func (c *Kubectl) connectArgs() []string {
 	return args
 }
 
-func (c *Kubectl) apply(logger log.Logger, cs changeSet) (errs cluster.SyncErrors) {
+func (c *Kubectl) apply(logger log.Logger, cs changeSet) (errs cluster.SyncError) {
 	f := func(m map[string][]*apiObject, cmd string, args ...string) {
 		objs := m[cmd]
 		if len(objs) == 0 {
@@ -64,7 +64,7 @@ func (c *Kubectl) apply(logger log.Logger, cs changeSet) (errs cluster.SyncError
 			for _, obj := range objs {
 				r := bytes.NewReader(obj.Bytes())
 				if err := c.doCommand(logger, r, args...); err != nil {
-					errs = append(errs, cluster.SyncError{obj.Resource, err})
+					errs = append(errs, cluster.ResourceError{obj.Resource, err})
 				}
 			}
 		}

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -132,7 +132,7 @@ func TestLoadSome(t *testing.T) {
 	if err := testfiles.WriteTestFiles(dir); err != nil {
 		t.Fatal(err)
 	}
-	objs, err := Load(dir)
+	objs, err := Load(dir, dir)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -20,7 +20,7 @@ import (
 // the source to learn about them.
 func updatePodController(def []byte, container string, newImageID image.Ref) ([]byte, error) {
 	// Sanity check
-	obj, err := definitionObj(def)
+	obj, err := parseObj(def)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -20,8 +20,11 @@ type Manifests interface {
 	// Update the definitions in a manifests bytes according to the
 	// spec given.
 	UpdateDefinition(def []byte, container string, newImageID image.Ref) ([]byte, error)
-	// Load all the resource manifests under the path given
-	LoadManifests(paths ...string) (map[string]resource.Resource, error)
+	// Load all the resource manifests under the path given. `baseDir`
+	// is used to relativise the paths, which are supplied as absolute
+	// paths to directories or files; at least one path must be
+	// supplied.
+	LoadManifests(baseDir, first string, rest ...string) (map[string]resource.Resource, error)
 	// Parse the manifests given in an exported blob
 	ParseManifests([]byte) (map[string]resource.Resource, error)
 	// UpdatePolicies modifies a manifest to apply the policy update specified

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -18,7 +18,7 @@ type Mock struct {
 	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
 	FindDefinedServicesFunc  func(path string) (map[flux.ResourceID][]string, error)
 	UpdateDefinitionFunc     func(def []byte, container string, newImageID image.Ref) ([]byte, error)
-	LoadManifestsFunc        func(paths ...string) (map[string]resource.Resource, error)
+	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
 	UpdatePoliciesFunc       func([]byte, policy.Update) ([]byte, error)
@@ -57,8 +57,8 @@ func (m *Mock) UpdateDefinition(def []byte, container string, newImageID image.R
 	return m.UpdateDefinitionFunc(def, container, newImageID)
 }
 
-func (m *Mock) LoadManifests(paths ...string) (map[string]resource.Resource, error) {
-	return m.LoadManifestsFunc(paths...)
+func (m *Mock) LoadManifests(base, first string, rest ...string) (map[string]resource.Resource, error) {
+	return m.LoadManifestsFunc(base, first, rest...)
 }
 
 func (m *Mock) ParseManifests(def []byte) (map[string]resource.Resource, error) {

--- a/cluster/sync.go
+++ b/cluster/sync.go
@@ -11,8 +11,8 @@ import (
 // SyncAction represents either the deletion or application (create or
 // update) of a resource.
 type SyncAction struct {
-	Delete     resource.Resource // ) one of these
-	Apply      resource.Resource // )
+	Delete resource.Resource // ) one of these
+	Apply  resource.Resource // )
 }
 
 type SyncDef struct {
@@ -20,14 +20,14 @@ type SyncDef struct {
 	Actions []SyncAction
 }
 
-type SyncError struct {
+type ResourceError struct {
 	resource.Resource
 	Error error
 }
 
-type SyncErrors []SyncError
+type SyncError []ResourceError
 
-func (err SyncErrors) Error() string {
+func (err SyncError) Error() string {
 	var errs []string
 	for _, e := range err {
 		errs = append(errs, e.ResourceID().String()+": "+e.Error.Error())

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -291,7 +291,7 @@ func TestDaemon_PolicyUpdate(t *testing.T) {
 			return false
 		}
 		defer co.Clean()
-		m, err := d.Manifests.LoadManifests(co.ManifestDir())
+		m, err := d.Manifests.LoadManifests(co.Dir(), co.ManifestDir())
 		if err != nil {
 			t.Fatalf("Error: %s", err.Error())
 		}

--- a/event/event.go
+++ b/event/event.go
@@ -195,6 +195,12 @@ type Commit struct {
 	Message  string `json:"message"`
 }
 
+type ResourceError struct {
+	ID    flux.ResourceID
+	Path  string
+	Error string
+}
+
 // SyncEventMetadata is the metadata for when new a commit is synced to the cluster
 type SyncEventMetadata struct {
 	// for parsing old events; Commits is now used in preference
@@ -205,7 +211,7 @@ type SyncEventMetadata struct {
 	// ourselves)
 	Includes map[string]bool `json:"includes,omitempty"`
 	// Per-resource errors
-	Errors map[string]string `json:"errors,omitempty"`
+	Errors []ResourceError `json:"errors,omitempty"`
 	// `true` if we have no record of having synced before
 	InitialSync bool `json:"initialSync,omitempty"`
 }

--- a/event/event.go
+++ b/event/event.go
@@ -204,6 +204,8 @@ type SyncEventMetadata struct {
 	// policy changes, and "other" (meaning things we didn't commit
 	// ourselves)
 	Includes map[string]bool `json:"includes,omitempty"`
+	// Per-resource errors
+	Errors map[string]string `json:"errors,omitempty"`
 	// `true` if we have no record of having synced before
 	InitialSync bool `json:"initialSync,omitempty"`
 }

--- a/git/working.go
+++ b/git/working.go
@@ -84,7 +84,12 @@ func (c *Checkout) Clean() {
 	}
 }
 
-// ManifestDir returns a path to where the files are
+// Dir returns the path to the repo
+func (c *Checkout) Dir() string {
+	return c.dir
+}
+
+// ManifestDir returns the path to the manifests files
 func (c *Checkout) ManifestDir() string {
 	return filepath.Join(c.dir, c.config.Path)
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -55,8 +55,7 @@ func prepareSyncDelete(logger log.Logger, repoResources map[string]resource.Reso
 	}
 	if _, ok := repoResources[id]; !ok {
 		sync.Actions = append(sync.Actions, cluster.SyncAction{
-			ResourceID: id,
-			Delete:     res.Bytes(),
+			Delete:     res,
 		})
 	}
 }
@@ -73,7 +72,6 @@ func prepareSyncApply(logger log.Logger, clusterResources map[string]resource.Re
 		}
 	}
 	sync.Actions = append(sync.Actions, cluster.SyncAction{
-		ResourceID: id,
-		Apply:      res.Bytes(),
+		Apply:      res,
 	})
 }

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -34,7 +34,7 @@ func TestSync(t *testing.T) {
 	manifests := &kubernetes.Manifests{}
 	var clus cluster.Cluster = &syncCluster{mockCluster, map[string][]byte{}}
 
-	resources, err := manifests.LoadManifests(checkout.ManifestDir())
+	resources, err := manifests.LoadManifests(checkout.Dir(), checkout.ManifestDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +55,7 @@ func TestSync(t *testing.T) {
 		break
 	}
 
-	resources, err = manifests.LoadManifests(checkout.ManifestDir())
+	resources, err = manifests.LoadManifests(checkout.Dir(), checkout.ManifestDir())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -244,7 +244,7 @@ func checkClusterMatchesFiles(t *testing.T, m cluster.Manifests, c cluster.Clust
 	if err != nil {
 		t.Fatal(err)
 	}
-	files, err := m.LoadManifests(dir)
+	files, err := m.LoadManifests(dir, dir)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A sync can be a partial success, in that we skip lightly over individual resources failing to be applied. This means that bogus manifests don't get noticed, and the symptoms can be difficult to pin down if you are used to thinking `cluster == git`.

This PR surfaces those errors by including them in the Sync event, as described in #756. (It fixes #756, in fact.)

There are other measures we could take, e.g., annotating offending commits (maybe? we may not be able to pin it down); keeping a gauge of sync failures which can be alerted on. But this is a fair start.