### PR TITLE
Add force flag for work on forced deployments

### DIFF
--- a/update/release.go
+++ b/update/release.go
@@ -59,6 +59,7 @@ type ReleaseSpec struct {
 	ImageSpec    ImageSpec
 	Kind         ReleaseKind
 	Excludes     []flux.ResourceID
+	Force        bool
 }
 
 // ReleaseType gives a one-word description of the release, mainly


### PR DESCRIPTION
This will ensure the change will also be vendored into flux-api so it 
can handle the force-flag as well.

fixes weaveworks/service#1851