### PR TITLE
Make notifications at least once delivery

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -362,11 +362,15 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 			},
 		}); err != nil {
 			logger.Log("err", err)
+			// Abort early to ensure at least once delivery of events
+			return err
 		}
 
 		for _, event := range noteEvents {
 			if err = d.LogEvent(event); err != nil {
 				logger.Log("err", err)
+				// Abort early to ensure at least once delivery of events
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
changed flux loop so that if a sync or noteEvent fails to send, just return and do not move tag forward. This way if a notification fails, we wait for the next sync event to retry sending logic.
fixes weaveworks/service#1550
As stated in:
https://github.com/weaveworks/service/issues/1550
Since fluxd is constantly checking and bringing the cluster's state in line with the specified state in git, if an event does not fire for one sync, it will likely fire on the next sync.