### PR TITLE
Fix multiline lock reason yaml corruption

### DIFF
--- a/cluster/kubernetes/policies.go
+++ b/cluster/kubernetes/policies.go
@@ -77,7 +77,7 @@ func updateAnnotations(def []byte, tagAll string, f func(map[string]string) map[
 	// TODO: This should handle potentially different indentation.
 	// TODO: There's probably a more elegant regex-ey way to do this in one pass.
 	replaced := false
-	annotationsRE := regexp.MustCompile(`(?m:\n  annotations:\s*(?:#.*)*(?:\n    .*)*$)`)
+	annotationsRE := regexp.MustCompile(`(?m:\n  annotations:\s*(?:#.*)*(?:\n    .*|\n)*$)`)
 	newDef := annotationsRE.ReplaceAllStringFunc(string(def), func(found string) string {
 		if !replaced {
 			replaced = true


### PR DESCRIPTION
Lock reason messages can be spread over multiple lines. YAML's multiline
output omits indentation for empty lines. The regex looking for a
fragment to replace did not include these lines and therefore was not
removing the full multiline content but just until the first empty line.

One implication was that the `flux.weave.works/locked_user` annotation was
never cleared and the original locker wrongfully returned as the author of
the current lock.

This PR expands matching for existing annotations to include these empty
lines.

User locked with multiline and empty line:
```
metadata:
  annotations:
    flux.weave.works/locked: "true"
    flux.weave.works/locked_msg: |-
      first

      second
    flux.weave.works/locked_user: test <test@test.test>
```

After removing lock:
```
metadata:
  annotations:

      second
    flux.weave.works/locked_user: test <test@test.test>
```

Another person locks:
```
metadata:
  annotations:
    flux.weave.works/locked: "true"
    flux.weave.works/locked_msg: Do not update.
    flux.weave.works/locked_user: someone <else@test.test>

      second
    flux.weave.works/locked_user: test <test@test.test>
```