### PR TITLE
Removes delete action from helm-operator manual release sync

### DIFF
--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -22,7 +22,6 @@ var (
 type Action string
 
 const (
-	DeleteAction  Action = "DELETE"
 	InstallAction Action = "CREATE"
 	UpgradeAction Action = "UPDATE"
 )


### PR DESCRIPTION
The original assumption was that user's cluster only contains
Chart releases defined by FluxHelmReleases stored in git repo.
As a result the provided implementation deleted any release
not having a FHR counterpart. This resulted in unwanted deletions
such as helm-operator deleting itself when deployed as a Chart etc