### PR TITLE
Break dependencies among git, job, event packages

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -149,22 +149,19 @@ func (d *Daemon) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6
 	return res, nil
 }
 
-// Let's use the CommitEventMetadata as a convenient transport for the
-// results of a job; if no commit was made (e.g., if it was a dry
-// run), leave the revision field empty.
-type DaemonJobFunc func(ctx context.Context, jobID job.ID, working *git.Checkout, logger log.Logger) (*event.CommitEventMetadata, error)
+type daemonJobFunc func(ctx context.Context, jobID job.ID, working *git.Checkout, logger log.Logger) (job.Result, error)
 
 // executeJob runs a job func in a cloned working directory, keeping track of its status.
-func (d *Daemon) executeJob(id job.ID, do DaemonJobFunc, logger log.Logger) (*event.CommitEventMetadata, error) {
+func (d *Daemon) executeJob(id job.ID, do daemonJobFunc, logger log.Logger) (job.Result, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultJobTimeout)
 	defer cancel()
 	d.JobStatusCache.SetStatus(id, job.Status{StatusString: job.StatusRunning})
 	// make a working clone so we don't mess with files we
 	// will be reading from elsewhere
-	var metadata *event.CommitEventMetadata
+	var result job.Result
 	err := d.WithClone(ctx, func(working *git.Checkout) error {
 		var err error
-		metadata, err = do(ctx, id, working, logger)
+		result, err = do(ctx, id, working, logger)
 		if err != nil {
 			return err
 		}
@@ -172,14 +169,14 @@ func (d *Daemon) executeJob(id job.ID, do DaemonJobFunc, logger log.Logger) (*ev
 	})
 	if err != nil {
 		d.JobStatusCache.SetStatus(id, job.Status{StatusString: job.StatusFailed, Err: err.Error()})
-		return nil, err
+		return result, err
 	}
-	d.JobStatusCache.SetStatus(id, job.Status{StatusString: job.StatusSucceeded, Result: *metadata})
-	return metadata, nil
+	d.JobStatusCache.SetStatus(id, job.Status{StatusString: job.StatusSucceeded, Result: result})
+	return result, nil
 }
 
 // queueJob queues a job func to be executed.
-func (d *Daemon) queueJob(do DaemonJobFunc) job.ID {
+func (d *Daemon) queueJob(do daemonJobFunc) job.ID {
 	id := job.ID(guid.New())
 	enqueuedAt := time.Now()
 	d.Jobs.Enqueue(&job.Job{
@@ -187,18 +184,25 @@ func (d *Daemon) queueJob(do DaemonJobFunc) job.ID {
 		Do: func(logger log.Logger) error {
 			queueDuration.Observe(time.Since(enqueuedAt).Seconds())
 			started := time.Now().UTC()
-			metadata, err := d.executeJob(id, do, logger)
+			result, err := d.executeJob(id, do, logger)
 			if err != nil {
 				return err
 			}
-			logger.Log("revision", metadata.Revision)
-			if metadata.Revision != "" {
+			logger.Log("revision", result.Revision)
+			if result.Revision != "" {
 				var serviceIDs []flux.ResourceID
-				for id, result := range metadata.Result {
+				for id, result := range result.Result {
 					if result.Status == update.ReleaseStatusSuccess {
 						serviceIDs = append(serviceIDs, id)
 					}
 				}
+
+				metadata := &event.CommitEventMetadata{
+					Revision: result.Revision,
+					Spec:     result.Spec,
+					Result:   result.Result,
+				}
+
 				return d.LogEvent(event.Event{
 					ServiceIDs: serviceIDs,
 					Type:       event.EventCommit,
@@ -237,11 +241,11 @@ func (d *Daemon) UpdateManifests(ctx context.Context, spec update.Spec) (job.ID,
 	}
 }
 
-func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) DaemonJobFunc {
-	return func(ctx context.Context, jobID job.ID, working *git.Checkout, logger log.Logger) (*event.CommitEventMetadata, error) {
+func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) daemonJobFunc {
+	return func(ctx context.Context, jobID job.ID, working *git.Checkout, logger log.Logger) (job.Result, error) {
 		// For each update
 		var serviceIDs []flux.ResourceID
-		metadata := &event.CommitEventMetadata{
+		result := job.Result{
 			Spec:   &spec,
 			Result: update.Result{},
 		}
@@ -259,19 +263,19 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) DaemonJo
 			err := cluster.UpdateManifest(d.Manifests, working.ManifestDir(), serviceID, func(def []byte) ([]byte, error) {
 				newDef, err := d.Manifests.UpdatePolicies(def, u)
 				if err != nil {
-					metadata.Result[serviceID] = update.ControllerResult{
+					result.Result[serviceID] = update.ControllerResult{
 						Status: update.ReleaseStatusFailed,
 						Error:  err.Error(),
 					}
 					return nil, err
 				}
 				if string(newDef) == string(def) {
-					metadata.Result[serviceID] = update.ControllerResult{
+					result.Result[serviceID] = update.ControllerResult{
 						Status: update.ReleaseStatusSkipped,
 					}
 				} else {
 					serviceIDs = append(serviceIDs, serviceID)
-					metadata.Result[serviceID] = update.ControllerResult{
+					result.Result[serviceID] = update.ControllerResult{
 						Status: update.ReleaseStatusSuccess,
 					}
 				}
@@ -279,18 +283,18 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) DaemonJo
 			})
 			switch err {
 			case cluster.ErrNoResourceFilesFoundForService, cluster.ErrMultipleResourceFilesFoundForService:
-				metadata.Result[serviceID] = update.ControllerResult{
+				result.Result[serviceID] = update.ControllerResult{
 					Status: update.ReleaseStatusFailed,
 					Error:  err.Error(),
 				}
 			case nil:
 				// continue
 			default:
-				return nil, err
+				return result, err
 			}
 		}
 		if len(serviceIDs) == 0 {
-			return metadata, nil
+			return result, nil
 		}
 
 		commitAuthor := ""
@@ -298,35 +302,38 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) DaemonJo
 			commitAuthor = spec.Cause.User
 		}
 		commitAction := git.CommitAction{Author: commitAuthor, Message: policyCommitMessage(updates, spec.Cause)}
-		if err := working.CommitAndPush(ctx, commitAction, &git.Note{JobID: jobID, Spec: spec}); err != nil {
+		if err := working.CommitAndPush(ctx, commitAction, &note{JobID: jobID, Spec: spec}); err != nil {
 			// On the chance pushing failed because it was not
 			// possible to fast-forward, ask for a sync so the
 			// next attempt is more likely to succeed.
 			d.AskForSync()
-			return nil, err
+			return result, err
 		}
 		if anythingAutomated {
 			d.AskForImagePoll()
 		}
 
 		var err error
-		metadata.Revision, err = working.HeadRevision(ctx)
+		result.Revision, err = working.HeadRevision(ctx)
 		if err != nil {
-			return nil, err
+			return result, err
 		}
-		return metadata, nil
+		return result, nil
 	}
 }
 
-func (d *Daemon) release(spec update.Spec, c release.Changes) DaemonJobFunc {
-	return func(ctx context.Context, jobID job.ID, working *git.Checkout, logger log.Logger) (*event.CommitEventMetadata, error) {
+func (d *Daemon) release(spec update.Spec, c release.Changes) daemonJobFunc {
+	return func(ctx context.Context, jobID job.ID, working *git.Checkout, logger log.Logger) (job.Result, error) {
 		rc := release.NewReleaseContext(d.Cluster, d.Manifests, d.Registry, working)
 		result, err := release.Release(rc, c, logger)
+
+		var zero job.Result
 		if err != nil {
-			return nil, err
+			return zero, err
 		}
 
 		var revision string
+
 		if c.ReleaseKind() == update.ReleaseKindExecute {
 			commitMsg := spec.Cause.Message
 			if commitMsg == "" {
@@ -337,20 +344,20 @@ func (d *Daemon) release(spec update.Spec, c release.Changes) DaemonJobFunc {
 				commitAuthor = spec.Cause.User
 			}
 			commitAction := git.CommitAction{Author: commitAuthor, Message: commitMsg}
-			if err := working.CommitAndPush(ctx, commitAction, &git.Note{JobID: jobID, Spec: spec, Result: result}); err != nil {
+			if err := working.CommitAndPush(ctx, commitAction, &note{JobID: jobID, Spec: spec, Result: result}); err != nil {
 				// On the chance pushing failed because it was not
 				// possible to fast-forward, ask the repo to fetch
 				// from upstream ASAP, so the next attempt is more
 				// likely to succeed.
 				d.Repo.Notify()
-				return nil, err
+				return zero, err
 			}
 			revision, err = working.HeadRevision(ctx)
 			if err != nil {
-				return nil, err
+				return zero, err
 			}
 		}
-		return &event.CommitEventMetadata{
+		return job.Result{
 			Revision: revision,
 			Spec:     &spec,
 			Result:   result,
@@ -407,14 +414,15 @@ func (d *Daemon) JobStatus(ctx context.Context, jobID job.ID) (job.Status, error
 
 		for _, commit := range commits {
 			if _, ok := notes[commit.Revision]; ok {
-				note, _ := working.GetNote(ctx, commit.Revision)
-				if note != nil && note.JobID == jobID {
+				var n note
+				ok, err := working.GetNote(ctx, commit.Revision, &n)
+				if ok && err == nil && n.JobID == jobID {
 					status = job.Status{
 						StatusString: job.StatusSucceeded,
-						Result: event.CommitEventMetadata{
+						Result: job.Result{
 							Revision: commit.Revision,
-							Spec:     &note.Spec,
-							Result:   note.Result,
+							Spec:     &n.Spec,
+							Result:   n.Result,
 						},
 					}
 					return nil

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -280,12 +280,13 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 				continue
 			}
 			ctx, cancel := context.WithTimeout(ctx, gitOpTimeout)
-			n, err := working.GetNote(ctx, commits[i].Revision)
+			var n note
+			ok, err := working.GetNote(ctx, commits[i].Revision, &n)
 			cancel()
 			if err != nil {
 				return errors.Wrap(err, "loading notes from repo")
 			}
-			if n == nil {
+			if !ok {
 				includes[event.NoneOfTheAbove] = true
 				continue
 			}

--- a/daemon/note.go
+++ b/daemon/note.go
@@ -1,11 +1,11 @@
-package git
+package daemon
 
 import (
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/update"
 )
 
-type Note struct {
+type note struct {
 	JobID  job.ID        `json:"jobID"`
 	Spec   update.Spec   `json:"spec"`
 	Result update.Result `json:"result"`

--- a/git/operations.go
+++ b/git/operations.go
@@ -128,7 +128,7 @@ func getNotesRef(ctx context.Context, workingDir, ref string) (string, error) {
 	return strings.TrimSpace(out.String()), nil
 }
 
-func addNote(ctx context.Context, workingDir, rev, notesRef string, note *Note) error {
+func addNote(ctx context.Context, workingDir, rev, notesRef string, note interface{}) error {
 	b, err := json.Marshal(note)
 	if err != nil {
 		return err
@@ -136,20 +136,18 @@ func addNote(ctx context.Context, workingDir, rev, notesRef string, note *Note) 
 	return execGitCmd(ctx, workingDir, nil, "notes", "--ref", notesRef, "add", "-m", string(b), rev)
 }
 
-// NB return values (*Note, nil), (nil, error), (nil, nil)
-func getNote(ctx context.Context, workingDir, notesRef, rev string) (*Note, error) {
+func getNote(ctx context.Context, workingDir, notesRef, rev string, note interface{}) (ok bool, err error) {
 	out := &bytes.Buffer{}
 	if err := execGitCmd(ctx, workingDir, out, "notes", "--ref", notesRef, "show", rev); err != nil {
 		if strings.Contains(strings.ToLower(err.Error()), "no note found for object") {
-			return nil, nil
+			return false, nil
 		}
-		return nil, err
+		return false, err
 	}
-	var note Note
-	if err := json.NewDecoder(out).Decode(&note); err != nil {
-		return nil, err
+	if err := json.NewDecoder(out).Decode(note); err != nil {
+		return false, err
 	}
-	return &note, nil
+	return true, nil
 }
 
 // Get all revisions with a note (NB: DO NOT RELY ON THE ORDERING)

--- a/git/working.go
+++ b/git/working.go
@@ -97,7 +97,7 @@ func (c *Checkout) ManifestDir() string {
 
 // CommitAndPush commits changes made in this checkout, along with any
 // extra data as a note, and pushes the commit and note to the remote repo.
-func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction, note *Note) error {
+func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction, note interface{}) error {
 	if !check(ctx, c.dir, c.config.Path) {
 		return ErrNoChanges
 	}
@@ -133,8 +133,8 @@ func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction,
 }
 
 // GetNote gets a note for the revision specified, or nil if there is no such note.
-func (c *Checkout) GetNote(ctx context.Context, rev string) (*Note, error) {
-	return getNote(ctx, c.dir, c.realNotesRef, rev)
+func (c *Checkout) GetNote(ctx context.Context, rev string, note interface{}) (bool, error) {
+	return getNote(ctx, c.dir, c.realNotesRef, rev, note)
 }
 
 func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {

--- a/job/job.go
+++ b/job/job.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 
-	"github.com/weaveworks/flux/event"
+	"github.com/weaveworks/flux/update"
 )
 
 type ID string
@@ -26,12 +26,21 @@ const (
 	StatusSucceeded StatusString = "succeeded"
 )
 
+// Result looks like CommitEventMetadata, because that's what we
+// used to send. But in the interest of breaking cycles before
+// they happen, it's (almost) duplicated here.
+type Result struct {
+	Revision string        `json:"revision,omitempty"`
+	Spec     *update.Spec  `json:"spec,omitempty"`
+	Result   update.Result `json:"result,omitempty"`
+}
+
 // Status holds the possible states of a job; either,
 //  1. queued or otherwise pending
 //  2. succeeded with a job-specific result
 //  3. failed, resulting in an error and possibly a job-specific result
 type Status struct {
-	Result       event.CommitEventMetadata
+	Result       Result
 	Err          string
 	StatusString StatusString
 }


### PR DESCRIPTION
These all use each others types, and that makes it difficult to
refactor other packages without introducing cycles. To break the
dependencies, I needed to:

 - make git accept any (JSON serialisable) value as a note
 - stop referring to an event type in the job package, and thereby the
   API and client