### PR TITLE
Log in places we might encounter an untagged image

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -56,6 +56,10 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 			logger.Log("repo", repo, "pattern", pattern)
 
 			if latest, ok := imageMap.LatestImage(repo, pattern); ok && latest.ID != currentImageID {
+				if latest.ID.Tag == "" {
+					logger.Log("msg", "untagged image in available images", "action", "skip", "available", repo)
+					continue
+				}
 				newImage := currentImageID.WithNewTag(latest.ID.Tag)
 				changes.Add(service.ID, container, newImage)
 				logger.Log("msg", "added image to changes", "newimage", newImage)

--- a/update/images.go
+++ b/update/images.go
@@ -120,7 +120,8 @@ func exactImages(reg registry.Registry, images []image.Ref) (ImageMap, error) {
 }
 
 // Checks whether the given image exists in the repository.
-// Return true if exist, false otherwise
+// Return true if exist, false otherwise.
+// FIXME(michael): never returns an error; should it?
 func imageExists(reg registry.Registry, imageID image.Ref) (bool, error) {
 	_, err := reg.GetImage(imageID)
 	if err != nil {


### PR DESCRIPTION
We don't expect to see untagged images from the image metadata DB, but
we do. To track down #1051, this commit adds some logging to a couple
of places where we would see an empty tag, as well as taking action
when that happens (either aborting the cahe warming op, or skipping
the automated update).