### PR TITLE
Sync for manual Chart releases

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -117,7 +117,6 @@ func main() {
 		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
 		logger = log.With(logger, "caller", log.DefaultCaller)
 	}
-	// ----------------------------------------------------------------------
 
 	// SHUTDOWN  ----------------------------------------------------------------------------
 	errc := make(chan error)
@@ -137,7 +136,6 @@ func main() {
 		close(shutdown)
 		shutdownWg.Wait()
 	}()
-	// ----------------------------------------------------------------------
 
 	mainLogger := log.With(logger, "component", "helm-operator")
 
@@ -197,7 +195,6 @@ func main() {
 		mainLogger.Log("info", "Set up Helm client")
 		break
 	}
-	//---------------------------------------------------------------------------------------
 
 	// GIT REPO CLONING ---------------------------------------------------------------------
 	mainLogger.Log("info", "Starting to clone repo ...")
@@ -269,7 +266,6 @@ func main() {
 	}
 	mainLogger.Log("info", "Repo cloned")
 
-	//=======================================================================================
 	// CUSTOM RESOURCES CACHING SETUP -------------------------------------------------------
 	//				SharedInformerFactory sets up informer, that maps resource type to a cache shared informer.
 	//				operator attaches event handler to the informer and syncs the informer cache
@@ -279,19 +275,15 @@ func main() {
 
 	rel := release.New(log.With(logger, "component", "release"), helmClient, checkoutFhr, checkoutCh, checkoutR)
 
-	//---------------------------------------------------------------------------------------
-
 	// CHARTS CHANGES SYNC -----------------------------------------------------------------------------
 	chartSync := chartsync.New(log.With(logger, "component", "chartsync"), *chartsSyncInterval, *chartsSyncTimeout, *kubeClient, *ifClient, fhrInformer, rel)
 	chartSync.Run(shutdown, errc, shutdownWg)
-	//---------------------------------------------------------------------------------------
 
 	// MANUAL CHART RELEASES SYNC -----------------------------------------------------------------------------
 	releaseSync := releasesync.New(log.With(logger, "component", "releasesync"), *chartsSyncInterval, *chartsSyncTimeout, *kubeClient, *ifClient, rel)
 	releaseSync.Run(shutdown, errc, shutdownWg)
-	//---------------------------------------------------------------------------------------
 
-	// OPERATOR - CUSTOM RRESOURCES CHANGE SYNC ----------------------------------------------
+	// OPERATOR - CUSTOM RESOURCES CHANGE SYNC ----------------------------------------------
 	opr := operator.New(log.With(logger, "component", "operator"), kubeClient, fhrInformer, rel)
 	// Starts handling k8s events related to the given resource kind
 	go ifInformerFactory.Start(shutdown)
@@ -300,7 +292,6 @@ func main() {
 		logger.Log("error", msg)
 		errc <- fmt.Errorf(ErrOperatorFailure, err)
 	}
-	//=======================================================================================
 }
 
 // Helper functions

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaveworks/flux/integrations/helm/git"
 	"github.com/weaveworks/flux/integrations/helm/operator"
 	"github.com/weaveworks/flux/integrations/helm/release"
+	"github.com/weaveworks/flux/integrations/helm/releasesync"
 	"github.com/weaveworks/flux/ssh"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
