### PR TITLE
Allow namespace tag policies

### DIFF
--- a/cluster/kubernetes/files.go
+++ b/cluster/kubernetes/files.go
@@ -29,3 +29,23 @@ func (c *Manifests) FindDefinedServices(path string) (map[flux.ResourceID][]stri
 	}
 	return result, nil
 }
+
+// FindNamespaces finds all the namespaces defined under the directory
+// given, and returns a map of namespace IDs (default:namespace:<namespace>)
+// to the paths of the namespace defintion files.
+func (c *Manifests) FindNamespaces(path string) (map[flux.ResourceID][]string, error) {
+	objects, err := resource.Load(path, path)
+	if err != nil {
+		return nil, errors.Wrap(err, "loading resources")
+	}
+
+	var result = map[flux.ResourceID][]string{}
+	for _, obj := range objects {
+		id := obj.ResourceID()
+		_, kind, _ := id.Components()
+		if kind == "namespace" {
+			result[id] = append(result[id], filepath.Join(path, obj.Source()))
+		}
+	}
+	return result, nil
+}

--- a/cluster/kubernetes/files_test.go
+++ b/cluster/kubernetes/files_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 )
 
-func TestDefinedServices(t *testing.T) {
+func TestFindDefinedServices(t *testing.T) {
 	dir, cleanup := testfiles.TempDir(t)
 	defer cleanup()
 
@@ -22,5 +22,23 @@ func TestDefinedServices(t *testing.T) {
 
 	if !reflect.DeepEqual(testfiles.ServiceMap(dir), services) {
 		t.Errorf("Expected:\n%#v\ngot:\n%#v\n", testfiles.ServiceMap(dir), services)
+	}
+}
+
+func TestFindNamespaces(t *testing.T) {
+	dir, cleanup := testfiles.TempDir(t)
+	defer cleanup()
+
+	if err := testfiles.WriteTestFiles(dir); err != nil {
+		t.Fatal(err)
+	}
+
+	namespaces, err := (&Manifests{}).FindNamespaces(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(testfiles.NamespaceMap(dir), namespaces) {
+		t.Errorf("Expected:\n%#v\ngot:\n%#v\n", testfiles.NamespaceMap(dir), namespaces)
 	}
 }

--- a/cluster/kubernetes/policies.go
+++ b/cluster/kubernetes/policies.go
@@ -171,6 +171,27 @@ func (m *Manifests) ServicesWithPolicies(root string) (policy.ResourceMap, error
 	return result, nil
 }
 
+func (m *Manifests) NamespacesWithPolicies(root string) (policy.ResourceMap, error) {
+	all, err := m.FindNamespaces(root)
+	if err != nil {
+		return nil, err
+	}
+
+	result := map[flux.ResourceID]policy.Set{}
+	err = iterateManifests(all, func(ns flux.ResourceID, m Manifest) error {
+		ps, err := policiesFrom(m)
+		if err != nil {
+			return err
+		}
+		result[ns] = ps
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
 func iterateManifests(services map[flux.ResourceID][]string, f func(flux.ResourceID, Manifest) error) error {
 	for serviceID, paths := range services {
 		if len(paths) != 1 {

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -136,7 +136,7 @@ func TestLoadSome(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(objs) != len(testfiles.ServiceMap(dir)) {
+	if len(objs) != len(testfiles.ServiceMap(dir))+len(testfiles.NamespaceMap(dir)) {
 		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testfiles.ServiceMap(dir)), len(testfiles.Files), objs)
 	}
 }

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -52,9 +52,22 @@ func ServiceMap(dir string) map[flux.ResourceID][]string {
 	}
 }
 
+// NamespaceMap ... given a base path, construct the map representing the
+// namespaces given in the test data.
+func NamespaceMap(dir string) map[flux.ResourceID][]string {
+	return map[flux.ResourceID][]string{
+		flux.MustParseResourceID("default:namespace/helloworld"): []string{filepath.Join(dir, "helloworld-namespace.yaml")},
+	}
+}
+
 var Files = map[string]string{
 	"garbage": "This should just be ignored, since it is not YAML",
 	// Some genuine manifests
+	"helloworld-namespace.yaml": `apiVersion: v1
+kind: Namespace
+metadata:
+  name: helloworld
+  `,
 	"helloworld-deploy.yaml": `apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -32,6 +32,7 @@ type Manifests interface {
 	UpdatePolicies([]byte, policy.Update) ([]byte, error)
 	// ServicesWithPolicies returns all services with their associated policies
 	ServicesWithPolicies(path string) (policy.ResourceMap, error)
+	NamespacesWithPolicies(path string) (policy.ResourceMap, error)
 }
 
 // UpdateManifest looks for the manifest for a given service, reads

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -10,19 +10,20 @@ import (
 
 // Doubles as a cluster.Cluster and cluster.Manifests implementation
 type Mock struct {
-	AllServicesFunc          func(maybeNamespace string) ([]Controller, error)
-	SomeServicesFunc         func([]flux.ResourceID) ([]Controller, error)
-	PingFunc                 func() error
-	ExportFunc               func() ([]byte, error)
-	SyncFunc                 func(SyncDef) error
-	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
-	FindDefinedServicesFunc  func(path string) (map[flux.ResourceID][]string, error)
-	UpdateDefinitionFunc     func(def []byte, container string, newImageID image.Ref) ([]byte, error)
-	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
-	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
-	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
-	UpdatePoliciesFunc       func([]byte, policy.Update) ([]byte, error)
-	ServicesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
+	AllServicesFunc            func(maybeNamespace string) ([]Controller, error)
+	SomeServicesFunc           func([]flux.ResourceID) ([]Controller, error)
+	PingFunc                   func() error
+	ExportFunc                 func() ([]byte, error)
+	SyncFunc                   func(SyncDef) error
+	PublicSSHKeyFunc           func(regenerate bool) (ssh.PublicKey, error)
+	FindDefinedServicesFunc    func(path string) (map[flux.ResourceID][]string, error)
+	UpdateDefinitionFunc       func(def []byte, container string, newImageID image.Ref) ([]byte, error)
+	LoadManifestsFunc          func(base, first string, rest ...string) (map[string]resource.Resource, error)
+	ParseManifestsFunc         func([]byte) (map[string]resource.Resource, error)
+	UpdateManifestFunc         func(path, resourceID string, f func(def []byte) ([]byte, error)) error
+	UpdatePoliciesFunc         func([]byte, policy.Update) ([]byte, error)
+	ServicesWithPoliciesFunc   func(path string) (policy.ResourceMap, error)
+	NamespacesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
 }
 
 func (m *Mock) AllControllers(maybeNamespace string) ([]Controller, error) {
@@ -75,4 +76,8 @@ func (m *Mock) UpdatePolicies(def []byte, p policy.Update) ([]byte, error) {
 
 func (m *Mock) ServicesWithPolicies(path string) (policy.ResourceMap, error) {
 	return m.ServicesWithPoliciesFunc(path)
+}
+
+func (m *Mock) NamespacesWithPolicies(path string) (policy.ResourceMap, error) {
+	return m.NamespacesWithPoliciesFunc(path)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -414,6 +414,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 		}
 		k8s.PingFunc = func() error { return nil }
 		k8s.ServicesWithPoliciesFunc = (&kubernetes.Manifests{}).ServicesWithPolicies
+		k8s.NamespacesWithPoliciesFunc = (&kubernetes.Manifests{}).NamespacesWithPolicies
 		k8s.SomeServicesFunc = func([]flux.ResourceID) ([]cluster.Controller, error) {
 			return []cluster.Controller{
 				singleService,

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -49,6 +49,7 @@ func daemon(t *testing.T) (*Daemon, func()) {
 	k8s.ExportFunc = func() ([]byte, error) { return nil, nil }
 	k8s.FindDefinedServicesFunc = (&kubernetes.Manifests{}).FindDefinedServices
 	k8s.ServicesWithPoliciesFunc = (&kubernetes.Manifests{}).ServicesWithPolicies
+	k8s.NamespacesWithPoliciesFunc = (&kubernetes.Manifests{}).NamespacesWithPolicies
 
 	events = &mockEventWriter{}
 

--- a/flux.go
+++ b/flux.go
@@ -86,6 +86,11 @@ func MakeResourceID(namespace, kind, name string) ResourceID {
 	return ResourceID{resourceID{namespace, strings.ToLower(kind), name}}
 }
 
+// MakeNamespaceID constructs a ResourceID for a namespace.
+func MakeNamespaceID(namespace string) ResourceID {
+	return MakeResourceID("default", "namespace", namespace)
+}
+
 // Components returns the constituent components of a ResourceID
 func (id ResourceID) Components() (namespace, kind, name string) {
 	switch impl := id.resourceIDImpl.(type) {


### PR DESCRIPTION
Fixes #1045.

- If no tag policy is set on the service, we check if one exists on the namespace.
- This PR does not implement updating namespace tags via flux.
- Decided to create new functions to fetch Namespace objects - we could instead include namespace objects as a service resource kind and remove some of the duplicated code I've added here? Otherwise the separation works well for now.

e.g.
```
---
apiVersion: v1
kind: Namespace
metadata:
  name: cortex
  annotations:
    flux.weave.works/tag.cortex: glob:master-*
```
