### PR TITLE
Ignore helm charts when scanning manifests

### DIFF
--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -136,8 +136,7 @@ func TestLoadSome(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	// assume it's one per file for the minute
-	if len(objs) != len(testfiles.Files) {
-		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testfiles.Files), len(testfiles.Files), objs)
+	if len(objs) != len(testfiles.ServiceMap(dir)) {
+		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testfiles.ServiceMap(dir)), len(testfiles.Files), objs)
 	}
 }

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -30,6 +30,9 @@ func TempDir(t *testing.T) (string, func()) {
 func WriteTestFiles(dir string) error {
 	for name, content := range Files {
 		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0777); err != nil {
+			return err
+		}
 		if err := ioutil.WriteFile(path, []byte(content), 0666); err != nil {
 			return err
 		}
@@ -45,11 +48,12 @@ func ServiceMap(dir string) map[flux.ResourceID][]string {
 	return map[flux.ResourceID][]string{
 		flux.MustParseResourceID("default:deployment/helloworld"):     []string{filepath.Join(dir, "helloworld-deploy.yaml")},
 		flux.MustParseResourceID("default:deployment/locked-service"): []string{filepath.Join(dir, "locked-service-deploy.yaml")},
-		flux.MustParseResourceID("default:deployment/test-service"):   []string{filepath.Join(dir, "test-service-deploy.yaml")},
+		flux.MustParseResourceID("default:deployment/test-service"):   []string{filepath.Join(dir, "test/test-service-deploy.yaml")},
 	}
 }
 
 var Files = map[string]string{
+	"garbage": "This should just be ignored, since it is not YAML",
 	"helloworld-deploy.yaml": `apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -98,7 +102,7 @@ spec:
         ports:
         - containerPort: 80
 `,
-	"test-service-deploy.yaml": `apiVersion: extensions/v1beta1
+	"test/test-service-deploy.yaml": `apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: test-service

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -195,7 +195,7 @@ func TestDaemon_NotifyChange(t *testing.T) {
 		t.Errorf("Sync was not called once, was called %d times", syncCalled)
 	} else if syncDef == nil {
 		t.Errorf("Sync was called with a nil syncDef")
-	} else if len(syncDef.Actions) != len(testfiles.Files) {
+	} else if len(syncDef.Actions) != len(testfiles.ServiceMap("unimportant")) {
 		t.Errorf("Sync was not called with the %d actions, was called with: %d", len(testfiles.Files), len(syncDef.Actions))
 	}
 

--- a/site/requirements.md
+++ b/site/requirements.md
@@ -25,6 +25,11 @@ Flux has some requirements of the files it finds in your git repo.
    namespace in which you want them to run. Otherwise, the
    conventional default (`"default"`) will be assumed.
 
+ * Flux will ignore directories that look like Helm charts, to avoid
+   applying templated YAML manifests. A directory will be skipped if
+   its contents include the files `Chart.yaml` and `values.yaml`, as
+   these are the (only) mandatory components of a Helm chart.
+
 It is _not_ a requirement that the files are arranged in any
 particular way into directories. Flux will look in subdirectories for
 YAML files recursively, but does not infer any meaning from the

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -45,11 +44,11 @@ func TestSync(t *testing.T) {
 	}
 	checkClusterMatchesFiles(t, manifests, clus, checkout.ManifestDir())
 
-	for file := range testfiles.Files {
-		if err := execCommand("rm", filepath.Join(checkout.ManifestDir(), file)); err != nil {
+	for _, res := range testfiles.ServiceMap(checkout.ManifestDir()) {
+		if err := execCommand("rm", res[0]); err != nil {
 			t.Fatal(err)
 		}
-		commitAction := &git.CommitAction{Author: "", Message: "deleted " + file}
+		commitAction := &git.CommitAction{Author: "", Message: "deleted " + res[0]}
 		if err := checkout.CommitAndPush(context.Background(), commitAction, nil); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
At the minute, if you have any Helm charts in the path you give to flux, it'll probably bork. The templated manifests in `<chart>/templates/` will either not parse as yamels, or be applied with weird field values.

So: when walking the repo looking for manifests, skip any directory that looks like a chart. What looks like a chart? The telltale things are:
 - a `Chart.yaml` file; and,
 - a `values.yaml` file.

Both of these, and only these, are mandatory. Looking for anything else would give false negatives (-> failing to skip a chart); _not_ looking for those would give false positives (-> failing to include a non-chart).

The first commit prepares the ground a little by making the test fixture more varied (i.e., including subdirectories and non-yamels), so chart files can be added to it in the latter commit to verify that everything still works by virtue of the chart being ignored.