### PR TITLE
Only pull user.name and user.email in .gitconfig

### DIFF
--- a/cmd/fluxctl/args_test.go
+++ b/cmd/fluxctl/args_test.go
@@ -1,122 +1,62 @@
 package main
 
 import (
-	"reflect"
+        "fmt"
 	"testing"
+	"os"
+	"os/exec"
 )
 
-var gitConfig = `push.default=simple
-    merge.conflictstyle=diff3
-    pull.ff=only
-    core.repositoryformatversion=0
-    core.filemode=true
-    core.bare=false
-    `
-
-func gitConfigMap(input map[string]string) map[string]string {
-	res := map[string]string{
-		"push.default":                 "simple",
-		"merge.conflictstyle":          "diff3",
-		"pull.ff":                      "only",
-		"core.repositoryformatversion": "0",
-		"core.filemode":                "true",
-		"core.bare":                    "false",
-	}
-	for k, v := range input {
-		res[k] = v
-	}
-	return res
+func helperCommand(command string, s ...string) (cmd *exec.Cmd) {
+	cs := []string{"-test.run=TestHelperProcess", "--", command}
+	cs = append(cs, s...)
+	cmd = exec.Command(os.Args[0], cs...)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	return cmd
 }
 
-func checkUserGitconfigMap(t *testing.T, d string, expected map[string]string) {
-	userGitconfigInfo := userGitconfigMap(d)
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+	defer os.Exit(0)
 
-	if len(userGitconfigInfo) != len(expected) {
-		t.Fatalf("got map with %d keys instead of expected %d",
-			len(userGitconfigInfo), len(expected))
+
+	args := os.Args
+	for len(args) > 0 {
+		if args[0] == "--" {
+			args = args[1:]
+			break
+		}
+		args = args[1:]
 	}
-	if !reflect.DeepEqual(userGitconfigInfo, expected) {
-		t.Fatal("result map does not match expected structure")
+	if len(args) == 0 {
+		t.Fatalf("No command\n")
 	}
+
+	_, args = args[0], args[1:]
+        for _, a := range args {
+            if a == "user.name" {
+    		fmt.Fprintf(os.Stdout, "Jane Doe")
+            } else if a == "user.email" {
+    		fmt.Fprintf(os.Stdout, "jd@j.d")
+            }
+        }
 }
 
-func checkAuthor(t *testing.T, input map[string]string, expected string) {
-	author := getCommitAuthor(input)
+func checkAuthor(t *testing.T, input string, expected string) {
+    	execCommand = helperCommand
+    	defer func(){ execCommand = exec.Command }()
+	author := getUserGitConfigValue(input)
 	if author != expected {
 		t.Fatalf("author %q does not match expected value %q", author, expected)
 	}
 }
 
-func TestUserGitconfigMap_EmptyString(t *testing.T) {
-	d := ""
-	expected := map[string]string{}
-	checkUserGitconfigMap(t, d, expected)
-}
-
-func TestUserGitconfigMap(t *testing.T) {
-	d := gitConfig
-	expected := gitConfigMap(nil)
-	checkUserGitconfigMap(t, d, expected)
-}
-
-func TestUserGitconfigMap_WithEmptyLines(t *testing.T) {
-	d := `
-    user.name=Jane Doe
-
-    ` + gitConfig + `
-    `
-	expected := gitConfigMap(map[string]string{
-		"user.name": "Jane Doe",
-	})
-	checkUserGitconfigMap(t, d, expected)
-}
-
-func TestUserGitconfigMap_WithNoKeys(t *testing.T) {
-	d := `
-	`
-	expected := map[string]string{}
-	checkUserGitconfigMap(t, d, expected)
-}
-
-func TestGetCommitAuthor_BothNameAndEmail(t *testing.T) {
-	input := gitConfigMap(map[string]string{
-		"user.name":  "Jane Doe",
-		"user.email": "jd@j.d",
-	})
-	checkAuthor(t, input, "Jane Doe <jd@j.d>")
-}
-
 func TestGetCommitAuthor_OnlyName(t *testing.T) {
-	input := gitConfigMap(map[string]string{
-		"user.name": "Jane Doe",
-	})
-	checkAuthor(t, input, "Jane Doe")
+	checkAuthor(t, "user.name", "Jane Doe")
 }
 
 func TestGetCommitAuthor_OnlyEmail(t *testing.T) {
-	input := gitConfigMap(map[string]string{
-		"user.email": "jd@j.d",
-	})
-	checkAuthor(t, input, "jd@j.d")
-}
-
-func TestGetCommitAuthor_NoNameNoEmail(t *testing.T) {
-	input := gitConfigMap(nil)
-	checkAuthor(t, input, "")
-}
-
-func TestGetCommitAuthor_NameAndEmptyEmail(t *testing.T) {
-	input := gitConfigMap(map[string]string{
-		"user.name":  "Jane Doe",
-		"user.email": "",
-	})
-	checkAuthor(t, input, "Jane Doe")
-}
-
-func TestGetCommitAuthor_EmailAndEmptyName(t *testing.T) {
-	input := gitConfigMap(map[string]string{
-		"user.name":  "",
-		"user.email": "jd@j.d",
-	})
-	checkAuthor(t, input, "jd@j.d")
+	checkAuthor(t, "user.email", "jd@j.d")
 }


### PR DESCRIPTION
Parsing through the entire .gitconfig is cumbersome when it has multiline entries. This commit uses the command line to pull the user.name an user.email global entries from the command-line.

Fixes #1072.