### PR TITLE
Log the daemon version on startup

### DIFF
--- a/cmd/fluxd/checkpoint.go
+++ b/cmd/fluxd/checkpoint.go
@@ -18,10 +18,10 @@ func checkForUpdates(clusterString string, gitString string, logger log.Logger) 
 			return
 		}
 		if r.Outdated {
-			logger.Log("msg", "update available", "version", r.CurrentVersion, "URL", r.CurrentDownloadURL)
+			logger.Log("msg", "update available", "latest", r.CurrentVersion, "URL", r.CurrentDownloadURL)
 			return
 		}
-		logger.Log("msg", "up to date", "version", r.CurrentVersion)
+		logger.Log("msg", "up to date", "latest", r.CurrentVersion)
 	}
 
 	flags := map[string]string{

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -36,7 +36,7 @@ import (
 	"github.com/weaveworks/flux/ssh"
 )
 
-var version string
+var version = "unversioned"
 
 const (
 	// The number of connections chosen for memcache and remote GETs should match for best performance (hence the single hardcoded value)
@@ -117,9 +117,6 @@ func main() {
 
 	fs.Parse(os.Args)
 
-	if version == "" {
-		version = "unversioned"
-	}
 	if *versionFlag {
 		fmt.Println(version)
 		os.Exit(0)
@@ -132,7 +129,7 @@ func main() {
 		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 		logger = log.With(logger, "caller", log.DefaultCaller)
 	}
-	logger.Log("started", true)
+	logger.Log("version", version)
 
 	// Argument validation
 


### PR DESCRIPTION
If a new flux release isn't adding to our checkpoint-api, there's some potentially misleading log output on daemon startup.

Specifically, we were seeing this output when running flux 1.2.5:
```
ts=2018-03-22T08:57:19.895914653Z caller=checkpoint.go:24 component=checkpoint msg="up to date" version=1.2.4
```