### PR TITLE
Add org.opencontainers.image.* labels to Dockerfiles

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,7 +1,13 @@
 FROM alpine:3.6
 
 # These are pretty static
-LABEL org.label-schema.schema-version="1.0" \
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="flux" \
+      org.opencontainers.image.description="The Flux daemon, for synchronising your cluster with a git repo, and deploying new images" \
+      org.opencontainers.image.url="https://github.com/weaveworks/flux" \
+      org.opencontainers.image.source="git@github.com:weaveworks/flux" \
+      org.opencontainers.image.vendor="Weaveworks" \
+      org.label-schema.schema-version="1.0" \
       org.label-schema.name="flux" \
       org.label-schema.description="The Flux daemon, for synchronising your cluster with a git repo, and deploying new images" \
       org.label-schema.url="https://github.com/weaveworks/flux" \
@@ -28,5 +34,7 @@ ARG BUILD_DATE
 ARG VCS_REF
 
 # These will change for every build
-LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.build-date=$BUILD_DATE
+LABEL org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.label-schema.vcs-ref="$VCS_REF" \
+      org.label-schema.build-date="$BUILD_DATE"

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -1,7 +1,13 @@
 FROM alpine:3.6
 
 # These are pretty static
-LABEL org.label-schema.schema-version="1.0" \
+LABEL maintainer="Weaveworks <help@weave.works>" \
+      org.opencontainers.image.title="flux-helm-operator" \
+      org.opencontainers.image.description="The Flux Helm operator, for releasing Helm charts according to git" \
+      org.opencontainers.image.url="https://github.com/weaveworks/flux" \
+      org.opencontainers.image.source="git@github.com:weaveworks/flux" \
+      org.opencontainers.image.vendor="Weaveworks" \
+      org.label-schema.schema-version="1.0" \
       org.label-schema.name="flux-helm-operator" \
       org.label-schema.description="The Flux Helm operator, for releasing Helm charts according to git" \
       org.label-schema.url="https://github.com/weaveworks/flux" \
@@ -28,5 +34,7 @@ ARG BUILD_DATE
 ARG VCS_REF
 
 # These will change for every build
-LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.build-date=$BUILD_DATE
+LABEL org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.label-schema.vcs-ref="$VCS_REF" \
+      org.label-schema.build-date="$BUILD_DATE"


### PR DESCRIPTION
Why? What?

- This should ultimately help for image-to-code back references.
- `org.label-schema.*` labels are now deprecated, in favour of `org.opencontainers.image.*` labels.
  See also: https://github.com/opencontainers/image-spec/blob/master/annotations.md#back-compatibility-with-label-schema
- `MAINTAINER` is deprecated, in favour of the `maintainer` label. Both were missing so the latter was added.

Testing
```console
$ docker inspect quay.io/weaveworks/flux
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.label-schema.build-date": "2018-05-11T13:56:53Z",
                "org.label-schema.description": "The Flux daemon, for synchronising your cluster with a git repo, and deploying new images",
                "org.label-schema.name": "flux",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "https://github.com/weaveworks/flux",
                "org.label-schema.vcs-ref": "b719f6404ccc5247278d73849df1a89cf5e78b8c",
                "org.label-schema.vcs-url": "git@github.com:weaveworks/flux",
                "org.label-schema.vendor": "Weaveworks",
                "org.opencontainers.image.created": "2018-05-11T13:56:53Z",
                "org.opencontainers.image.description": "The Flux daemon, for synchronising your cluster with a git repo, and deploying new images",
                "org.opencontainers.image.revision": "b719f6404ccc5247278d73849df1a89cf5e78b8c",
                "org.opencontainers.image.source": "git@github.com:weaveworks/flux",
                "org.opencontainers.image.title": "flux",
                "org.opencontainers.image.url": "https://github.com/weaveworks/flux",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]

$ docker inspect quay.io/weaveworks/helm-operator
[
    {
        [...]
        "ContainerConfig": {
            [...]
            "Labels": {
                "maintainer": "Weaveworks <help@weave.works>",
                "org.label-schema.build-date": "2018-05-11T13:56:53Z",
                "org.label-schema.description": "The Flux Helm operator, for releasing Helm charts according to git",
                "org.label-schema.name": "flux-helm-operator",
                "org.label-schema.schema-version": "1.0",
                "org.label-schema.url": "https://github.com/weaveworks/flux",
                "org.label-schema.vcs-ref": "b719f6404ccc5247278d73849df1a89cf5e78b8c",
                "org.label-schema.vcs-url": "git@github.com:weaveworks/flux",
                "org.label-schema.vendor": "Weaveworks",
                "org.opencontainers.image.created": "2018-05-11T13:56:53Z",
                "org.opencontainers.image.description": "The Flux Helm operator, for releasing Helm charts according to git",
                "org.opencontainers.image.revision": "b719f6404ccc5247278d73849df1a89cf5e78b8c",
                "org.opencontainers.image.source": "git@github.com:weaveworks/flux",
                "org.opencontainers.image.title": "flux-helm-operator",
                "org.opencontainers.image.url": "https://github.com/weaveworks/flux",
                "org.opencontainers.image.vendor": "Weaveworks"
            }
[...]
```