### PR TITLE
Dedup parsing in UpdatePolicy and UpdateImage

### DIFF
--- a/cluster/kubernetes/manifests.go
+++ b/cluster/kubernetes/manifests.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"github.com/weaveworks/flux"
 	kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/resource"
@@ -19,8 +20,8 @@ func (c *Manifests) ParseManifests(allDefs []byte) (map[string]resource.Resource
 	return kresource.ParseMultidoc(allDefs, "exported")
 }
 
-func (c *Manifests) UpdateDefinition(def []byte, container string, image image.Ref) ([]byte, error) {
-	return updatePodController(def, container, image)
+func (c *Manifests) UpdateImage(def []byte, id flux.ResourceID, container string, image image.Ref) ([]byte, error) {
+	return updatePodController(def, id, container, image)
 }
 
 // UpdatePolicies and ServicesWithPolicies in policies.go

--- a/cluster/kubernetes/policies_test.go
+++ b/cluster/kubernetes/policies_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"text/template"
 
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/policy"
 )
 
@@ -117,7 +118,8 @@ func TestUpdatePolicies(t *testing.T) {
 	} {
 		caseIn := templToString(t, annotationsTemplate, c.in)
 		caseOut := templToString(t, annotationsTemplate, c.out)
-		out, err := (&Manifests{}).UpdatePolicies([]byte(caseIn), c.update)
+		id := flux.MustParseResourceID("default:deplot/nginx")
+		out, err := (&Manifests{}).UpdatePolicies([]byte(caseIn), id, c.update)
 		if err != nil {
 			t.Errorf("[%s] %v", c.name, err)
 		} else if string(out) != caseOut {

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -7,18 +7,21 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
 )
 
-// updatePodController takes the body of a Deployment resource definition
-// (specified in YAML) and the name of the new image that should be put in the
-// definition (in the format "repo.org/group/name:tag"). It returns a new
-// resource definition body where all references to the old image have been
-// replaced with the new one.
+// updatePodController takes the body of a resource definition
+// (specified in YAML), the ID of a particular resource and container
+// therein, and the name of the new image that should be put in the
+// definition (in the format "repo.org/group/name:tag") for that
+// resource and container. It returns a new resource definition body
+// where all references to the old image have been replaced with the
+// new one.
 //
-// This function has many additional requirements that are likely in flux. Read
-// the source to learn about them.
-func updatePodController(def []byte, container string, newImageID image.Ref) ([]byte, error) {
+// This function has some requirements of the YAML structure. Read the
+// source and comments below to learn about them.
+func updatePodController(def []byte, resourceID flux.ResourceID, container string, newImageID image.Ref) ([]byte, error) {
 	// Sanity check
 	obj, err := parseObj(def)
 	if err != nil {

--- a/cluster/kubernetes/update.go
+++ b/cluster/kubernetes/update.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/resource"
 )
 
 // updatePodController takes the body of a resource definition
@@ -33,7 +34,7 @@ func updatePodController(def []byte, resourceID flux.ResourceID, container strin
 	}
 
 	var buf bytes.Buffer
-	err = tryUpdate(def, container, newImageID, &buf)
+	err = tryUpdate(def, resourceID, container, newImageID, &buf)
 	return buf.Bytes(), err
 }
 
@@ -80,42 +81,22 @@ func updatePodController(def []byte, resourceID flux.ResourceID, container strin
 //         ports:
 //         - containerPort: 80
 // ```
-func tryUpdate(def []byte, container string, newImage image.Ref, out io.Writer) error {
-	manifest, err := parseManifest(def)
-	if err != nil {
-		return err
-	}
-	if manifest.Metadata.Name == "" {
-		return fmt.Errorf("could not find resource name")
-	}
+func tryUpdate(def []byte, id flux.ResourceID, container string, newImage image.Ref, out io.Writer) error {
+	containers, err := extractContainers(def, id)
 
-	// Check if any containers need updating. As we go through, we calculate the
-	// new manifest name, in case it includes the image tag (as in replication
-	// controllers).
-	newDefName := manifest.Metadata.Name
-	matchingContainers := map[int]Container{}
-	for i, c := range append(manifest.Spec.Template.Spec.Containers, manifest.Spec.JobTemplate.Spec.Template.Spec.Containers...) {
+	matchingContainers := map[int]resource.Container{}
+	for i, c := range containers {
 		if c.Name != container {
 			continue
 		}
-		currentImage, err := image.ParseRef(c.Image)
+		currentImage := c.Image
 		if err != nil {
 			return fmt.Errorf("could not parse image %s", c.Image)
 		}
 		if currentImage.CanonicalName() == newImage.CanonicalName() {
 			matchingContainers[i] = c
 		}
-		_, _, oldImageTag := currentImage.Components()
-		if strings.HasSuffix(manifest.Metadata.Name, oldImageTag) {
-			newDefName = manifest.Metadata.Name[:len(manifest.Metadata.Name)-len(oldImageTag)] + newImage.Tag
-		}
 	}
-
-	// Some values (most likely the version) will be interpreted as a
-	// number if unquoted; while, on the other hand, it is apparently
-	// not OK to quote things that don't look like numbers. So: we
-	// extract values *without* quotes, and add them if necessary.
-	newDefName = maybeQuote(newDefName)
 
 	if len(matchingContainers) == 0 {
 		return fmt.Errorf("could not find container using image: %s", newImage.Repository())
@@ -164,19 +145,6 @@ func tryUpdate(def []byte, container string, newImage image.Ref, out io.Writer) 
 		}
 		return fmt.Errorf("did not update expected containers: %s", strings.Join(missed, ", "))
 	}
-
-	// TODO: delete all regular expressions which are used to modify YAML.
-	// See #1019. Modifying this is not recommended.
-	// The name we want is that under `metadata:`, which will *probably* be the first one
-	replacedName := false
-	replaceRCNameRE := regexp.MustCompile(`(\s+` + optq + `name` + optq + `:\s*)` + optq + `(?:[\w\.\-/:]+\s*?)` + optq + `([\t\f #]+.*)`)
-	replaceRCNameRE.ReplaceAllStringFunc(newDef, func(found string) string {
-		if replacedName {
-			return found
-		}
-		replacedName = true
-		return replaceRCNameRE.ReplaceAllString(found, fmt.Sprintf(`${1}%s${2}`, newDefName))
-	})
 
 	// TODO: delete all regular expressions which are used to modify YAML.
 	// See #1019. Modifying this is not recommended.

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -18,9 +18,8 @@ type Manifests interface {
 	// which services.
 	// FIXME(michael): remove when redundant
 	FindDefinedServices(path string) (map[flux.ResourceID][]string, error)
-	// Update the definitions in a manifests bytes according to the
-	// spec given.
-	UpdateDefinition(def []byte, container string, newImageID image.Ref) ([]byte, error)
+	// Update the image in a manifest's bytes to that given
+	UpdateImage(def []byte, resourceID flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
 	// Load all the resource manifests under the path given. `baseDir`
 	// is used to relativise the paths, which are supplied as absolute
 	// paths to directories or files; at least one path must be

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -28,7 +28,7 @@ type Manifests interface {
 	// Parse the manifests given in an exported blob
 	ParseManifests([]byte) (map[string]resource.Resource, error)
 	// UpdatePolicies modifies a manifest to apply the policy update specified
-	UpdatePolicies([]byte, policy.Update) ([]byte, error)
+	UpdatePolicies([]byte, flux.ResourceID, policy.Update) ([]byte, error)
 	// ServicesWithPolicies returns all services with their associated policies
 	ServicesWithPolicies(path string) (policy.ResourceMap, error)
 }

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -21,7 +21,7 @@ type Mock struct {
 	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
-	UpdatePoliciesFunc       func([]byte, policy.Update) ([]byte, error)
+	UpdatePoliciesFunc       func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
 	ServicesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
 }
 
@@ -69,8 +69,8 @@ func (m *Mock) UpdateManifest(path string, resourceID string, f func(def []byte)
 	return m.UpdateManifestFunc(path, resourceID, f)
 }
 
-func (m *Mock) UpdatePolicies(def []byte, p policy.Update) ([]byte, error) {
-	return m.UpdatePoliciesFunc(def, p)
+func (m *Mock) UpdatePolicies(def []byte, id flux.ResourceID, p policy.Update) ([]byte, error) {
+	return m.UpdatePoliciesFunc(def, id, p)
 }
 
 func (m *Mock) ServicesWithPolicies(path string) (policy.ResourceMap, error) {

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -17,7 +17,7 @@ type Mock struct {
 	SyncFunc                 func(SyncDef) error
 	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
 	FindDefinedServicesFunc  func(path string) (map[flux.ResourceID][]string, error)
-	UpdateDefinitionFunc     func(def []byte, container string, newImageID image.Ref) ([]byte, error)
+	UpdateImageFunc          func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
 	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
 	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
@@ -53,8 +53,8 @@ func (m *Mock) FindDefinedServices(path string) (map[flux.ResourceID][]string, e
 	return m.FindDefinedServicesFunc(path)
 }
 
-func (m *Mock) UpdateDefinition(def []byte, container string, newImageID image.Ref) ([]byte, error) {
-	return m.UpdateDefinitionFunc(def, container, newImageID)
+func (m *Mock) UpdateImage(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error) {
+	return m.UpdateImageFunc(def, id, container, newImageID)
 }
 
 func (m *Mock) LoadManifests(base, first string, rest ...string) (map[string]resource.Resource, error) {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -272,7 +272,7 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) daemonJo
 			}
 			// find the service manifest
 			err := cluster.UpdateManifest(d.Manifests, working.ManifestDir(), serviceID, func(def []byte) ([]byte, error) {
-				newDef, err := d.Manifests.UpdatePolicies(def, u)
+				newDef, err := d.Manifests.UpdatePolicies(def, serviceID, u)
 				if err != nil {
 					result.Result[serviceID] = update.ControllerResult{
 						Status: update.ReleaseStatusFailed,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -421,7 +421,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 		}
 		k8s.SyncFunc = func(def cluster.SyncDef) error { return nil }
 		k8s.UpdatePoliciesFunc = (&kubernetes.Manifests{}).UpdatePolicies
-		k8s.UpdateDefinitionFunc = (&kubernetes.Manifests{}).UpdateDefinition
+		k8s.UpdateImageFunc = (&kubernetes.Manifests{}).UpdateImage
 	}
 
 	var imageRegistry registry.Registry

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -105,6 +105,16 @@ func (s Set) Get(p Policy) (string, bool) {
 	return v, ok
 }
 
+func (s Set) Without(omit Policy) Set {
+	newMap := Set{}
+	for p, v := range s {
+		if p != omit {
+			newMap[p] = v
+		}
+	}
+	return newMap
+}
+
 func (s Set) ToStringMap() map[string]string {
 	m := map[string]string{}
 	for p, v := range s {

--- a/update/automated.go
+++ b/update/automated.go
@@ -108,7 +108,7 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 				// resource (e.g., to avoid canonicalising it)
 				newImageID := currentImageID.WithNewTag(change.ImageID.Tag)
 				var err error
-				u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, newImageID)
+				u.ManifestBytes, err = rc.Manifests().UpdateImage(u.ManifestBytes, u.ResourceID, container.Name, newImageID)
 				if err != nil {
 					return nil, err
 				}

--- a/update/release.go
+++ b/update/release.go
@@ -251,7 +251,7 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 			// canonical form.
 			newImageID := currentImageID.WithNewTag(latestImage.ID.Tag)
 
-			u.ManifestBytes, err = rc.Manifests().UpdateDefinition(u.ManifestBytes, container.Name, newImageID)
+			u.ManifestBytes, err = rc.Manifests().UpdateImage(u.ManifestBytes, u.ResourceID, container.Name, newImageID)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This rewrites Kubernetes UpdatePolicies/UpdateImages to use the
generic resource parsing (in cluster/kubernetes/resource), rather than
doing its own. It's not possible to avoid entirely, because the way
the updating is written, it needs the annotations rather than the
policy.

As a side effect, this introduces a ResourceID into the arguments for both methods; this will be useful for supporting multidocs and lists, later.

The internals of UpdateImage can also be rewritten, to a lesser
extent. I also removed some of the code that dealt with
ReplicationControllers, which we have not supported for a while.