### PR TITLE
Reinstate control over the git polling interval

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -86,6 +86,8 @@ func main() {
 		gitSkipMessage = fs.String("git-ci-skip-message", "", "additional text for commit messages, useful for skipping builds in CI. Use this to supply specific text, or set --git-ci-skip")
 
 		gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period at which to poll git repo for new commits")
+		// syncing
+		syncInterval = fs.Duration("sync-interval", 5*time.Minute, "apply config in git to cluster at least this often, even if there are no new commits")
 		// registry
 		memcachedHostname    = fs.String("memcached-hostname", "memcached", "Hostname for memcached service.")
 		memcachedTimeout     = fs.Duration("memcached-timeout", time.Second, "Maximum time to wait before giving up on memcached requests.")
@@ -334,7 +336,7 @@ func main() {
 		SkipMessage: *gitSkipMessage,
 	}
 
-	repo := git.NewRepo(gitRemote)
+	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval))
 	{
 		shutdownWg.Add(1)
 		go func() {
@@ -371,7 +373,7 @@ func main() {
 		JobStatusCache: &job.StatusCache{Size: 100},
 		Logger:         log.With(logger, "component", "daemon"),
 		LoopVars: &daemon.LoopVars{
-			SyncInterval:         *gitPollInterval,
+			SyncInterval:         *syncInterval,
 			RegistryPollInterval: *registryPollInterval,
 		},
 	}

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -39,9 +39,9 @@ fluxd requires setup and offers customization though a multitude of flags.
 
 |flag                    | default                       | purpose |
 |------------------------|-------------------------------|---------|
-|--listen -l             | `:3030`                         | Listen address where /metrics and API will be served|
-|--kubernetes-kubectl    |                               | Optional, explicit path to kubectl tool|
-|--version               | false                         | Get version number|
+|--listen -l             | `:3030`                         | listen address where /metrics and API will be served|
+|--kubernetes-kubectl    |                               | optional, explicit path to kubectl tool|
+|--version               | false                         | output the version number and exit |
 |**Git repo & key etc.** |                              ||
 |--git-url               |                               | URL of git repo with Kubernetes manifests; e.g., `git@github.com:weaveworks/flux-example`|
 |--git-branch            | `master`                        | branch of git repo to use for Kubernetes manifests|
@@ -54,7 +54,9 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--git-label             |                               | label to keep track of sync progress; overrides both --git-sync-tag and --git-notes-ref|
 |--git-sync-tag          | `flux-sync`             | tag to use to mark sync progress for this cluster (old config, still used if --git-label is not supplied)|
 |--git-notes-ref         | `flux`            | ref to use for keeping commit annotations in git notes|
-|--git-poll-interval     | `5 minutes`                 | period at which to poll git repo for new commits|
+|--git-poll-interval     | `5 minutes`                 | period at which to fetch any new commits from the git repo |
+|**syncing**             |                             | control over how config is applied to the cluster |
+|--sync-interval         | `5 minutes`                 | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs |
 |**registry cache**      |                               | (none of these need overriding, usually) |
 |--memcached-hostname    | `memcached` | hostname for memcached service to use for caching image metadata|
 |--memcached-timeout     | `1 second`                   | maximum time to wait before giving up on memcached requests|


### PR DESCRIPTION
The flag --git-poll-interval used to control how often the daemon'
sync loop would run a sync, which involved fetching any new commits,
then applying the config (whether there were new commits or not) to
the cluster.

When git.Repo gained its own independent existence, the flag was left
where it was, in the sync loop. That meant it controlled the syncs,
but no longer the git polling, which was hard-wired.

This commit makes it affect the git polling interval again,
directly. The sync interval gets its own flag, with the same default
value.

Resolves #1029.