### PR TITLE
Report the affected resources for each event

### DIFF
--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -241,6 +241,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 		changedFiles, err := working.ChangedFiles(ctx, oldTagRev)
 		if err == nil && len(changedFiles) > 0 {
 			// We had some changed files, we're syncing a diff
+			// FIXME(michael): this won't be accurate when a file can have more than one resource
 			changedResources, err = d.Manifests.LoadManifests(working.Dir(), changedFiles[0], changedFiles[1:]...)
 		}
 		cancel()
@@ -310,7 +311,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 			case update.Images:
 				spec := n.Spec.Spec.(update.ReleaseSpec)
 				noteEvents = append(noteEvents, event.Event{
-					ServiceIDs: serviceIDs.ToSlice(),
+					ServiceIDs: n.Result.AffectedResources(),
 					Type:       event.EventRelease,
 					StartedAt:  started,
 					EndedAt:    time.Now().UTC(),
@@ -329,7 +330,7 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 			case update.Auto:
 				spec := n.Spec.Spec.(update.Automated)
 				noteEvents = append(noteEvents, event.Event{
-					ServiceIDs: serviceIDs.ToSlice(),
+					ServiceIDs: n.Result.AffectedResources(),
 					Type:       event.EventAutoRelease,
 					StartedAt:  started,
 					EndedAt:    time.Now().UTC(),

--- a/update/result.go
+++ b/update/result.go
@@ -30,6 +30,16 @@ func (r Result) ServiceIDs() []string {
 	return result
 }
 
+func (r Result) AffectedResources() flux.ResourceIDs {
+	ids := flux.ResourceIDs{}
+	for id, result := range r {
+		if result.Status == ReleaseStatusSuccess {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 func (r Result) ChangedImages() []string {
 	images := map[image.Ref]struct{}{}
 	for _, serviceResult := range r {
@@ -72,10 +82,6 @@ type ControllerResult struct {
 	Status       ControllerUpdateStatus // summary of what happened, e.g., "incomplete", "ignored", "success"
 	Error        string                 `json:",omitempty"` // error if there was one finding the service (e.g., it doesn't exist in repo)
 	PerContainer []ContainerUpdate      // what happened with each container
-}
-
-func (fr ControllerResult) Msg(id flux.ResourceID) string {
-	return fmt.Sprintf("%s service %s as it is %s", fr.Status, id.String(), fr.Error)
 }
 
 type ContainerUpdate struct {


### PR DESCRIPTION
Hitherto we have used a single list of `ResourceID`s to populate the
event field. It was calculated by looking at which files have changed
since last sync, and which resources are in those changed files.

This is inaccurate because

 1. files don't always contain one resource (though currently, files
 _we can change_ only contain one resource)
 2. each event gets the list of resources changed in _any_ commit.

To address 2., use the Result field from the git note, which has a
record of what was actually changed in that operation.

1.) is less of a problem for now, because we can only change files
containing one resource at present anyway.

Fixes #729.