### PR TITLE
Make mode of ssh identity files RO

### DIFF
--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -17,6 +17,7 @@ spec:
       - name: git-key
         secret:
           secretName: flux-git-deploy
+          defaultMode: 0400 # when mounted read-only, we won't be able to chmod
       containers:
       - name: flux-helm-operator
         # There are no ":latest" images for helm-operator. Find the most recent
@@ -27,6 +28,7 @@ spec:
         volumeMounts:
         - name: git-key
           mountPath: /etc/fluxd/ssh
+          readOnly: true # this will be the case perforce in K8s >=1.10
         args:
         # replace (at least) the following URL
         - --git-url=git@github.com:weaveworks/flux-helm-test


### PR DESCRIPTION
This causes flux-helm-operator not to try to chmod them to this mode,
which in kubernetes 1.9.4+ and 1.10+, breaks, as secrets volumes are now
read-only filesystems, to mitigate CVE-2017-1002102. This effectively
reapplied the same fix to the main fluxd deployment.