### PR TITLE
Ensure RPC clients implement `io.Closer`

### DIFF
--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"io"
 
 	"github.com/pkg/errors"
 
@@ -15,7 +16,13 @@ import (
 
 type baseClient struct{}
 
-var _ api.UpstreamServer = baseClient{}
+type completeServer interface {
+	api.UpstreamServer
+	// An RPC server implementation must closeable by the client.
+	io.Closer
+}
+
+var _ completeServer = baseClient{}
 
 func (bc baseClient) Version(context.Context) (string, error) {
 	return "", remote.UpgradeNeededError(errors.New("Version method not implemented"))
@@ -56,4 +63,8 @@ func (bc baseClient) SyncStatus(context.Context, string) ([]string, error) {
 
 func (bc baseClient) GitRepoConfig(context.Context, bool) (v6.GitConfig, error) {
 	return v6.GitConfig{}, remote.UpgradeNeededError(errors.New("GitRepoConfig method not implemented"))
+}
+
+func (bc baseClient) Close() error {
+	return remote.UpgradeNeededError(errors.New("Close method not implemented"))
 }

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -24,47 +24,61 @@ type completeServer interface {
 
 var _ completeServer = baseClient{}
 
-func (bc baseClient) Version(context.Context) (string, error) {
-	return "", remote.UpgradeNeededError(errors.New("Version method not implemented"))
+func (bc baseClient) Version(context.Context) (_ string, err error) {
+	err = upgradeError("Version")
+	return
 }
 
-func (bc baseClient) Ping(context.Context) error {
-	return remote.UpgradeNeededError(errors.New("Ping method not implemented"))
+func (bc baseClient) Ping(context.Context) (err error) {
+	err = upgradeError("Ping")
+	return
 }
 
-func (bc baseClient) Export(context.Context) ([]byte, error) {
-	return nil, remote.UpgradeNeededError(errors.New("Export method not implemented"))
+func (bc baseClient) Export(context.Context) (_ []byte, err error) {
+	err = upgradeError("Export")
+	return
 }
 
-func (bc baseClient) ListServices(context.Context, string) ([]v6.ControllerStatus, error) {
-	return nil, remote.UpgradeNeededError(errors.New("ListServices method not implemented"))
+func (bc baseClient) ListServices(context.Context, string) (_ []v6.ControllerStatus, err error) {
+	err = upgradeError("ListServices")
+	return
 }
 
-func (bc baseClient) ListImages(context.Context, update.ResourceSpec) ([]v6.ImageStatus, error) {
-	return nil, remote.UpgradeNeededError(errors.New("ListImages method not implemented"))
+func (bc baseClient) ListImages(context.Context, update.ResourceSpec) (_ []v6.ImageStatus, err error) {
+	err = upgradeError("ListImages")
+	return
 }
 
-func (bc baseClient) UpdateManifests(context.Context, update.Spec) (job.ID, error) {
-	var id job.ID
-	return id, remote.UpgradeNeededError(errors.New("UpdateManifests method not implemented"))
+func (bc baseClient) UpdateManifests(context.Context, update.Spec) (_ job.ID, err error) {
+	err = upgradeError("UpdateManifests")
+	return
 }
 
-func (bc baseClient) NotifyChange(context.Context, v9.Change) error {
-	return remote.UpgradeNeededError(errors.New("NotifyChange method not implemented"))
+func (bc baseClient) NotifyChange(context.Context, v9.Change) (err error) {
+	err = upgradeError("NotifyChange")
+	return
 }
 
-func (bc baseClient) JobStatus(context.Context, job.ID) (job.Status, error) {
-	return job.Status{}, remote.UpgradeNeededError(errors.New("JobStatus method not implemented"))
+func (bc baseClient) JobStatus(context.Context, job.ID) (_ job.Status, err error) {
+	err = upgradeError("JobStatus")
+	return
 }
 
-func (bc baseClient) SyncStatus(context.Context, string) ([]string, error) {
-	return nil, remote.UpgradeNeededError(errors.New("SyncStatus method not implemented"))
+func (bc baseClient) SyncStatus(context.Context, string) (_ []string, err error) {
+	err = upgradeError("SyncStatus")
+	return
 }
 
-func (bc baseClient) GitRepoConfig(context.Context, bool) (v6.GitConfig, error) {
-	return v6.GitConfig{}, remote.UpgradeNeededError(errors.New("GitRepoConfig method not implemented"))
+func (bc baseClient) GitRepoConfig(context.Context, bool) (_ v6.GitConfig, err error) {
+	err = upgradeError("SyncStatus")
+	return
 }
 
-func (bc baseClient) Close() error {
-	return remote.UpgradeNeededError(errors.New("Close method not implemented"))
+func (bc baseClient) Close() (err error) {
+	err = upgradeError("Close")
+	return
+}
+
+func upgradeError(method string) error {
+	return remote.UpgradeNeededError(errors.New(method + " method not implemented"))
 }

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -17,7 +17,7 @@ import (
 // talking to remote daemons.
 type RPCClientV6 struct {
 	client *rpc.Client
-	baseClient
+	fallback
 }
 
 type clientV6 interface {

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -16,8 +16,8 @@ import (
 // RPCClient is the rpc-backed implementation of a server, for
 // talking to remote daemons.
 type RPCClientV6 struct {
-	*baseClient
 	client *rpc.Client
+	baseClient
 }
 
 type clientV6 interface {
@@ -48,7 +48,7 @@ var supportedKindsV6 = []string{"service"}
 
 // NewClient creates a new rpc-backed implementation of the server.
 func NewClientV6(conn io.ReadWriteCloser) *RPCClientV6 {
-	return &RPCClientV6{&baseClient{}, jsonrpc.NewClient(conn)}
+	return &RPCClientV6{client: jsonrpc.NewClient(conn)}
 }
 
 // Ping is used to check if the remote server is available.
@@ -177,4 +177,8 @@ func (p *RPCClientV6) GitRepoConfig(ctx context.Context, regenerate bool) (v6.Gi
 		err = remoteApplicationError(err)
 	}
 	return result, err
+}
+
+func (p *RPCClientV6) Close() error {
+	return p.client.Close()
 }

--- a/remote/rpc/fallback.go
+++ b/remote/rpc/fallback.go
@@ -14,7 +14,9 @@ import (
 	"github.com/weaveworks/flux/update"
 )
 
-type baseClient struct{}
+// fallback is, as the name suggests, a fallback api.UpstreamServer implementation.
+// Any method not implemented in a given RPC client will terminate here.
+type fallback struct{}
 
 type completeServer interface {
 	api.UpstreamServer
@@ -22,59 +24,59 @@ type completeServer interface {
 	io.Closer
 }
 
-var _ completeServer = baseClient{}
+var _ completeServer = fallback{}
 
-func (bc baseClient) Version(context.Context) (_ string, err error) {
+func (fallback) Version(context.Context) (_ string, err error) {
 	err = upgradeError("Version")
 	return
 }
 
-func (bc baseClient) Ping(context.Context) (err error) {
+func (fallback) Ping(context.Context) (err error) {
 	err = upgradeError("Ping")
 	return
 }
 
-func (bc baseClient) Export(context.Context) (_ []byte, err error) {
+func (fallback) Export(context.Context) (_ []byte, err error) {
 	err = upgradeError("Export")
 	return
 }
 
-func (bc baseClient) ListServices(context.Context, string) (_ []v6.ControllerStatus, err error) {
+func (fallback) ListServices(context.Context, string) (_ []v6.ControllerStatus, err error) {
 	err = upgradeError("ListServices")
 	return
 }
 
-func (bc baseClient) ListImages(context.Context, update.ResourceSpec) (_ []v6.ImageStatus, err error) {
+func (fallback) ListImages(context.Context, update.ResourceSpec) (_ []v6.ImageStatus, err error) {
 	err = upgradeError("ListImages")
 	return
 }
 
-func (bc baseClient) UpdateManifests(context.Context, update.Spec) (_ job.ID, err error) {
+func (fallback) UpdateManifests(context.Context, update.Spec) (_ job.ID, err error) {
 	err = upgradeError("UpdateManifests")
 	return
 }
 
-func (bc baseClient) NotifyChange(context.Context, v9.Change) (err error) {
+func (fallback) NotifyChange(context.Context, v9.Change) (err error) {
 	err = upgradeError("NotifyChange")
 	return
 }
 
-func (bc baseClient) JobStatus(context.Context, job.ID) (_ job.Status, err error) {
+func (fallback) JobStatus(context.Context, job.ID) (_ job.Status, err error) {
 	err = upgradeError("JobStatus")
 	return
 }
 
-func (bc baseClient) SyncStatus(context.Context, string) (_ []string, err error) {
+func (fallback) SyncStatus(context.Context, string) (_ []string, err error) {
 	err = upgradeError("SyncStatus")
 	return
 }
 
-func (bc baseClient) GitRepoConfig(context.Context, bool) (_ v6.GitConfig, err error) {
+func (fallback) GitRepoConfig(context.Context, bool) (_ v6.GitConfig, err error) {
 	err = upgradeError("SyncStatus")
 	return
 }
 
-func (bc baseClient) Close() (err error) {
+func (fallback) Close() (err error) {
 	err = upgradeError("Close")
 	return
 }


### PR DESCRIPTION
Since #974 the `Close` method isn't implemented on our RPC clients. This was able to happen because removing it wasn't a compile error. Now it is.

Also contains some cleanup in the general area.