### PR TITLE
Add `fluxctl sync` command

### DIFF
--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -67,6 +67,7 @@ func (opts *rootOpts) Command() *cobra.Command {
 		newControllerPolicy(opts).Command(),
 		newSave(opts).Command(),
 		newIdentity(opts).Command(),
+		newSync(opts).Command(),
 	)
 
 	return cmd

--- a/cmd/fluxctl/sync_cmd.go
+++ b/cmd/fluxctl/sync_cmd.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/weaveworks/flux/git"
+	"github.com/weaveworks/flux/update"
+)
+
+type syncOpts struct {
+	*rootOpts
+}
+
+func newSync(parent *rootOpts) *syncOpts {
+	return &syncOpts{rootOpts: parent}
+}
+
+func (opts *syncOpts) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "sync",
+		Short: "synchronize the cluster with the git repository, now",
+		RunE:  opts.RunE,
+	}
+	return cmd
+}
+
+func (opts *syncOpts) RunE(cmd *cobra.Command, args []string) error {
+	if len(args) > 0 {
+		return errorWantedNoArgs
+	}
+
+	ctx := context.Background()
+
+	gitConfig, err := opts.API.GitRepoConfig(ctx, false)
+	if err != nil {
+		return err
+	}
+
+	switch gitConfig.Status {
+	case git.RepoNoConfig:
+		return fmt.Errorf("no git repository is configured")
+	case git.RepoReady:
+		break
+	default:
+		return fmt.Errorf("git repository %s is not ready to sync (status: %s)", gitConfig.Remote.URL, string(gitConfig.Status))
+	}
+
+	fmt.Fprintf(cmd.OutOrStderr(), "Synchronizing with %s\n", gitConfig.Remote.URL)
+
+	updateSpec := update.Spec{
+		Type: update.Sync,
+		Spec: update.ManualSync{},
+	}
+	jobID, err := opts.API.UpdateManifests(ctx, updateSpec)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStderr(), "Job ID %s\n", string(jobID))
+	result, err := awaitJob(ctx, opts.API, jobID)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStderr(), "HEAD of %s is %s\n", gitConfig.Remote.Branch, result.Revision)
+	err = awaitSync(ctx, opts.API, result.Revision)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(cmd.OutOrStderr(), "Applied %s\n", result.Revision)
+	fmt.Fprintln(cmd.OutOrStderr(), "Done.")
+	return nil
+}

--- a/cmd/fluxctl/sync_cmd.go
+++ b/cmd/fluxctl/sync_cmd.go
@@ -58,17 +58,19 @@ func (opts *syncOpts) RunE(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStderr(), "Job ID %s\n", string(jobID))
 	result, err := awaitJob(ctx, opts.API, jobID)
 	if err != nil {
+		fmt.Fprintf(cmd.OutOrStderr(), "Failed to complete sync job (ID %q)\n", jobID)
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStderr(), "HEAD of %s is %s\n", gitConfig.Remote.Branch, result.Revision)
-	err = awaitSync(ctx, opts.API, result.Revision)
+
+	rev := result.Revision[:7]
+	fmt.Fprintf(cmd.OutOrStderr(), "HEAD of %s is %s\n", gitConfig.Remote.Branch, rev)
+	fmt.Fprintf(cmd.OutOrStderr(), "Waiting for %s to be applied ...\n", rev)
+	err = awaitSync(ctx, opts.API, rev)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintf(cmd.OutOrStderr(), "Applied %s\n", result.Revision)
 	fmt.Fprintln(cmd.OutOrStderr(), "Done.")
 	return nil
 }

--- a/update/spec.go
+++ b/update/spec.go
@@ -11,6 +11,7 @@ const (
 	Images = "image"
 	Policy = "policy"
 	Auto   = "auto"
+	Sync   = "sync"
 )
 
 // How did this update get triggered?
@@ -56,6 +57,11 @@ func (spec *Spec) UnmarshalJSON(in []byte) error {
 		var update Automated
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err
+		}
+		spec.Spec = update
+	case Sync:
+		var update ManualSync
+		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 		}
 		spec.Spec = update
 	default:

--- a/update/sync.go
+++ b/update/sync.go
@@ -1,0 +1,4 @@
+package update
+
+type ManualSync struct {
+}


### PR DESCRIPTION
This adds the ability to manually trigger a sync (pull commits from
the git origin, and apply to cluster), and a command `fluxctl sync`
which triggers a manual sync and reports its progress.

Since a sync is potentially a long-running task, it's run using the
job machinery: the command posts an `update.Spec`, which is submitted
as a job and the ID returned. The command then proceeds more or less
as it would for a release or policy change.

Because the different kinds of update require different handling, I've
factored the creation of jobs out into some combinators (or near
combinators):

 - run a job that needs a git clone
 - run a job that results in a commit, and report the result back to
   the upstream server

Fixes #1079.