@@ -278,9 +279,16 @@ func main() {
 
 	rel := release.New(log.With(logger, "component", "release"), helmClient, checkoutFhr, checkoutCh, checkoutR)
 
+	//---------------------------------------------------------------------------------------
+
 	// CHARTS CHANGES SYNC -----------------------------------------------------------------------------
 	chartSync := chartsync.New(log.With(logger, "component", "chartsync"), *chartsSyncInterval, *chartsSyncTimeout, *kubeClient, *ifClient, fhrInformer, rel)
 	chartSync.Run(shutdown, errc, shutdownWg)
+	//---------------------------------------------------------------------------------------
+
+	// MANUAL CHART RELEASES SYNC -----------------------------------------------------------------------------
+	releaseSync := releasesync.New(log.With(logger, "component", "releasesync"), *chartsSyncInterval, *chartsSyncTimeout, *kubeClient, *ifClient, rel)
+	releaseSync.Run(shutdown, errc, shutdownWg)
 	//---------------------------------------------------------------------------------------
 
 	// OPERATOR - CUSTOM RRESOURCES CHANGE SYNC ----------------------------------------------

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -182,19 +182,13 @@ func main() {
 	gitLogger := log.With(logger, "component", "git")
 
 	// 		Chart releases sync due to Custom Resources changes -------------------------------
-	mainLogger.Log("info", "Starting to clone repo for fhrs changes ...")
-	checkoutFhr := git.RepoSetup(gitLogger, gitAuth, gitRemoteConfig, git.FhrsChangesClone)
-	defer checkoutFhr.Cleanup()
-	mainLogger.Log("info", "Repo for fhrs changes cloned")
-
-	// 		Chart releases sync due to Custom Resources changes -------------------------------
-	mainLogger.Log("info", "Starting to clone repo for chartsync ...")
-	checkoutCh := git.RepoSetup(gitLogger, gitAuth, gitRemoteConfig, git.ChartsChangesClone)
-	defer checkoutCh.Cleanup()
-	mainLogger.Log("info", "Repo for chartsync cloned")
+	mainLogger.Log("info", "Starting to clone repo ...")
+	checkout := git.RepoSetup(gitLogger, gitAuth, gitRemoteConfig, git.ChangesClone)
+	defer checkout.Cleanup()
+	mainLogger.Log("info", "Repo cloned")
 
 	// release instance is needed during the sync of Charts changes and during the sync of FluxHelRelease changes
-	rel := release.New(log.With(logger, "component", "release"), helmClient, checkoutFhr, checkoutCh)
+	rel := release.New(log.With(logger, "component", "release"), helmClient, checkout)
 	relsync := releasesync.New(log.With(logger, "component", "releasesync"), rel)
 
 	// CHARTS CHANGES SYNC ------------------------------------------------------------------

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -219,7 +219,7 @@ func main() {
 
 	// If cloning not immediately possible, we wait until it is -----------------------------
 	for {
-		mainLogger.Log("info", "Cloning repo ...")
+		mainLogger.Log("info", "Cloning custom resource sync repo ...")
 		ctx, cancel := context.WithTimeout(context.Background(), git.DefaultCloneTimeout)
 		err = checkoutFhr.Clone(ctx, git.FhrsChangesClone)
 		cancel()
@@ -229,42 +229,25 @@ func main() {
 		mainLogger.Log("error", fmt.Sprintf("Failed to clone git repo [%s, %s, %s]: %v", gitRemoteConfigFhr.URL, gitRemoteConfigFhr.Path, gitRemoteConfigFhr.Branch, err))
 		time.Sleep(10 * time.Second)
 	}
-	mainLogger.Log("info", "Repo cloned")
+	mainLogger.Log("info", "Custom resource sync repo cloned")
 
-	// 		Chart releases sync due to pure Charts changes ------------------------------------
+	// 		Chart releases sync due to Custom Resources changes -------------------------------
 	checkoutCh := git.NewCheckout(log.With(logger, "component", "git"), gitRemoteConfigCh, gitAuth)
 	defer checkoutCh.Cleanup()
 
 	// If cloning not immediately possible, we wait until it is -----------------------------
 	for {
-		mainLogger.Log("info", "Cloning repo ...")
+		mainLogger.Log("info", "Cloning chartsync repo ...")
 		ctx, cancel := context.WithTimeout(context.Background(), git.DefaultCloneTimeout)
 		err = checkoutCh.Clone(ctx, git.ChartsChangesClone)
 		cancel()
 		if err == nil {
 			break
 		}
-		mainLogger.Log("error", fmt.Sprintf("Failed to clone git repo [%s, %s, %s]: %v", gitRemoteConfigCh.URL, gitRemoteConfigCh.Branch, gitRemoteConfigCh.Path, err))
+		mainLogger.Log("error", fmt.Sprintf("Failed to clone git repo [%s, %s, %s]: %v", gitRemoteConfigCh.URL, gitRemoteConfigCh.Path, gitRemoteConfigCh.Branch, err))
 		time.Sleep(10 * time.Second)
 	}
-	mainLogger.Log("info", "Repo cloned")
-
-	// 		Chart releases sync due to manual chart release changes ------------------------------------
-	checkoutR := git.NewCheckout(log.With(logger, "component", "git"), gitRemoteReleaseCh, gitAuth)
-	defer checkoutR.Cleanup()
-	// If cloning not immediately possible, we wait until it is -----------------------------
-	for {
-		mainLogger.Log("info", "Cloning repo ...")
-		ctx, cancel := context.WithTimeout(context.Background(), git.DefaultCloneTimeout)
-		err = checkoutR.Clone(ctx, git.ReleasesChangesClone)
-		cancel()
-		if err == nil {
-			break
-		}
-		mainLogger.Log("error", fmt.Sprintf("Failed to clone git repo [%s, %s, %s]: %v", gitRemoteConfigCh.URL, gitRemoteConfigCh.Branch, gitRemoteConfigCh.Path, err))
-		time.Sleep(10 * time.Second)
-	}
-	mainLogger.Log("info", "Repo cloned")
+	mainLogger.Log("info", "Chartsync repo cloned")
 
 	// CUSTOM RESOURCES CACHING SETUP -------------------------------------------------------
 	//				SharedInformerFactory sets up informer, that maps resource type to a cache shared informer.
@@ -273,15 +256,15 @@ func main() {
 	// 				Obtain reference to shared index informers for the FluxHelmRelease
 	fhrInformer := ifInformerFactory.Helm().V1alpha().FluxHelmReleases()
 
-	rel := release.New(log.With(logger, "component", "release"), helmClient, checkoutFhr, checkoutCh, checkoutR)
+	rel := release.New(log.With(logger, "component", "release"), helmClient, checkoutFhr, checkoutCh)
+	relsync := releasesync.New(log.With(logger, "component", "releasesync"), rel)
 
 	// CHARTS CHANGES SYNC -----------------------------------------------------------------------------
-	chartSync := chartsync.New(log.With(logger, "component", "chartsync"), *chartsSyncInterval, *chartsSyncTimeout, *kubeClient, *ifClient, fhrInformer, rel)
+	chartSync := chartsync.New(log.With(logger, "component", "chartsync"),
+		chartsync.Polling{Interval: *chartsSyncInterval, Timeout: *chartsSyncTimeout},
+		chartsync.Clients{KubeClient: *kubeClient, IfClient: *ifClient},
+		rel, *relsync)
 	chartSync.Run(shutdown, errc, shutdownWg)
-
-	// MANUAL CHART RELEASES SYNC -----------------------------------------------------------------------------
-	releaseSync := releasesync.New(log.With(logger, "component", "releasesync"), *chartsSyncInterval, *chartsSyncTimeout, *kubeClient, *ifClient, rel)
-	releaseSync.Run(shutdown, errc, shutdownWg)
 
 	// OPERATOR - CUSTOM RESOURCES CHANGE SYNC ----------------------------------------------
 	opr := operator.New(log.With(logger, "component", "operator"), kubeClient, fhrInformer, rel)

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -27,8 +27,7 @@ import (
 
 	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha"
 	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
-	fhrv1 "github.com/weaveworks/flux/integrations/client/informers/externalversions/helm.integrations.flux.weave.works/v1alpha"
-	iflister "github.com/weaveworks/flux/integrations/client/listers/helm.integrations.flux.weave.works/v1alpha" // kubernetes 1.9
+	fhrv1 "github.com/weaveworks/flux/integrations/client/informers/externalversions/helm.integrations.flux.weave.works/v1alpha" // kubernetes 1.9
 	helmgit "github.com/weaveworks/flux/integrations/helm/git"
 	chartrelease "github.com/weaveworks/flux/integrations/helm/release"
 )
@@ -43,7 +42,6 @@ type ChartChangeSync struct {
 	Polling
 	kubeClient          kubernetes.Clientset
 	ifClient            ifclientset.Clientset
-	fhrLister           iflister.FluxHelmReleaseLister
 	release             *chartrelease.Release
 	lastCheckedRevision string
 	//sync.RWMutex
@@ -67,7 +65,6 @@ func New(
 		Polling:             Polling{Interval: syncInterval, Timeout: syncTimeout},
 		kubeClient:          kubeClient,
 		ifClient:            ifClient,
-		fhrLister:           fhrInformer.Lister(),
 		release:             release,
 		lastCheckedRevision: lastCheckedRevision,
 	}

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -79,8 +79,7 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 		defer runtime.HandleCrash()
 		defer wg.Done()
 
-		chartsSync := chs.release.Repo.ChartsSync
-		defer chartsSync.Cleanup()
+		defer chs.release.Repo.ChartsSync.Cleanup()
 
 		var exist bool
 		var newRev string
@@ -136,7 +135,7 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 					fmt.Printf("\n\t... CHARTSYNC work FINISHED at %s\n\n", time.Now().String())
 					continue
 				}
-				// Nothimg to release
+				// Nothing to release
 				if len(chartsToRelease) == 0 {
 					chs.lastCheckedRevision = newRev
 					fmt.Printf("\n\t... CHARTSYNC work FINISHED at %s\n\n", time.Now().String())

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -324,7 +324,8 @@ func (chs *ChartChangeSync) releaseCharts(chartsToRelease []string, chartFhrs ma
 			rlsName := chartrelease.GetReleaseName(fhr)
 
 			chs.logger.Log("info", "INSTALLING")
-			_, err = chs.release.Install(checkout, rlsName, fhr, "UPDATE", false)
+			opts := chartrelease.InstallOptions{DryRun: false}
+			_, err = chs.release.Install(checkout, rlsName, fhr, "UPDATE", opts)
 			if err != nil {
 				chs.logger.Log("info", fmt.Sprintf("Error during dry run upgrade of release of [%s]: %s. Skipping.", rlsName, err.Error()))
 				// TODO: collect errors and return them after looping through all - ?

--- a/integrations/helm/chartsync/utils.go
+++ b/integrations/helm/chartsync/utils.go
@@ -11,8 +11,8 @@ import (
 )
 
 func (chs *ChartChangeSync) chartChanged(ctx context.Context, dir, revRange, chart string) (bool, error) {
-	chs.release.Repo.ChartsSync.Lock()
-	defer chs.release.Repo.ChartsSync.Unlock()
+	chs.release.Repo.ConfigSync.Lock()
+	defer chs.release.Repo.ConfigSync.Unlock()
 
 	if len(dir) == 0 || dir[0] != '/' {
 		return false, fmt.Errorf("directory must provided and must be absolute: [%s]", dir)

--- a/integrations/helm/customresource/customresource.go
+++ b/integrations/helm/customresource/customresource.go
@@ -1,0 +1,11 @@
+package customresource
+
+import (
+	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha"
+	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func GetNSCustomResources(ifClient ifclientset.Clientset, ns string) (*ifv1.FluxHelmReleaseList, error) {
+	return ifClient.HelmV1alpha().FluxHelmReleases(ns).List(metav1.ListOptions{})
+}

--- a/integrations/helm/git/git.go
+++ b/integrations/helm/git/git.go
@@ -79,7 +79,6 @@ func RepoSetup(logger log.Logger, auth *gitssh.PublicKeys, config GitRemoteConfi
 	// If cloning not immediately possible, we wait until it is -----------------------------
 	var err error
 	for {
-		logger.Log("info", "Cloning repo ...")
 		ctx, cancel := context.WithTimeout(context.Background(), DefaultCloneTimeout)
 		err = checkout.Clone(ctx, cloneSubdir)
 		cancel()
@@ -89,7 +88,6 @@ func RepoSetup(logger log.Logger, auth *gitssh.PublicKeys, config GitRemoteConfi
 		logger.Log("error", fmt.Sprintf("Failed to clone git repo [%s, %s, %s]: %v", config.URL, config.Path, config.Branch, err))
 		time.Sleep(10 * time.Second)
 	}
-	logger.Log("info", "Repo cloned")
 
 	return checkout
 }

--- a/integrations/helm/git/git.go
+++ b/integrations/helm/git/git.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	DefaultCloneTimeout = 2 * time.Minute
-	DefaultPullTimeout  = 2 * time.Minute
-	privateKeyFileMode  = os.FileMode(0400)
-	FhrsChangesClone    = "fhrs_sync_clone"
-	ChartsChangesClone  = "charts_sync_clone"
+	DefaultCloneTimeout  = 2 * time.Minute
+	DefaultPullTimeout   = 2 * time.Minute
+	privateKeyFileMode   = os.FileMode(0400)
+	FhrsChangesClone     = "fhrs_sync_clone"
+	ChartsChangesClone   = "charts_sync_clone"
+	ReleasesChangesClone = "rels_sync_clone"
 )
 
 var (

--- a/integrations/helm/git/git.go
+++ b/integrations/helm/git/git.go
@@ -18,12 +18,10 @@ import (
 )
 
 const (
-	DefaultCloneTimeout  = 2 * time.Minute
-	DefaultPullTimeout   = 2 * time.Minute
-	privateKeyFileMode   = os.FileMode(0400)
-	FhrsChangesClone     = "fhrs_sync_clone"
-	ChartsChangesClone   = "charts_sync_clone"
-	ReleasesChangesClone = "rels_sync_clone"
+	DefaultCloneTimeout = 2 * time.Minute
+	DefaultPullTimeout  = 2 * time.Minute
+	privateKeyFileMode  = os.FileMode(0400)
+	ChangesClone        = "sync_clone"
 )
 
 var (

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -105,6 +105,7 @@ func New(
 	// ----- EVENT HANDLERS for FluxHelmRelease resources change ---------
 	fhrInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc: func(new interface{}) {
+			controller.logger.Log("info", "CREATING release")
 			controller.logger.Log("info", "Custom Resource driven release install")
 			_, ok := checkCustomResourceType(controller.logger, new)
 			if ok {
@@ -331,6 +332,7 @@ func (c *Controller) enqueueUpateJob(old, new interface{}) {
 	oldResVer := oldFhr.ResourceVersion
 	newResVer := newFhr.ResourceVersion
 	if newResVer != oldResVer {
+		c.logger.Log("info", "UPGRADING release")
 		c.logger.Log("info", "Custom Resource driven release upgrade")
 		c.enqueueJob(new)
 	}

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -122,7 +122,7 @@ func New(
 			}
 		},
 	})
-	controller.logger.Log("info", "Event handlers are set up")
+	controller.logger.Log("info", "Event handlers set up")
 
 	return controller
 }

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -270,7 +270,8 @@ func (c *Controller) syncHandler(key string) error {
 	}
 
 	// Chart installation of the appropriate type
-	_, err = c.release.Install(c.release.Repo.ConfigSync, releaseName, *fhr, syncType, false)
+	opts := chartrelease.InstallOptions{DryRun: false}
+	_, err = c.release.Install(c.release.Repo.ConfigSync, releaseName, *fhr, syncType, opts)
 	if err != nil {
 		return err
 	}

--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -37,7 +37,6 @@ type Release struct {
 
 type repo struct {
 	ConfigSync *helmgit.Checkout
-	ChartSync  *helmgit.Checkout
 }
 
 type DeployInfo struct {
@@ -50,10 +49,9 @@ type InstallOptions struct {
 }
 
 // New creates a new Release instance
-func New(logger log.Logger, helmClient *k8shelm.Client, configCheckout *helmgit.Checkout, chartsCheckout *helmgit.Checkout) *Release {
+func New(logger log.Logger, helmClient *k8shelm.Client, configCheckout *helmgit.Checkout) *Release {
 	repo := repo{
 		ConfigSync: configCheckout,
-		ChartSync:  chartsCheckout,
 	}
 	r := &Release{
 		logger:     logger,

--- a/integrations/helm/releasesync/releasesync.go
+++ b/integrations/helm/releasesync/releasesync.go
@@ -5,7 +5,9 @@ with the prescribed state defined in the get repo.
 package releasesync
 
 import (
+	"context"
 	"fmt"
+	"sync"
 	"time"
 
 	protobuf "github.com/golang/protobuf/ptypes/timestamp"
@@ -13,14 +15,15 @@ import (
 	"github.com/weaveworks/flux/integrations/helm/release"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/go-kit/kit/log"
 
 	//"gopkg.in/src-d/go-git.v4/plumbing"
 	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha"
-	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
-	iflister "github.com/weaveworks/flux/integrations/client/listers/helm.integrations.flux.weave.works/v1alpha" // kubernetes 1.9
+	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned" // kubernetes 1.9
+	helmgit "github.com/weaveworks/flux/integrations/helm/git"
 	chartrelease "github.com/weaveworks/flux/integrations/helm/release"
 )
 
@@ -28,28 +31,42 @@ type action string
 
 const (
 	CustomResourceKind        = "FluxHelmRelease"
-	releaseLagTime            = int64(60 * time.Second)
+	releaseLagTime            = 30
 	deleteAction       action = "DELETE"
-	installAction      action = "INSTALL"
-	upgradeAction      action = "UPGRADE"
+	installAction      action = "CREATE"
+	upgradeAction      action = "UPDATE"
 )
 
-// Polling allows to specify polling criteria
-type Polling struct {
-	Interval time.Duration
-	Timeout  time.Duration
+type ReleaseFhr struct {
+	RelName string
+	FhrName string
+	Fhr     ifv1.FluxHelmRelease
 }
 
 // ReleaseChangeSync will become a receiver, that contains
 //
 type ReleaseChangeSync struct {
 	logger log.Logger
-	Polling
+	chartsync.Polling
 	kubeClient kubernetes.Clientset
-	chartSync  chartsync.ChartChangeSync
-	ifClient   ifclientset.Clientset
-	fhrLister  iflister.FluxHelmReleaseLister
-	release    *chartrelease.Release
+	//chartSync  chartsync.ChartChangeSync
+	ifClient ifclientset.Clientset
+	//fhrLister iflister.FluxHelmReleaseLister
+	release *chartrelease.Release
+}
+
+func New(
+	logger log.Logger, syncInterval time.Duration, syncTimeout time.Duration,
+	kubeClient kubernetes.Clientset, ifClient ifclientset.Clientset,
+	release *chartrelease.Release) *ReleaseChangeSync {
+
+	return &ReleaseChangeSync{
+		logger:     logger,
+		Polling:    chartsync.Polling{Interval: syncInterval, Timeout: syncTimeout},
+		kubeClient: kubeClient,
+		ifClient:   ifClient,
+		release:    release,
+	}
 }
 
 type customResourceInfo struct {
@@ -64,6 +81,59 @@ type chartRelease struct {
 	desiredState ifv1.FluxHelmRelease
 }
 
+// Run ... creates a syncing loop monitoring repo chart changes
+func (rs *ReleaseChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *sync.WaitGroup) {
+	rs.logger.Log("info", "Starting repo charts sync loop")
+
+	wg.Add(1)
+	go func() {
+		defer runtime.HandleCrash()
+		defer wg.Done()
+		defer rs.release.Repo.ReleasesSync.Cleanup()
+
+		time.Sleep(30 * time.Second)
+
+		ticker := time.NewTicker(rs.Polling.Interval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			// ------------------------------------------------------------------------------------
+			case <-ticker.C:
+				fmt.Printf("\n\t... RELEASESYNC at %s\n\n", time.Now().String())
+				ctx, cancel := context.WithTimeout(context.Background(), helmgit.DefaultCloneTimeout)
+				relsToSync, err := rs.releasesToSync(ctx)
+				cancel()
+				if err != nil {
+					rs.logger.Log("error", fmt.Sprintf("Failure to get info about manual chart release changes: %#v", err))
+					fmt.Printf("\n\t... RELEASESYNC work FINISHED at %s\n\n", time.Now().String())
+					continue
+				}
+
+				// manual chart release changes?
+				if len(relsToSync) == 0 {
+					rs.logger.Log("info", fmt.Sprintln("No manual changes of Chart releases"))
+					fmt.Printf("\n\t... RELEASESYNC work FINISHED at %s\n\n", time.Now().String())
+					continue
+				}
+
+				// sync Chart releases
+				ctx, cancel = context.WithTimeout(context.Background(), helmgit.DefaultCloneTimeout)
+				err = rs.sync(ctx, relsToSync)
+				cancel()
+				if err != nil {
+					rs.logger.Log("error", fmt.Sprintf("Failure to sync cluster after manual chart release changes: %#v", err))
+				}
+				fmt.Printf("\n\t... RELEASESYNC work FINISHED at %s\n\n", time.Now().String())
+			// ------------------------------------------------------------------------------------
+			case <-stopCh:
+				rs.logger.Log("stopping", "true")
+				break
+			}
+		}
+	}()
+}
+
 func (rs *ReleaseChangeSync) getNSCustomResources(ns string) (*ifv1.FluxHelmReleaseList, error) {
 	return rs.ifClient.HelmV1alpha().FluxHelmReleases(ns).List(metav1.ListOptions{})
 }
@@ -74,73 +144,70 @@ func (rs *ReleaseChangeSync) getNSEvents(ns string) (*v1.EventList, error) {
 
 // getCustomResources retrieves FluxHelmRelease resources
 //		and outputs them organised by namespace and: Chart release name or Custom Resource name
-//						map[namespace]["fhrName"][FHR name]     = ifv1.FluxHelmRelease
-//						map[namespace]["relName"][release name] = ifv1.FluxHelmRelease
-func (rs *ReleaseChangeSync) getCustomResources(namespaces []string) map[string]map[string]map[string]ifv1.FluxHelmRelease {
-	var relInfo map[string]map[string]map[string]ifv1.FluxHelmRelease
+//						map[namespace] = []ReleaseFhr
+func (rs *ReleaseChangeSync) getCustomResources(namespaces []string) (map[string][]ReleaseFhr, error) {
+	relInfo := make(map[string][]ReleaseFhr)
 
+	fmt.Println("\nGETTING CUSTOM RESOURCES")
 	for _, ns := range namespaces {
 		list, err := rs.getNSCustomResources(ns)
 		if err != nil {
 			rs.logger.Log("error", fmt.Errorf("Failure while retrieving FluxHelmReleases in namespace %s: %v", ns, err))
-			continue
+			return nil, err
 		}
-		var relM map[string]map[string]ifv1.FluxHelmRelease
-		var inRelNameM map[string]ifv1.FluxHelmRelease
-		var inFhrNameM map[string]ifv1.FluxHelmRelease
+		rf := []ReleaseFhr{}
 		for _, fhr := range list.Items {
 			relName := release.GetReleaseName(fhr)
-
-			inRelNameM[relName] = fhr
-			inFhrNameM[fhr.Name] = fhr
-
-			relM["relName"] = inRelNameM
-			relM["fhrName"] = inFhrNameM
-			relInfo[ns] = relM
+			rf = append(rf, ReleaseFhr{RelName: relName, Fhr: fhr})
+			//fmt.Printf(">>> existing FHRs    ns: %s ... relName: %s\n", ns, relName)
+		}
+		if len(rf) > 0 {
+			relInfo[ns] = rf
 		}
 	}
-	return relInfo
+	return relInfo, nil
 }
 
 // getReleaseEvents retrieves and stores last event timestamp for FluxHelmRelease resources (FHR)
 //		output:
-//						map[namespace][FHR name] = time.Unix() [int64]
+//						map[namespace][FHR name] = int64
 func (rs *ReleaseChangeSync) getEventsLastTimestamp(namespaces []string) (map[string]map[string]int64, error) {
-	var relEventsTime map[string]map[string]int64
+	relEventsTime := make(map[string]map[string]int64)
 
+	fmt.Println("\nGETTING CUSTOM RESOURCE EVENTS")
 	for _, ns := range namespaces {
 		eventList, err := rs.getNSEvents(ns)
 		if err != nil {
 			return relEventsTime, err
 		}
+		fhrD := make(map[string]int64)
 		for _, e := range eventList.Items {
 			if e.InvolvedObject.Kind == CustomResourceKind {
 				secs := e.LastTimestamp.Unix()
-				relEventsTime[ns] = map[string]int64{e.InvolvedObject.Name: secs}
+				fhrD[e.InvolvedObject.Name] = secs
+
+				//fmt.Printf("<<< existing FHR Events    ns: %s ... fhrName: %s ... %d (%s)\n", ns, e.InvolvedObject.Name, secs, e.LastTimestamp.String())
+				//fmt.Printf("\t<<< map of existing FHR Events    ns: %s \n\n\t%+v\n\n", ns, fhrD)
 			}
 		}
+		relEventsTime[ns] = fhrD
 	}
 	return relEventsTime, nil
 }
 
 // existingReleasesToSync determines which Chart releases need to be deleted/upgraded
 // to bring the cluster to the desired state
-// TODO: more thinking
 func (rs *ReleaseChangeSync) existingReleasesToSync(
 	currentReleases map[string]map[string]int64,
-	customResources map[string]map[string]map[string]ifv1.FluxHelmRelease,
-	events map[string]map[string]int64) (map[string][]chartRelease, error) {
-	/*namespaces, err := chartsync.GetNamespaces(rs.logger, kubeClient)
-	if err != nil {
-		return map[string][]chartRelease{}, err
-	}
-	*/
-	var relsToSync map[string][]chartRelease
-	var chRels []chartRelease
+	customResources map[string]map[string]ifv1.FluxHelmRelease,
+	events map[string]map[string]int64,
+	relsToSync map[string][]chartRelease) error {
 
+	var chRels []chartRelease
 	for ns, nsRelsM := range currentReleases {
+		chRels = relsToSync[ns]
 		for relName, relUpdated := range nsRelsM {
-			fhr, ok := customResources[ns]["relName"][relName]
+			fhr, ok := customResources[ns][relName]
 			if !ok {
 				chr := chartRelease{
 					releaseName:  relName,
@@ -149,8 +216,9 @@ func (rs *ReleaseChangeSync) existingReleasesToSync(
 				}
 				chRels = append(chRels, chr)
 			} else {
-				// TODO: more thinking
 				fhrUpdated := events[ns][fhr.Name]
+				rs.logger.Log("info", fmt.Sprintf("release last deploy: %d ... FHR last deploy: %d => relUpdated - fhrUpdated: %d secs\n\n", relUpdated, fhrUpdated, relUpdated-fhrUpdated))
+
 				if (relUpdated - fhrUpdated) > releaseLagTime {
 					chr := chartRelease{
 						releaseName:  relName,
@@ -161,46 +229,81 @@ func (rs *ReleaseChangeSync) existingReleasesToSync(
 				}
 			}
 		}
-		relsToSync[ns] = chRels
+		if len(chRels) > 0 {
+			relsToSync[ns] = chRels
+		}
 	}
-	return relsToSync, nil
+	return nil
 }
 
 // deletedReleasesToSync determines which Chart releases need to be installed
 // to bring the cluster to the desired state
-//
 func (rs *ReleaseChangeSync) deletedReleasesToSync(
-	namespaces []string,
-	customResources map[string]map[string]map[string]ifv1.FluxHelmRelease,
-	currentReleases map[string]map[string]int64) (map[string][]chartRelease, error) {
+	customResources map[string]map[string]ifv1.FluxHelmRelease,
+	currentReleases map[string]map[string]int64,
+	relsToSync map[string][]chartRelease) error {
 
-	var relsToSync map[string][]chartRelease
 	var chRels []chartRelease
-	for _, ns := range namespaces {
-		// there are Custom Resources (CRs) in this namespace
-		if nsRels, ok := customResources[ns]["relName"]; ok {
-			for relName := range nsRels {
-				// missing Chart release even though there is a CR
-				if _, ok := currentReleases[ns][relName]; !ok {
-					chr := chartRelease{
-						releaseName:  relName,
-						action:       installAction,
-						desiredState: nsRels[relName],
-					}
-					chRels = append(chRels, chr)
+	for ns, nsFhrs := range customResources {
+		chRels = relsToSync[ns]
+
+		for relName, fhr := range nsFhrs {
+			// there are Custom Resources (CRs) in this namespace
+			// missing Chart release even though there is a CR
+			if _, ok := currentReleases[ns][relName]; !ok {
+				chr := chartRelease{
+					releaseName:  relName,
+					action:       installAction,
+					desiredState: fhr,
 				}
+				chRels = append(chRels, chr)
 			}
 		}
-		relsToSync[ns] = chRels
+		if len(chRels) > 0 {
+			relsToSync[ns] = chRels
+		}
 	}
+	return nil
+}
+
+// releasesToSync gathers all releases that need syncing
+func (rs *ReleaseChangeSync) releasesToSync(ctx context.Context) (map[string][]chartRelease, error) {
+	ns, err := chartsync.GetNamespaces(rs.logger, rs.kubeClient)
+	if err != nil {
+		return nil, err
+	}
+	relDepl, err := rs.release.GetCurrentWithDate()
+	if err != nil {
+		return nil, err
+	}
+	curRels := MappifyDeployInfo(relDepl)
+	//rs.logger.Log("info", fmt.Sprintf("+++ curRels:\n\n%#v\n\n", curRels))
+	//fmt.Sprintf("*** curRels:\n\n%+v\n\n", curRels)
+
+	relCrs, err := rs.getCustomResources(ns)
+	if err != nil {
+		return nil, err
+	}
+	crs := MappifyReleaseFhrInfo(relCrs)
+	//rs.logger.Log("info", fmt.Sprintf("+++ crs:\n\n%#v\n\n", crs))
+	//fmt.Sprintf("*** crs:\n\n%+v\n\n", crs)
+
+	evs, err := rs.getEventsLastTimestamp(ns)
+	if err != nil {
+		return nil, err
+	}
+
+	relsToSync := make(map[string][]chartRelease)
+	rs.deletedReleasesToSync(crs, curRels, relsToSync)
+	rs.existingReleasesToSync(curRels, crs, evs, relsToSync)
 
 	return relsToSync, nil
 }
 
 // sync deletes/upgrades a Chart release
-func (rs *ReleaseChangeSync) sync(releases map[string][]chartRelease) error {
-	checkout := rs.release.Repo.ReleasesSync
+func (rs *ReleaseChangeSync) sync(ctx context.Context, releases map[string][]chartRelease) error {
 
+	checkout := rs.release.Repo.ReleasesSync
 	for ns, relsToProcess := range releases {
 		for _, chr := range relsToProcess {
 			relName := chr.releaseName
@@ -219,7 +322,7 @@ func (rs *ReleaseChangeSync) sync(releases map[string][]chartRelease) error {
 				}
 			case installAction:
 				rs.logger.Log("info", fmt.Sprintf("Installing manually deleted Chart release %s (namespace %s)", relName, ns))
-				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("INSTALL"), false)
+				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("CREATE"), false)
 				if err != nil {
 					return err
 				}

--- a/integrations/helm/releasesync/releasesync.go
+++ b/integrations/helm/releasesync/releasesync.go
@@ -1,0 +1,230 @@
+/*
+When a Chart release is deleted/upgraded/created manually, the cluster gets out of sync
+with the prescribed state defined in the get repo.
+*/
+package releasesync
+
+import (
+	"fmt"
+	"time"
+
+	protobuf "github.com/golang/protobuf/ptypes/timestamp"
+	"github.com/weaveworks/flux/integrations/helm/chartsync"
+	"github.com/weaveworks/flux/integrations/helm/release"
+	"k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/go-kit/kit/log"
+
+	//"gopkg.in/src-d/go-git.v4/plumbing"
+	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha"
+	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
+	iflister "github.com/weaveworks/flux/integrations/client/listers/helm.integrations.flux.weave.works/v1alpha" // kubernetes 1.9
+	chartrelease "github.com/weaveworks/flux/integrations/helm/release"
+)
+
+type action string
+
+const (
+	CustomResourceKind        = "FluxHelmRelease"
+	releaseLagTime            = int64(60 * time.Second)
+	deleteAction       action = "DELETE"
+	installAction      action = "INSTALL"
+	upgradeAction      action = "UPGRADE"
+)
+
+// Polling allows to specify polling criteria
+type Polling struct {
+	Interval time.Duration
+	Timeout  time.Duration
+}
+
+// ReleaseChangeSync will become a receiver, that contains
+//
+type ReleaseChangeSync struct {
+	logger log.Logger
+	Polling
+	kubeClient kubernetes.Clientset
+	chartSync  chartsync.ChartChangeSync
+	ifClient   ifclientset.Clientset
+	fhrLister  iflister.FluxHelmReleaseLister
+	release    *chartrelease.Release
+}
+
+type customResourceInfo struct {
+	name, releaseName string
+	resource          ifv1.FluxHelmRelease
+	lastUpdated       protobuf.Timestamp
+}
+
+type chartRelease struct {
+	releaseName  string
+	action       action
+	desiredState ifv1.FluxHelmRelease
+}
+
+func (rs *ReleaseChangeSync) getNSCustomResources(ns string) (*ifv1.FluxHelmReleaseList, error) {
+	return rs.ifClient.HelmV1alpha().FluxHelmReleases(ns).List(metav1.ListOptions{})
+}
+
+func (rs *ReleaseChangeSync) getNSEvents(ns string) (*v1.EventList, error) {
+	return rs.kubeClient.CoreV1().Events(ns).List(metav1.ListOptions{})
+}
+
+// getCustomResources retrieves FluxHelmRelease resources
+//		and outputs them organised by namespace and: Chart release name or Custom Resource name
+//						map[namespace]["fhrName"][FHR name]     = ifv1.FluxHelmRelease
+//						map[namespace]["relName"][release name] = ifv1.FluxHelmRelease
+func (rs *ReleaseChangeSync) getCustomResources(namespaces []string) map[string]map[string]map[string]ifv1.FluxHelmRelease {
+	var relInfo map[string]map[string]map[string]ifv1.FluxHelmRelease
+
+	for _, ns := range namespaces {
+		list, err := rs.getNSCustomResources(ns)
+		if err != nil {
+			rs.logger.Log("error", fmt.Errorf("Failure while retrieving FluxHelmReleases in namespace %s: %v", ns, err))
+			continue
+		}
+		var relM map[string]map[string]ifv1.FluxHelmRelease
+		var inRelNameM map[string]ifv1.FluxHelmRelease
+		var inFhrNameM map[string]ifv1.FluxHelmRelease
+		for _, fhr := range list.Items {
+			relName := release.GetReleaseName(fhr)
+
+			inRelNameM[relName] = fhr
+			inFhrNameM[fhr.Name] = fhr
+
+			relM["relName"] = inRelNameM
+			relM["fhrName"] = inFhrNameM
+			relInfo[ns] = relM
+		}
+	}
+	return relInfo
+}
+
+// getReleaseEvents retrieves and stores last event timestamp for FluxHelmRelease resources (FHR)
+//		output:
+//						map[namespace][FHR name] = time.Unix() [int64]
+func (rs *ReleaseChangeSync) getEventsLastTimestamp(namespaces []string) (map[string]map[string]int64, error) {
+	var relEventsTime map[string]map[string]int64
+
+	for _, ns := range namespaces {
+		eventList, err := rs.getNSEvents(ns)
+		if err != nil {
+			return relEventsTime, err
+		}
+		for _, e := range eventList.Items {
+			if e.InvolvedObject.Kind == CustomResourceKind {
+				secs := e.LastTimestamp.Unix()
+				relEventsTime[ns] = map[string]int64{e.InvolvedObject.Name: secs}
+			}
+		}
+	}
+	return relEventsTime, nil
+}
+
+// existingReleasesToSync determines which Chart releases need to be deleted/upgraded
+// to bring the cluster to the desired state
+// TODO: more thinking
+func (rs *ReleaseChangeSync) existingReleasesToSync(
+	currentReleases map[string]map[string]int64,
+	customResources map[string]map[string]map[string]ifv1.FluxHelmRelease,
+	events map[string]map[string]int64) (map[string][]chartRelease, error) {
+	/*namespaces, err := chartsync.GetNamespaces(rs.logger, kubeClient)
+	if err != nil {
+		return map[string][]chartRelease{}, err
+	}
+	*/
+	var relsToSync map[string][]chartRelease
+	var chRels []chartRelease
+
+	for ns, nsRelsM := range currentReleases {
+		for relName, relUpdated := range nsRelsM {
+			fhr, ok := customResources[ns]["relName"][relName]
+			if !ok {
+				chr := chartRelease{
+					releaseName:  relName,
+					action:       deleteAction,
+					desiredState: fhr,
+				}
+				chRels = append(chRels, chr)
+			} else {
+				// TODO: more thinking
+				fhrUpdated := events[ns][fhr.Name]
+				if (relUpdated - fhrUpdated) > releaseLagTime {
+					chr := chartRelease{
+						releaseName:  relName,
+						action:       upgradeAction,
+						desiredState: fhr,
+					}
+					chRels = append(chRels, chr)
+				}
+			}
+		}
+		relsToSync[ns] = chRels
+	}
+	return relsToSync, nil
+}
+
+// deletedReleasesToSync determines which Chart releases need to be installed
+// to bring the cluster to the desired state
+//
+func (rs *ReleaseChangeSync) deletedReleasesToSync(
+	namespaces []string,
+	customResources map[string]map[string]map[string]ifv1.FluxHelmRelease,
+	currentReleases map[string]map[string]int64) (map[string][]chartRelease, error) {
+
+	var relsToSync map[string][]chartRelease
+	var chRels []chartRelease
+	for _, ns := range namespaces {
+		// there are Custom Resources (CRs) in this namespace
+		if nsRels, ok := customResources[ns]["relName"]; ok {
+			for relName := range nsRels {
+				// missing Chart release even though there is a CR
+				if _, ok := currentReleases[ns][relName]; !ok {
+					chr := chartRelease{
+						releaseName:  relName,
+						action:       installAction,
+						desiredState: nsRels[relName],
+					}
+					chRels = append(chRels, chr)
+				}
+			}
+		}
+		relsToSync[ns] = chRels
+	}
+
+	return relsToSync, nil
+}
+
+// sync deletes/upgrades a Chart release
+func (rs *ReleaseChangeSync) sync(releases map[string][]chartRelease) error {
+	checkout := rs.release.Repo.ReleasesSync
+
+	for ns, relsToProcess := range releases {
+		for _, chr := range relsToProcess {
+			relName := chr.releaseName
+			switch chr.action {
+			case deleteAction:
+				rs.logger.Log("info", fmt.Sprintf("Deleting manually installed Chart release %s (namespace %s)", relName, ns))
+				err := rs.release.Delete(relName)
+				if err != nil {
+					return err
+				}
+			case upgradeAction:
+				rs.logger.Log("info", fmt.Sprintf("Resyncing manually upgraded Chart release %s (namespace %s)", relName, ns))
+				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("UPDATE"), false)
+				if err != nil {
+					return err
+				}
+			case installAction:
+				rs.logger.Log("info", fmt.Sprintf("Installing manually deleted Chart release %s (namespace %s)", relName, ns))
+				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("INSTALL"), false)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
+}

--- a/integrations/helm/releasesync/releasesync.go
+++ b/integrations/helm/releasesync/releasesync.go
@@ -304,6 +304,7 @@ func (rs *ReleaseChangeSync) releasesToSync(ctx context.Context) (map[string][]c
 func (rs *ReleaseChangeSync) sync(ctx context.Context, releases map[string][]chartRelease) error {
 
 	checkout := rs.release.Repo.ReleasesSync
+	opts := chartrelease.InstallOptions{DryRun: false}
 	for ns, relsToProcess := range releases {
 		for _, chr := range relsToProcess {
 			relName := chr.releaseName
@@ -316,13 +317,13 @@ func (rs *ReleaseChangeSync) sync(ctx context.Context, releases map[string][]cha
 				}
 			case upgradeAction:
 				rs.logger.Log("info", fmt.Sprintf("Resyncing manually upgraded Chart release %s (namespace %s)", relName, ns))
-				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("UPDATE"), false)
+				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("UPDATE"), opts)
 				if err != nil {
 					return err
 				}
 			case installAction:
 				rs.logger.Log("info", fmt.Sprintf("Installing manually deleted Chart release %s (namespace %s)", relName, ns))
-				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("CREATE"), false)
+				_, err := rs.release.Install(checkout, relName, chr.desiredState, chartrelease.ReleaseType("CREATE"), opts)
 				if err != nil {
 					return err
 				}

--- a/integrations/helm/releasesync/utils.go
+++ b/integrations/helm/releasesync/utils.go
@@ -5,13 +5,13 @@ import (
 	"github.com/weaveworks/flux/integrations/helm/release"
 )
 
-func MappifyDeployInfo(releases map[string][]release.DeployInfo) map[string]map[string]int64 {
-	deployM := make(map[string]map[string]int64)
+func MappifyDeployInfo(releases map[string][]release.DeployInfo) map[string]map[string]struct{} {
+	deployM := make(map[string]map[string]struct{})
 
 	for ns, nsRels := range releases {
-		nsDeployM := make(map[string]int64)
+		nsDeployM := make(map[string]struct{})
 		for _, r := range nsRels {
-			nsDeployM[r.Name] = r.Deployed
+			nsDeployM[r.Name] = struct{}{}
 		}
 		deployM[ns] = nsDeployM
 	}

--- a/integrations/helm/releasesync/utils.go
+++ b/integrations/helm/releasesync/utils.go
@@ -1,0 +1,33 @@
+package releasesync
+
+import (
+	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha"
+	"github.com/weaveworks/flux/integrations/helm/release"
+)
+
+func MappifyDeployInfo(releases map[string][]release.DeployInfo) map[string]map[string]int64 {
+	deployM := make(map[string]map[string]int64)
+
+	for ns, nsRels := range releases {
+		nsDeployM := make(map[string]int64)
+		for _, r := range nsRels {
+			nsDeployM[r.Name] = r.Deployed
+		}
+		deployM[ns] = nsDeployM
+	}
+	return deployM
+}
+
+func MappifyReleaseFhrInfo(fhrs map[string][]ReleaseFhr) map[string]map[string]ifv1.FluxHelmRelease {
+	relFhrM := make(map[string]map[string]ifv1.FluxHelmRelease)
+
+	for ns, nsFhrs := range fhrs {
+		nsRels := make(map[string]ifv1.FluxHelmRelease)
+		for _, r := range nsFhrs {
+			nsRels[r.RelName] = r.Fhr
+		}
+		relFhrM[ns] = nsRels
+	}
+
+	return relFhrM
+}


### PR DESCRIPTION
When a Chart release is manually handled (upgraded/installed/deleted), the cluster gets out of sync with the desired state prescribed through Custom Resources.

The implementation regularly polls the cluster to check whether only expected Chart releases are running, all of them and no others. The existing Chart releases are checked for changes from the desired state described by their respective Custom Resources. Diversion from the expected state leads to an upgrade install of the changed release.

Fixes #980