### PR TITLE
Resurrect the --docker-config flag for local use

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -111,11 +111,8 @@ func main() {
 		upstreamURL = fs.String("connect", "", "Connect to an upstream service e.g., Weave Cloud, at this base address")
 		token       = fs.String("token", "", "Authentication token for upstream service")
 
-		// Deprecated
-		_ = fs.String("docker-config", "", "path to a docker config to use for credentials")
+		dockerConfig = fs.String("docker-config", "", "path to a docker config to use for image registry credentials")
 	)
-
-	fs.MarkDeprecated("docker-config", "credentials are taken from imagePullSecrets now")
 
 	fs.Parse(os.Args)
 
@@ -240,6 +237,14 @@ func main() {
 		}
 
 		imageCreds = k8sInst.ImagesToFetch
+		if *dockerConfig != "" {
+			credsWithDefaults, err := registry.ImageCredsWithDefaults(imageCreds, *dockerConfig)
+			if err != nil {
+				logger.Log("msg", "--docker-config not used", "err", err)
+			} else {
+				imageCreds = credsWithDefaults
+			}
+		}
 		k8s = k8sInst
 		// There is only one way we currently interpret a repo of
 		// files as manifests, and that's as Kubernetes yamels.


### PR DESCRIPTION
We deprecated the --docker-config flag when we switched to looking up
imagePullSecrets to get credentials. However, it's still useful if
you're not using those -- for example, if you don't pull images from
the registry, or (less so) if you assign credentials to service
accounts.

This commit brings the flag back, and implements it by loading the
given docker config file, to supplement any credentials found via
imagePullSecrets.