### PR TITLE
Fix git-key volume

### DIFF
--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -15,10 +15,10 @@ spec:
       serviceAccount: flux
       volumes:
       - name: git-key
-        defaultMode: 0400 # when mounted read-only, we won't be able to chmod
         secret:
           secretName: flux-git-deploy
-
+          defaultMode: 0400 # when mounted read-only, we won't be able to chmod
+        
       # This is a tmpfs used for generating SSH keys. In K8s >= 1.10,
       # mounted secrets are read-only, so we need a separate volume we
       # can write to.


### PR DESCRIPTION
The field `defaultMode` needs to be placed below `secret`. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.9/#secretvolumesource-v1-core