### PR TITLE
Generate keys in a separate tmpfs volume

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -154,12 +154,8 @@ func main() {
 	}
 
 	if *sshKeygenDir == "" {
-		logger.Log("err", "SSH keygen dir (--ssh-keygen-dir) missing; this is a directory in which to generate SSH keys (ideally mounted from a tmpfs volume)")
-		os.Exit(1)
-	}
-	if _, err := os.Stat(*sshKeygenDir); err != nil && os.IsNotExist(err) {
-		logger.Log("err", "SSH keygen dir (supplied as argument --ssh-keygen-dir) does not exist. This should be a directory mounted from a tmpfs volume.")
-		os.Exit(1)
+		logger.Log("info", fmt.Sprintf("SSH keygen dir (--ssh-keygen-dir) not provided, so using the deploy key volume (--k8s-secret-volume-mount-path=%s); this may cause problems if the deploy key volume is mounted read-only", *k8sSecretVolumeMountPath))
+		*sshKeygenDir = *k8sSecretVolumeMountPath
 	}
 
 	// Cluster component.

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -101,8 +101,9 @@ func main() {
 		k8sSecretVolumeMountPath = fs.String("k8s-secret-volume-mount-path", "/etc/fluxd/ssh", "Mount location of the k8s secret storing the private SSH key")
 		k8sSecretDataKey         = fs.String("k8s-secret-data-key", "identity", "Data key holding the private SSH key within the k8s secret")
 		// SSH key generation
-		sshKeyBits = optionalVar(fs, &ssh.KeyBitsValue{}, "ssh-keygen-bits", "-b argument to ssh-keygen (default unspecified)")
-		sshKeyType = optionalVar(fs, &ssh.KeyTypeValue{}, "ssh-keygen-type", "-t argument to ssh-keygen (default unspecified)")
+		sshKeyBits   = optionalVar(fs, &ssh.KeyBitsValue{}, "ssh-keygen-bits", "-b argument to ssh-keygen (default unspecified)")
+		sshKeyType   = optionalVar(fs, &ssh.KeyTypeValue{}, "ssh-keygen-type", "-t argument to ssh-keygen (default unspecified)")
+		sshKeygenDir = fs.String("ssh-keygen-dir", "", "directory, ideally on a tmpfs volume, in which to generate new SSH keys when necessary")
 
 		upstreamURL = fs.String("connect", "", "Connect to an upstream service e.g., Weave Cloud, at this base address")
 		token       = fs.String("token", "", "Authentication token for upstream service")
@@ -132,6 +133,8 @@ func main() {
 	}
 	logger.Log("started", true)
 
+	// Argument validation
+
 	// Sort out values for the git tag and notes ref. There are
 	// running deployments that assume the defaults as given, so don't
 	// mess with those unless explicitly told.
@@ -147,6 +150,15 @@ func main() {
 
 	if len(*gitPath) > 0 && (*gitPath)[0] == '/' {
 		logger.Log("err", "git subdirectory (--git-path) should not have leading forward slash")
+		os.Exit(1)
+	}
+
+	if *sshKeygenDir == "" {
+		logger.Log("err", "SSH keygen dir (--ssh-keygen-dir) missing; this is a directory in which to generate SSH keys (ideally mounted from a tmpfs volume)")
+		os.Exit(1)
+	}
+	if _, err := os.Stat(*sshKeygenDir); err != nil && os.IsNotExist(err) {
+		logger.Log("err", "SSH keygen dir (supplied as argument --ssh-keygen-dir) does not exist. This should be a directory mounted from a tmpfs volume.")
 		os.Exit(1)
 	}
 
@@ -192,6 +204,7 @@ func main() {
 			SecretDataKey:         *k8sSecretDataKey,
 			KeyBits:               sshKeyBits,
 			KeyType:               sshKeyType,
+			KeyGenDir:             *sshKeygenDir,
 		})
 		if err != nil {
 			logger.Log("err", err)

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -18,9 +18,14 @@ spec:
         defaultMode: 0400 # when mounted read-only, we won't be able to chmod
         secret:
           secretName: flux-git-deploy
+
+      # This is a tmpfs used for generating SSH keys. In K8s >= 1.10,
+      # mounted secrets are read-only, so we need a separate volume we
+      # can write to.
       - name: git-keygen
         emptyDir:
           medium: Memory
+
       containers:
       - name: flux
         # There are no ":latest" images for flux. Find the most recent
@@ -44,12 +49,14 @@ spec:
         # - --memcached-hostname=memcached.default.svc.cluster.local
         # - --memcached-service=memcached
 
-        # this must be supplied, and be in the tmpfs (emptyDir) mounted above
-        --ssh-keygen-dir=/var/fluxd/keygen
+        # this must be supplied, and be in the tmpfs (emptyDir)
+        # mounted above, for K8s >= 1.10
+        - --ssh-keygen-dir=/var/fluxd/keygen
 
         # replace (at least) the following URL
         - --git-url=git@github.com:weaveworks/flux-example
         - --git-branch=master
+
         # include these next two to connect to an "upstream" service
         # (e.g., Weave Cloud). The token is particular to the service.
         # - --connect=wss://cloud.weave.works/api/flux

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -15,8 +15,12 @@ spec:
       serviceAccount: flux
       volumes:
       - name: git-key
+        defaultMode: 0400 # when mounted read-only, we won't be able to chmod
         secret:
           secretName: flux-git-deploy
+      - name: git-keygen
+        emptyDir:
+          medium: Memory
       containers:
       - name: flux
         # There are no ":latest" images for flux. Find the most recent
@@ -28,7 +32,10 @@ spec:
         - containerPort: 3030 # informational
         volumeMounts:
         - name: git-key
-          mountPath: /etc/fluxd/ssh
+          mountPath: /etc/fluxd/ssh # to match image's ~/.ssh/config
+          readOnly: true # this will be the case perforce in K8s >=1.10
+        - name: git-keygen
+          mountPath: /var/fluxd/keygen # to match image's ~/.ssh/config
         args:
 
         # if you deployed memcached in a different namespace to flux,
@@ -36,6 +43,9 @@ spec:
         # following two arguments to tell fluxd how to connect to it.
         # - --memcached-hostname=memcached.default.svc.cluster.local
         # - --memcached-service=memcached
+
+        # this must be supplied, and be in the tmpfs (emptyDir) mounted above
+        --ssh-keygen-dir=/var/fluxd/keygen
 
         # replace (at least) the following URL
         - --git-url=git@github.com:weaveworks/flux-example

--- a/docker/ssh_config
+++ b/docker/ssh_config
@@ -1,4 +1,5 @@
 Host *
 StrictHostKeyChecking yes
 IdentityFile /etc/fluxd/ssh/identity
+IdentityFile /var/fluxd/keygen/identity
 LogLevel error

--- a/ssh/keygen.go
+++ b/ssh/keygen.go
@@ -2,6 +2,7 @@ package ssh
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os/exec"
@@ -156,9 +157,9 @@ type PublicKey struct {
 // ExtractPublicKey extracts and returns the public key from the specified
 // private key, along with its fingerprint hashes.
 func ExtractPublicKey(privateKeyPath string) (PublicKey, error) {
-	keyBytes, err := exec.Command("ssh-keygen", "-y", "-f", privateKeyPath).Output()
+	keyBytes, err := exec.Command("ssh-keygen", "-y", "-f", privateKeyPath).CombinedOutput()
 	if err != nil {
-		return PublicKey{}, err
+		return PublicKey{}, errors.New(string(keyBytes))
 	}
 
 	md5Print, err := ExtractFingerprint(privateKeyPath, "md5")


### PR DESCRIPTION
In Kubernetes >= 1.10, secrets (and config-maps) will be mounted read-only. This means we cannot use the tmpfs volume used for the deploy secret as a workspace for generating new keys (and that we have to mount the secret with the right mode, since we won't be able to `chmod` it).

Instead, allow _another_ tmpfs to be mounted, and use that when directed to. The new flag `--ssh-keygen-dir` is for providing the path; otherwise, it will use the path for the mounted secret, as before.

So we can still use stable paths, both possible stable locations of the private key (in the mounted secret or in the mounted tmpfs workspace) are mentioned in ~/.ssh/config (in the Docker image).

The example is also updated to reflect the new way of doing things, compatible with Kubernetes 1.10; existing configs will continue to work.

Fixes #1002.