### PR TITLE
Explicitly chmod the SSH config for fluxd

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -19,6 +19,7 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && \
     chmod 600 ~/.ssh/known_hosts
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /root/.ssh/config
+RUN chmod 600 /root/.ssh/config
 
 COPY ./kubectl /usr/local/bin/
 COPY ./fluxd /usr/local/bin/


### PR DESCRIPTION
It's possible by accident or coincidence for the source file
./docker/ssh_config to end up with permissions that SSH doesn't
like. This will render the flux image unusable, since git will refuse
to clone a repo over SSH. So: explicitly chmod the file after copying
it.