### PR TITLE
Make auto-release commits and events more accurate

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/ssh"
 )
 
@@ -37,26 +38,18 @@ type Controller struct {
 	Containers ContainersOrExcuse
 }
 
-// A Container represents a container specification in a pod. The Name
-// identifies it within the pod, and the Image says which image it's
-// configured to run.
-type Container struct {
-	Name  string
-	Image string
-}
-
 // Sometimes we care if we can't find the containers for a service,
 // sometimes we just want the information we can get.
 type ContainersOrExcuse struct {
 	Excuse     string
-	Containers []Container
+	Containers []resource.Container
 }
 
-func (s Controller) ContainersOrNil() []Container {
+func (s Controller) ContainersOrNil() []resource.Container {
 	return s.Containers.Containers
 }
 
-func (s Controller) ContainersOrError() ([]Container, error) {
+func (s Controller) ContainersOrError() ([]resource.Container, error) {
 	var err error
 	if s.Containers.Excuse != "" {
 		err = errors.New(s.Containers.Excuse)

--- a/cluster/kubernetes/resource/cronjob.go
+++ b/cluster/kubernetes/resource/cronjob.go
@@ -1,5 +1,22 @@
 package resource
 
+import (
+	"github.com/weaveworks/flux/resource"
+)
+
 type CronJob struct {
 	baseObject
+	Spec CronJobSpec
+}
+
+type CronJobSpec struct {
+	JobTemplate struct {
+		Spec struct {
+			Template PodTemplate
+		}
+	}
+}
+
+func (c CronJob) Containers() []resource.Container {
+	return c.Spec.JobTemplate.Spec.Template.Containers()
 }

--- a/cluster/kubernetes/resource/daemonset.go
+++ b/cluster/kubernetes/resource/daemonset.go
@@ -1,5 +1,9 @@
 package resource
 
+import (
+	"github.com/weaveworks/flux/resource"
+)
+
 type DaemonSet struct {
 	baseObject
 	Spec DaemonSetSpec
@@ -7,4 +11,8 @@ type DaemonSet struct {
 
 type DaemonSetSpec struct {
 	Template PodTemplate
+}
+
+func (ds DaemonSet) Containers() []resource.Container {
+	return ds.Spec.Template.Containers()
 }

--- a/cluster/kubernetes/resource/deployment.go
+++ b/cluster/kubernetes/resource/deployment.go
@@ -1,5 +1,9 @@
 package resource
 
+import (
+	"github.com/weaveworks/flux/resource"
+)
+
 type Deployment struct {
 	baseObject
 	Spec DeploymentSpec
@@ -8,4 +12,8 @@ type Deployment struct {
 type DeploymentSpec struct {
 	Replicas int
 	Template PodTemplate
+}
+
+func (d Deployment) Containers() []resource.Container {
+	return d.Spec.Template.Containers()
 }

--- a/cluster/kubernetes/resource/spec.go
+++ b/cluster/kubernetes/resource/spec.go
@@ -1,5 +1,10 @@
 package resource
 
+import (
+	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/resource"
+)
+
 // Types that daemonsets, deployments, and other things have in
 // common.
 
@@ -11,6 +16,16 @@ type ObjectMeta struct {
 type PodTemplate struct {
 	Metadata ObjectMeta
 	Spec     PodSpec
+}
+
+func (t PodTemplate) Containers() []resource.Container {
+	var result []resource.Container
+	for _, c := range t.Spec.Containers {
+		// FIXME(michael): account for possible errors here
+		im, _ := image.ParseRef(c.Image)
+		result = append(result, resource.Container{Name: c.Name, Image: im})
+	}
+	return result
 }
 
 type PodSpec struct {

--- a/cluster/kubernetes/resource/statefulset.go
+++ b/cluster/kubernetes/resource/statefulset.go
@@ -1,5 +1,9 @@
 package resource
 
+import (
+	"github.com/weaveworks/flux/resource"
+)
+
 type StatefulSet struct {
 	baseObject
 	Spec StatefulSetSpec
@@ -8,4 +12,8 @@ type StatefulSet struct {
 type StatefulSetSpec struct {
 	Replicas int
 	Template PodTemplate
+}
+
+func (ss StatefulSet) Containers() []resource.Container {
+	return ss.Spec.Template.Containers()
 }

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -16,6 +16,7 @@ import (
 type Manifests interface {
 	// Given a directory with manifest files, find which files define
 	// which services.
+	// FIXME(michael): remove when redundant
 	FindDefinedServices(path string) (map[flux.ResourceID][]string, error)
 	// Update the definitions in a manifests bytes according to the
 	// spec given.

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -348,7 +348,7 @@ func (d *Daemon) release(spec update.Spec, c release.Changes) daemonJobFunc {
 		if c.ReleaseKind() == update.ReleaseKindExecute {
 			commitMsg := spec.Cause.Message
 			if commitMsg == "" {
-				commitMsg = c.CommitMessage()
+				commitMsg = c.CommitMessage(result)
 			}
 			commitAuthor := ""
 			if d.GitConfig.SetAuthor {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -119,6 +119,16 @@ func (d *Daemon) ListServices(ctx context.Context, namespace string) ([]v6.Contr
 	return res, nil
 }
 
+type clusterContainers []cluster.Controller
+
+func (cs clusterContainers) Len() int {
+	return len(cs)
+}
+
+func (cs clusterContainers) Containers(i int) []resource.Container {
+	return cs[i].ContainersOrNil()
+}
+
 // List the images available for set of services
 func (d *Daemon) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6.ImageStatus, error) {
 	var services []cluster.Controller
@@ -133,7 +143,7 @@ func (d *Daemon) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6
 		services, err = d.Cluster.SomeControllers([]flux.ResourceID{id})
 	}
 
-	images, err := update.CollectAvailableImages(d.Registry, services, d.Logger)
+	images, err := update.CollectAvailableImages(d.Registry, clusterContainers(services), d.Logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "getting images for services")
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/release"
+	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -520,14 +521,13 @@ func (d *Daemon) LogEvent(ev event.Event) error {
 
 // vvv helpers vvv
 
-func containers2containers(cs []cluster.Container) []v6.Container {
+func containers2containers(cs []resource.Container) []v6.Container {
 	res := make([]v6.Container, len(cs))
 	for i, c := range cs {
-		id, _ := image.ParseRef(c.Image)
 		res[i] = v6.Container{
 			Name: c.Name,
 			Current: image.Info{
-				ID: id,
+				ID: c.Image,
 			},
 		}
 	}
@@ -536,8 +536,7 @@ func containers2containers(cs []cluster.Container) []v6.Container {
 
 func containersWithAvailable(service cluster.Controller, images update.ImageMap) (res []v6.Container) {
 	for _, c := range service.ContainersOrNil() {
-		im, _ := image.ParseRef(c.Image)
-		available := images.Available(im.Name)
+		available := images.Available(c.Image.Name)
 		availableErr := ""
 		if available == nil {
 			availableErr = registry.ErrNoImageData.Error()
@@ -545,7 +544,7 @@ func containersWithAvailable(service cluster.Controller, images update.ImageMap)
 		res = append(res, v6.Container{
 			Name: c.Name,
 			Current: image.Info{
-				ID: im,
+				ID: c.Image,
 			},
 			Available:      available,
 			AvailableError: availableErr,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -344,8 +344,15 @@ func TestDaemon_JobStatusWithNoCache(t *testing.T) {
 }
 
 func makeImageInfo(ref string, t time.Time) image.Info {
-	r, _ := image.ParseRef(ref)
-	return image.Info{ID: r, CreatedAt: t}
+	return image.Info{ID: mustParseImageRef(ref), CreatedAt: t}
+}
+
+func mustParseImageRef(ref string) image.Ref {
+	r, err := image.ParseRef(ref)
+	if err != nil {
+		panic(err)
+	}
+	return r
 }
 
 func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEventWriter) {
@@ -354,10 +361,10 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 	singleService := cluster.Controller{
 		ID: flux.MustParseResourceID(svc),
 		Containers: cluster.ContainersOrExcuse{
-			Containers: []cluster.Container{
+			Containers: []resource.Container{
 				{
 					Name:  container,
-					Image: currentHelloImage,
+					Image: mustParseImageRef(currentHelloImage),
 				},
 			},
 		},
@@ -367,10 +374,10 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 		cluster.Controller{
 			ID: flux.MakeResourceID("another", "deployment", "service"),
 			Containers: cluster.ContainersOrExcuse{
-				Containers: []cluster.Container{
+				Containers: []resource.Container{
 					{
-						Name:  "it doesn't matter",
-						Image: "another/service:latest",
+						Name:  "it-doesn't-matter",
+						Image: mustParseImageRef("another/service:latest"),
 					},
 				},
 			},

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -34,7 +34,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 		return
 	}
 	// Check the latest available image(s) for each service
-	imageMap, err := update.CollectAvailableImages(d.Registry, services, logger)
+	imageMap, err := update.CollectAvailableImages(d.Registry, clusterContainers(services), logger)
 	if err != nil {
 		logger.Log("error", errors.Wrap(err, "fetching image updates"))
 		return

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/git"
-	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/update"
 )
@@ -46,7 +45,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 		for _, container := range service.ContainersOrNil() {
 			logger := log.With(logger, "service", service.ID, "container", container.Name, "currentimage", container.Image)
 
-			currentImageID, err := image.ParseRef(container.Image)
+			currentImageID := container.Image
 			if err != nil {
 				logger.Log("error", err)
 				continue

--- a/event/event.go
+++ b/event/event.go
@@ -91,7 +91,7 @@ func (e Event) String() string {
 	switch e.Type {
 	case EventRelease:
 		metadata := e.Metadata.(*ReleaseEventMetadata)
-		strImageIDs := metadata.Result.ImageIDs()
+		strImageIDs := metadata.Result.ChangedImages()
 		if len(strImageIDs) == 0 {
 			strImageIDs = []string{"no image changes"}
 		}
@@ -121,7 +121,7 @@ func (e Event) String() string {
 		)
 	case EventAutoRelease:
 		metadata := e.Metadata.(*AutoReleaseEventMetadata)
-		strImageIDs := metadata.Result.ImageIDs()
+		strImageIDs := metadata.Result.ChangedImages()
 		if len(strImageIDs) == 0 {
 			strImageIDs = []string{"no image changes"}
 		}

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -12,7 +12,7 @@ type Changes interface {
 	CalculateRelease(update.ReleaseContext, log.Logger) ([]*update.ControllerUpdate, update.Result, error)
 	ReleaseKind() update.ReleaseKind
 	ReleaseType() update.ReleaseType
-	CommitMessage() string
+	CommitMessage(update.Result) string
 }
 
 func Release(rc *ReleaseContext, changes Changes, logger log.Logger) (results update.Result, err error) {

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/weaveworks/flux/git/gittest"
 	"github.com/weaveworks/flux/image"
 	registryMock "github.com/weaveworks/flux/registry/mock"
+	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -32,20 +33,24 @@ var (
 	hwSvc         = cluster.Controller{
 		ID: hwSvcID,
 		Containers: cluster.ContainersOrExcuse{
-			Containers: []cluster.Container{
-				cluster.Container{
+			Containers: []resource.Container{
+				{
 					Name:  helloContainer,
-					Image: oldImage,
+					Image: oldRef,
 				},
-				cluster.Container{
+				{
 					Name:  sidecarContainer,
-					Image: sidecarImage,
+					Image: sidecarRef,
 				},
 			},
 		},
 	}
 
-	oldLockedImg     = "quay.io/weaveworks/locked-service:1"
+	testServiceRef, _ = image.ParseRef("quay.io/weaveworks/test-service:1")
+
+	oldLockedImg    = "quay.io/weaveworks/locked-service:1"
+	oldLockedRef, _ = image.ParseRef(oldLockedImg)
+
 	newLockedImg     = "quay.io/weaveworks/locked-service:2"
 	newLockedID, _   = image.ParseRef(newLockedImg)
 	lockedSvcID, _   = flux.ParseResourceID("default:deployment/locked-service")
@@ -53,10 +58,10 @@ var (
 	lockedSvc        = cluster.Controller{
 		ID: lockedSvcID,
 		Containers: cluster.ContainersOrExcuse{
-			Containers: []cluster.Container{
-				cluster.Container{
+			Containers: []resource.Container{
+				{
 					Name:  "locked-service",
-					Image: oldLockedImg,
+					Image: oldLockedRef,
 				},
 			},
 		},
@@ -65,10 +70,10 @@ var (
 	testSvc = cluster.Controller{
 		ID: flux.MustParseResourceID("default:deployment/test-service"),
 		Containers: cluster.ContainersOrExcuse{
-			Containers: []cluster.Container{
-				cluster.Container{
+			Containers: []resource.Container{
+				{
 					Name:  "test-service",
-					Image: "quay.io/weaveworks/test-service:1",
+					Image: testServiceRef,
 				},
 			},
 		},

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -18,3 +18,8 @@ type Container struct {
 	Name  string
 	Image image.Ref
 }
+
+type Workload interface {
+	Resource
+	Containers() []Container
+}

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -2,6 +2,7 @@ package resource
 
 import (
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 )
 
@@ -11,4 +12,9 @@ type Resource interface {
 	Policy() policy.Set          // policy for this resource; e.g., whether it is locked, automated, ignored
 	Source() string              // where did this come from (informational)
 	Bytes() []byte               // the definition, for sending to cluster.Sync
+}
+
+type Container struct {
+	Name  string
+	Image image.Ref
 }

--- a/update/automated.go
+++ b/update/automated.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
-	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/resource"
 )
 
 type Automated struct {
@@ -16,11 +16,11 @@ type Automated struct {
 
 type Change struct {
 	ServiceID flux.ResourceID
-	Container cluster.Container
+	Container resource.Container
 	ImageID   image.Ref
 }
 
-func (a *Automated) Add(service flux.ResourceID, container cluster.Container, image image.Ref) {
+func (a *Automated) Add(service flux.ResourceID, container resource.Container, image image.Ref) {
 	a.Changes = append(a.Changes, Change{service, container, image})
 }
 
@@ -100,11 +100,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 		changes := serviceMap[u.ResourceID]
 		containerUpdates := []ContainerUpdate{}
 		for _, container := range containers {
-			currentImageID, err := image.ParseRef(container.Image)
-			if err != nil {
-				return nil, err
-			}
-
+			currentImageID := container.Image
 			for _, change := range changes {
 				if change.Container.Name != container.Name {
 					continue

--- a/update/automated.go
+++ b/update/automated.go
@@ -1,8 +1,8 @@
 package update
 
 import (
+	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
@@ -52,24 +52,24 @@ func (a *Automated) ReleaseKind() ReleaseKind {
 	return ReleaseKindExecute
 }
 
-func (a *Automated) CommitMessage() string {
-	var images []string
-	for _, image := range a.Images() {
-		images = append(images, image.String())
+func (a *Automated) CommitMessage(result Result) string {
+	images := result.ChangedImages()
+	buf := &bytes.Buffer{}
+	prefix := ""
+	switch len(images) {
+	case 0: // FIXME(michael): can we get here?
+		fmt.Fprintln(buf, "Auto-release (no images)")
+	case 1:
+		fmt.Fprint(buf, "Auto-release ")
+	default:
+		fmt.Fprintln(buf, "Auto-release multiple images")
+		fmt.Fprintln(buf)
+		prefix = " - "
 	}
-	return fmt.Sprintf("Release %s to automated", strings.Join(images, ", "))
-}
-
-func (a *Automated) Images() []image.Ref {
-	imageMap := map[image.Ref]struct{}{}
-	for _, change := range a.Changes {
-		imageMap[change.ImageID] = struct{}{}
+	for _, im := range images {
+		fmt.Fprintf(buf, "%s%s\n", prefix, im)
 	}
-	var images []image.Ref
-	for image, _ := range imageMap {
-		images = append(images, image)
-	}
-	return images
+	return buf.String()
 }
 
 func (a *Automated) markSkipped(results Result) {
@@ -88,15 +88,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 
 	serviceMap := a.serviceMap()
 	for _, u := range candidates {
-		containers, err := u.Controller.ContainersOrError()
-		if err != nil {
-			result[u.ResourceID] = ControllerResult{
-				Status: ReleaseStatusFailed,
-				Error:  err.Error(),
-			}
-			continue
-		}
-
+		containers := u.Resource.Containers()
 		changes := serviceMap[u.ResourceID]
 		containerUpdates := []ContainerUpdate{}
 		for _, container := range containers {
@@ -106,7 +98,16 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 					continue
 				}
 
+				// It turns out this isn't a change after all; skip this container
+				if change.ImageID.CanonicalRef() == container.Image.CanonicalRef() {
+					continue
+				}
+
+				// We transplant the tag here, to make sure we keep
+				// the format of the image name as it is in the
+				// resource (e.g., to avoid canonicalising it)
 				newImageID := currentImageID.WithNewTag(change.ImageID.Tag)
+				var err error
 				u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, newImageID)
 				if err != nil {
 					return nil, err
@@ -129,8 +130,8 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 			}
 		} else {
 			result[u.ResourceID] = ControllerResult{
-				Status: ReleaseStatusIgnored,
-				Error:  DoesNotUseImage,
+				Status: ReleaseStatusSkipped,
+				Error:  ImageUpToDate,
 			}
 		}
 	}
@@ -138,6 +139,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 	return updates, nil
 }
 
+// serviceMap transposes the changes so they can be looked up by ID
 func (a *Automated) serviceMap() map[flux.ResourceID][]Change {
 	set := map[flux.ResourceID][]Change{}
 	for _, change := range a.Changes {

--- a/update/filter.go
+++ b/update/filter.go
@@ -31,9 +31,7 @@ func (f *SpecificImageFilter) Filter(u ControllerUpdate) ControllerResult {
 	}
 	// For each container in update
 	for _, c := range u.Controller.Containers.Containers {
-		cID, _ := image.ParseRef(c.Image)
-		// If container image == image in update
-		if cID.CanonicalName() == f.Img.CanonicalName() {
+		if c.Image.CanonicalName() == f.Img.CanonicalName() {
 			// We want to update this
 			return ControllerResult{}
 		}

--- a/update/images.go
+++ b/update/images.go
@@ -73,12 +73,7 @@ func CollectAvailableImages(reg registry.Registry, services []cluster.Controller
 	images := infoMap{}
 	for _, service := range services {
 		for _, container := range service.ContainersOrNil() {
-			id, err := image.ParseRef(container.Image)
-			if err != nil {
-				// container is running an invalid image id? what?
-				return ImageMap{}, err
-			}
-			images[id.CanonicalName()] = nil
+			images[container.Image.CanonicalName()] = nil
 		}
 	}
 	for name := range images {

--- a/update/release.go
+++ b/update/release.go
@@ -96,7 +96,7 @@ func (s ReleaseSpec) ReleaseKind() ReleaseKind {
 	return s.Kind
 }
 
-func (s ReleaseSpec) CommitMessage() string {
+func (s ReleaseSpec) CommitMessage(result Result) string {
 	image := strings.Trim(s.ImageSpec.String(), "<>")
 	var services []string
 	for _, spec := range s.ServiceSpecs {

--- a/update/release.go
+++ b/update/release.go
@@ -229,12 +229,7 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		var containerUpdates []ContainerUpdate
 
 		for _, container := range containers {
-			currentImageID, err := image.ParseRef(container.Image)
-			if err != nil {
-				// We may hope never to find a malformed image ID, but
-				// anything is possible.
-				return nil, err
-			}
+			currentImageID := container.Image
 
 			latestImage, ok := images.LatestImage(currentImageID.Name, "*")
 			if !ok {

--- a/update/result.go
+++ b/update/result.go
@@ -30,9 +30,12 @@ func (r Result) ServiceIDs() []string {
 	return result
 }
 
-func (r Result) ImageIDs() []string {
+func (r Result) ChangedImages() []string {
 	images := map[image.Ref]struct{}{}
 	for _, serviceResult := range r {
+		if serviceResult.Status != ReleaseStatusSuccess {
+			continue
+		}
 		for _, containerResult := range serviceResult.PerContainer {
 			images[containerResult.Target] = struct{}{}
 		}

--- a/update/service.go
+++ b/update/service.go
@@ -3,11 +3,13 @@ package update
 import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/resource"
 )
 
 type ControllerUpdate struct {
 	ResourceID    flux.ResourceID
 	Controller    cluster.Controller
+	Resource      resource.Workload
 	ManifestPath  string
 	ManifestBytes []byte
 	Updates       []ContainerUpdate


### PR DESCRIPTION
As described in #1026, it's possible to calculate a set of image updates that do not end up being carried out, usually because the cluster doesn't quite reflect what's in the git repo.

As a conservative fix that doesn't change behaviour, this PR makes the reporting of auto-releases more accurate by 

 1. skipping any changes that were calculated but turn out not to be changes;
 2. including only what was changed successfully in the commit message and event

There's also a bit of tidying and making way for deeper changes -- future work can, for example,

 - remove the separate preparation and application steps of auto-releases. At the minute, when it's time to do an "automation run", a list of updates is compiled by comparing the images running in the cluster with those available in the image registry. It's applied _after_ going through the job queue; but since it has to look at the git repo in both steps anyway, it may as well just do everything when the job runs.

 - remove the Calculate and ApplyChanges steps, or at least stop the latter from just splatting bytes into the given file, since that will prevent updates to multidoc files and List resources from working properly.
