### PR TITLE
Add ability to append [ci skip] to commit messages

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -281,7 +281,7 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) DaemonJo
 		if d.GitConfig.SetAuthor {
 			commitAuthor = spec.Cause.User
 		}
-		commitAction := &git.CommitAction{Author: commitAuthor, Message: policyCommitMessage(updates, spec.Cause)}
+		commitAction := git.CommitAction{Author: commitAuthor, Message: policyCommitMessage(updates, spec.Cause)}
 		if err := working.CommitAndPush(ctx, commitAction, &git.Note{JobID: jobID, Spec: spec}); err != nil {
 			// On the chance pushing failed because it was not
 			// possible to fast-forward, ask for a sync so the
@@ -320,7 +320,7 @@ func (d *Daemon) release(spec update.Spec, c release.Changes) DaemonJobFunc {
 			if d.GitConfig.SetAuthor {
 				commitAuthor = spec.Cause.User
 			}
-			commitAction := &git.CommitAction{Author: commitAuthor, Message: commitMsg}
+			commitAction := git.CommitAction{Author: commitAuthor, Message: commitMsg}
 			if err := working.CommitAndPush(ctx, commitAction, &git.Note{JobID: jobID, Spec: spec, Result: result}); err != nil {
 				// On the chance pushing failed because it was not
 				// possible to fast-forward, ask the repo to fetch

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -240,7 +240,7 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 			return err
 		}
 
-		commitAction := &git.CommitAction{Author: "", Message: "test commit"}
+		commitAction := git.CommitAction{Author: "", Message: "test commit"}
 		err = checkout.CommitAndPush(ctx, commitAction, nil)
 		if err != nil {
 			return err

--- a/git/operations.go
+++ b/git/operations.go
@@ -68,7 +68,7 @@ func checkPush(ctx context.Context, workingDir, upstream string) error {
 	return execGitCmd(ctx, workingDir, nil, "push", "--delete", upstream, "tag", CheckPushTag)
 }
 
-func commit(ctx context.Context, workingDir string, commitAction *CommitAction) error {
+func commit(ctx context.Context, workingDir string, commitAction CommitAction) error {
 	commitAuthor := commitAction.Author
 	if commitAuthor != "" {
 		if err := execGitCmd(ctx,

--- a/git/working.go
+++ b/git/working.go
@@ -9,13 +9,14 @@ import (
 // Config holds some values we use when working in the working clone of
 // a repo.
 type Config struct {
-	Branch    string // branch we're syncing to
-	Path      string // path within the repo containing files we care about
-	SyncTag   string
-	NotesRef  string
-	UserName  string
-	UserEmail string
-	SetAuthor bool
+	Branch      string // branch we're syncing to
+	Path        string // path within the repo containing files we care about
+	SyncTag     string
+	NotesRef    string
+	UserName    string
+	UserEmail   string
+	SetAuthor   bool
+	SkipMessage string
 }
 
 // Checkout is a local working clone of the remote repo. It is
@@ -96,10 +97,13 @@ func (c *Checkout) ManifestDir() string {
 
 // CommitAndPush commits changes made in this checkout, along with any
 // extra data as a note, and pushes the commit and note to the remote repo.
-func (c *Checkout) CommitAndPush(ctx context.Context, commitAction *CommitAction, note *Note) error {
+func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction, note *Note) error {
 	if !check(ctx, c.dir, c.config.Path) {
 		return ErrNoChanges
 	}
+
+	commitAction.Message += c.config.SkipMessage
+
 	if err := commit(ctx, c.dir, commitAction); err != nil {
 		return err
 	}

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -45,6 +45,8 @@ fluxd requires setup and offers customization though a multitude of flags.
 |**Git repo & key etc.** |                              ||
 |--git-url               |                               | URL of git repo with Kubernetes manifests; e.g., `git@github.com:weaveworks/flux-example`|
 |--git-branch            | `master`                        | branch of git repo to use for Kubernetes manifests|
+|--git-ci-skip           | false   | when set, fluxd will append `\n\n[ci skip]` to its commit messages |
+|--git-ci-skip-message   | `""`    | if provided, fluxd will append this to commit messages (overrides --git-ci-skip`) |
 |--git-path              |                               | path within git repo to locate Kubernetes manifests (relative path)|
 |--git-user              | `Weave Flux`                    | username to use as git committer|
 |--git-email             | `support@weave.works`           | email to use as git committer|

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -48,7 +48,7 @@ func TestSync(t *testing.T) {
 		if err := execCommand("rm", res[0]); err != nil {
 			t.Fatal(err)
 		}
-		commitAction := &git.CommitAction{Author: "", Message: "deleted " + res[0]}
+		commitAction := git.CommitAction{Author: "", Message: "deleted " + res[0]}
 		if err := checkout.CommitAndPush(context.Background(), commitAction, nil); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Appending `[ci skip]` to a commit message will instruct CI to skip the
build for that commit, at least in these systems:

 - https://circleci.com/docs/1.0/skip-a-build/
 - https://docs.travis-ci.com/user/customizing-the-build/#Skipping-a-build
 - https://docs.gitlab.com/ee/ci/yaml/#skipping-jobs

So: I've added a flag which switches that will do exactly that, to all
commits fluxd creates. To account for other CI systems that have a
similar mechanism but don't use that convention, the flag
`--git-ci-skip-message` lets you supply the text to append.

Resolves #856.