### PR TITLE
Make upstream.Close() wait for shutdown

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -398,7 +398,10 @@ func main() {
 				os.Exit(1)
 			}
 			daemon.EventWriter = upstream
-			defer upstream.Close()
+			go func() {
+				<-shutdown
+				upstream.Close()
+			}()
 		} else {
 			logger.Log("upstream", "no upstream URL given")
 		}


### PR DESCRIPTION
We let main() exit, and block on graceful shutdown in a `defer`ed
procedure. We _also_ `defer` a call to `upstream.Close()`, which stops
the upstream reconnecting and closes it.

The two deferred procedure calls used to be in such an order that by
coincidence, `upstream.Close()` was _also_ blocked on graceful
shutdown. But this order was shuffled in PR #962.

This commit makes the `upstream.Close()` explicitly wait for shutdown.

Fixes weaveworks/service-conf#2053.