### PR TITLE
Add ListImages summary fields

### DIFF
--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -42,19 +42,19 @@ type ControllerStatus struct {
 }
 
 type Container struct {
-	Name           string
-	Current        image.Info
-	LatestFiltered image.Info
+	Name           string     `json:",omitempty"`
+	Current        image.Info `json:",omitempty"`
+	LatestFiltered image.Info `json:",omitempty"`
 
 	// All available images (ignoring tag filters)
-	Available               []image.Info
-	AvailableError          string `json:",omitempty"`
-	AvailableImagesCount    int
-	NewAvailableImagesCount int
+	Available               []image.Info `json:",omitempty"`
+	AvailableError          string       `json:",omitempty"`
+	AvailableImagesCount    int          `json:",omitempty"`
+	NewAvailableImagesCount int          `json:",omitempty"`
 
 	// Filtered available images (matching tag filters)
-	FilteredImagesCount    int
-	NewFilteredImagesCount int
+	FilteredImagesCount    int `json:",omitempty"`
+	NewFilteredImagesCount int `json:",omitempty"`
 }
 
 // --- config types
@@ -75,13 +75,17 @@ type Deprecated interface {
 	SyncNotify(context.Context) error
 }
 
+type ListImagesOptions struct {
+	OverrideContainerFields []string
+}
+
 type NotDeprecated interface {
 	// from v5
 	Export(context.Context) ([]byte, error)
 
 	// v6
 	ListServices(ctx context.Context, namespace string) ([]ControllerStatus, error)
-	ListImages(context.Context, update.ResourceSpec) ([]ImageStatus, error)
+	ListImages(ctx context.Context, spec update.ResourceSpec, opts ListImagesOptions) ([]ImageStatus, error)
 	UpdateManifests(context.Context, update.Spec) (job.ID, error)
 	SyncStatus(ctx context.Context, ref string) ([]string, error)
 	JobStatus(context.Context, job.ID) (job.Status, error)

--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -44,8 +44,17 @@ type ControllerStatus struct {
 type Container struct {
 	Name           string
 	Current        image.Info
-	Available      []image.Info
-	AvailableError string `json:",omitempty"`
+	LatestFiltered image.Info
+
+	// All available images (ignoring tag filters)
+	Available               []image.Info
+	AvailableError          string `json:",omitempty"`
+	AvailableImagesCount    int
+	NewAvailableImagesCount int
+
+	// Filtered available images (matching tag filters)
+	FilteredImagesCount    int
+	NewFilteredImagesCount int
 }
 
 // --- config types

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -67,7 +67,7 @@ func (opts *controllerShowOpts) RunE(cmd *cobra.Command, args []string) error {
 
 	ctx := context.Background()
 
-	controllers, err := opts.API.ListImages(ctx, resourceSpec)
+	controllers, err := opts.API.ListImages(ctx, resourceSpec, v6.ListImagesOptions{})
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -139,7 +139,7 @@ func TestDaemon_ListImages(t *testing.T) {
 
 	// List all images for services
 	ss := update.ResourceSpec(update.ResourceSpecAll)
-	is, err := d.ListImages(ctx, ss)
+	is, err := d.ListImages(ctx, ss, v6.ListImagesOptions{})
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}
@@ -150,7 +150,7 @@ func TestDaemon_ListImages(t *testing.T) {
 
 	// List images for specific service
 	ss = update.ResourceSpec(svc)
-	is, err = d.ListImages(ctx, ss)
+	is, err = d.ListImages(ctx, ss, v6.ListImagesOptions{})
 	if err != nil {
 		t.Fatalf("Error: %s", err.Error())
 	}

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -18,17 +18,17 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 
 	ctx := context.Background()
 
-	candidateServices, err := d.unlockedAutomatedServices(ctx)
+	candidateServicesPolicyMap, err := d.getUnlockedAutomatedServicesPolicyMap(ctx)
 	if err != nil {
 		logger.Log("error", errors.Wrap(err, "getting unlocked automated services"))
 		return
 	}
-	if len(candidateServices) == 0 {
+	if len(candidateServicesPolicyMap) == 0 {
 		logger.Log("msg", "no automated services")
 		return
 	}
 	// Find images to check
-	services, err := d.Cluster.SomeControllers(candidateServices.ToSlice())
+	services, err := d.Cluster.SomeControllers(candidateServicesPolicyMap.ToSlice())
 	if err != nil {
 		logger.Log("error", errors.Wrap(err, "checking services for new images"))
 		return
@@ -51,11 +51,11 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 				continue
 			}
 
-			pattern := getTagPattern(candidateServices, service.ID, container.Name)
+			pattern := getTagPattern(candidateServicesPolicyMap, service.ID, container.Name)
 			repo := currentImageID.Name
 			logger.Log("repo", repo, "pattern", pattern)
 
-			if latest, ok := imageRepos.LatestImage(repo, pattern); ok && latest.ID != currentImageID {
+			if latest, ok := imageRepos.LatestFilteredImage(repo, pattern); ok && latest.ID != currentImageID {
 				if latest.ID.Tag == "" {
 					logger.Log("msg", "untagged image in available images", "action", "skip", "available", repo)
 					continue
@@ -73,6 +73,9 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 }
 
 func getTagPattern(services policy.ResourceMap, service flux.ResourceID, container string) string {
+	if services == nil {
+		return "*"
+	}
 	policies := services[service]
 	if pattern, ok := policies.Get(policy.TagPrefix(container)); ok {
 		return strings.TrimPrefix(pattern, "glob:")
@@ -80,7 +83,8 @@ func getTagPattern(services policy.ResourceMap, service flux.ResourceID, contain
 	return "*"
 }
 
-func (d *Daemon) unlockedAutomatedServices(ctx context.Context) (policy.ResourceMap, error) {
+// getUnlockedAutomatedServicesPolicyMap returns a resource policy map for all unlocked automated services
+func (d *Daemon) getUnlockedAutomatedServicesPolicyMap(ctx context.Context) (policy.ResourceMap, error) {
 	var services policy.ResourceMap
 	err := d.WithClone(ctx, func(checkout *git.Checkout) error {
 		var err error

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -55,7 +55,9 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 			repo := currentImageID.Name
 			logger.Log("repo", repo, "pattern", pattern)
 
-			if latest, ok := imageRepos.LatestFilteredImage(repo, pattern); ok && latest.ID != currentImageID {
+			filteredImages := imageRepos.GetRepoImages(repo).Filter(pattern)
+
+			if latest, ok := filteredImages.Latest(); ok && latest.ID != currentImageID {
 				if latest.ID.Tag == "" {
 					logger.Log("msg", "untagged image in available images", "action", "skip", "available", repo)
 					continue

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -34,7 +34,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 		return
 	}
 	// Check the latest available image(s) for each service
-	imageMap, err := update.CollectAvailableImages(d.Registry, clusterContainers(services), logger)
+	imageRepos, err := update.FetchImageRepos(d.Registry, clusterContainers(services), logger)
 	if err != nil {
 		logger.Log("error", errors.Wrap(err, "fetching image updates"))
 		return
@@ -55,7 +55,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 			repo := currentImageID.Name
 			logger.Log("repo", repo, "pattern", pattern)
 
-			if latest, ok := imageMap.LatestImage(repo, pattern); ok && latest.ID != currentImageID {
+			if latest, ok := imageRepos.LatestImage(repo, pattern); ok && latest.ID != currentImageID {
 				if latest.ID.Tag == "" {
 					logger.Log("msg", "untagged image in available images", "action", "skip", "available", repo)
 					continue

--- a/daemon/images_test.go
+++ b/daemon/images_test.go
@@ -1,0 +1,58 @@
+package daemon
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/policy"
+)
+
+func Test_getTagPattern(t *testing.T) {
+	resourceID, err := flux.ParseResourceID("default:deployment/helloworld")
+	assert.NoError(t, err)
+	container := "helloContainer"
+
+	type args struct {
+		services  policy.ResourceMap
+		service   flux.ResourceID
+		container string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Nil policies",
+			args: args{services: nil},
+			want: "*",
+		},
+		{
+			name: "No match",
+			args: args{services: policy.ResourceMap{}},
+			want: "*",
+		},
+		{
+			name: "Match",
+			args: args{
+				services: policy.ResourceMap{
+					resourceID: policy.Set{
+						policy.Policy(fmt.Sprintf("tag.%s", container)): "glob:master-*",
+					},
+				},
+				service:   resourceID,
+				container: container,
+			},
+			want: "master-*",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getTagPattern(tt.args.services, tt.args.service, tt.args.container); got != tt.want {
+				t.Errorf("getTagPattern() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -57,9 +57,9 @@ func (c *Client) ListServices(ctx context.Context, namespace string) ([]v6.Contr
 	return res, err
 }
 
-func (c *Client) ListImages(ctx context.Context, s update.ResourceSpec) ([]v6.ImageStatus, error) {
+func (c *Client) ListImages(ctx context.Context, s update.ResourceSpec, opts v6.ListImagesOptions) ([]v6.ImageStatus, error) {
 	var res []v6.ImageStatus
-	err := c.Get(ctx, &res, transport.ListImages, "service", string(s))
+	err := c.Get(ctx, &res, transport.ListImages, "service", string(s), "containerFields", strings.Join(opts.OverrideContainerFields, ","))
 	return res, err
 }
 
@@ -210,7 +210,7 @@ func (c *Client) executeRequest(req *http.Request) (*http.Response, error) {
 			if err := json.Unmarshal(body, &niceError); err != nil {
 				return resp, errors.Wrap(err, "decoding response body of error")
 			}
-			 // just in case it's JSON but not one of our own errors
+			// just in case it's JSON but not one of our own errors
 			if niceError.Err != nil {
 				return resp, &niceError
 			}

--- a/http/transport.go
+++ b/http/transport.go
@@ -29,8 +29,8 @@ func DeprecateVersions(r *mux.Router, versions ...string) {
 func NewAPIRouter() *mux.Router {
 	r := mux.NewRouter()
 
-	r.NewRoute().Name(ListServices).Methods("GET").Path("/v6/services").Queries("namespace", "{namespace}") // optional namespace!
-	r.NewRoute().Name(ListImages).Methods("GET").Path("/v6/images").Queries("service", "{service}")
+	r.NewRoute().Name(ListServices).Methods("GET").Path("/v6/services")
+	r.NewRoute().Name(ListImages).Methods("GET").Path("/v6/images")
 
 	r.NewRoute().Name(UpdateManifests).Methods("POST").Path("/v9/update-manifests")
 	r.NewRoute().Name(JobStatus).Methods("GET").Path("/v6/jobs").Queries("id", "{id}")

--- a/image/image.go
+++ b/image/image.go
@@ -225,16 +225,16 @@ func (i Ref) WithNewTag(t string) Ref {
 // from its registry.
 type Info struct {
 	// the reference to this image; probably a tagged image name
-	ID Ref
+	ID Ref `json:",omitempty"`
 	// the digest we got when fetching the metadata, which will be
 	// different each time a manifest is uploaded for the reference
-	Digest string
+	Digest string `json:",omitempty"`
 	// an identifier for the *image* this reference points to; this
 	// will be the same for references that point at the same image
 	// (but does not necessarily equal Docker's image ID)
-	ImageID string
+	ImageID string `json:",omitempty"`
 	// the time at which the image pointed at was created
-	CreatedAt time.Time
+	CreatedAt time.Time `json:",omitempty"`
 }
 
 // MarshalJSON returns the Info value in JSON (as bytes). It is

--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -66,14 +66,14 @@ Loop:
 		case <-timeout.C:
 			t.Fatal("Cache timeout")
 		case <-tick.C:
-			_, err := r.GetRepository(id.Name)
+			_, err := r.GetSortedRepositoryImages(id.Name)
 			if err == nil {
 				break Loop
 			}
 		}
 	}
 
-	img, err := r.GetRepository(id.Name)
+	img, err := r.GetSortedRepositoryImages(id.Name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -31,9 +31,9 @@ type Cache struct {
 	Reader Reader
 }
 
-// GetRepository returns the list of image manifests in an image
+// GetSortedRepositoryImages returns the list of image manifests in an image
 // repository (e.g,. at "quay.io/weaveworks/flux")
-func (c *Cache) GetRepository(id image.Name) ([]image.Info, error) {
+func (c *Cache) GetSortedRepositoryImages(id image.Name) ([]image.Info, error) {
 	repoKey := NewRepositoryKey(id.CanonicalName())
 	bytes, _, err := c.Reader.GetKey(repoKey)
 	if err != nil {

--- a/registry/cache/warming_test.go
+++ b/registry/cache/warming_test.go
@@ -71,7 +71,7 @@ func TestWarm(t *testing.T) {
 	warmer.warm(context.TODO(), logger, repo, registry.NoCredentials())
 
 	registry := &Cache{Reader: c}
-	repoInfo, err := registry.GetRepository(ref.Name)
+	repoInfo, err := registry.GetSortedRepositoryImages(ref.Name)
 	if err != nil {
 		t.Error(err)
 	}

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -40,7 +40,7 @@ type Registry struct {
 	Err    error
 }
 
-func (m *Registry) GetRepository(id image.Name) ([]image.Info, error) {
+func (m *Registry) GetSortedRepositoryImages(id image.Name) ([]image.Info, error) {
 	var imgs []image.Info
 	for _, i := range m.Images {
 		// include only if it's the same repository in the same place

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -46,9 +46,9 @@ func NewInstrumentedRegistry(next Registry) Registry {
 	}
 }
 
-func (m *instrumentedRegistry) GetRepository(id image.Name) (res []image.Info, err error) {
+func (m *instrumentedRegistry) GetSortedRepositoryImages(id image.Name) (res []image.Info, err error) {
 	start := time.Now()
-	res, err = m.next.GetRepository(id)
+	res, err = m.next.GetSortedRepositoryImages(id)
 	registryDuration.With(
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -12,7 +12,7 @@ var (
 
 // Registry is a store of image metadata.
 type Registry interface {
-	GetRepository(image.Name) ([]image.Info, error)
+	GetSortedRepositoryImages(image.Name) ([]image.Info, error)
 	GetImage(image.Ref) (image.Info, error)
 }
 

--- a/remote/logging.go
+++ b/remote/logging.go
@@ -43,13 +43,13 @@ func (p *ErrorLoggingServer) ListServices(ctx context.Context, maybeNamespace st
 	return p.server.ListServices(ctx, maybeNamespace)
 }
 
-func (p *ErrorLoggingServer) ListImages(ctx context.Context, spec update.ResourceSpec) (_ []v6.ImageStatus, err error) {
+func (p *ErrorLoggingServer) ListImages(ctx context.Context, spec update.ResourceSpec, opts v6.ListImagesOptions) (_ []v6.ImageStatus, err error) {
 	defer func() {
 		if err != nil {
 			p.logger.Log("method", "ListImages", "error", err)
 		}
 	}()
-	return p.server.ListImages(ctx, spec)
+	return p.server.ListImages(ctx, spec, opts)
 }
 
 func (p *ErrorLoggingServer) JobStatus(ctx context.Context, jobID job.ID) (_ job.Status, err error) {

--- a/remote/metrics.go
+++ b/remote/metrics.go
@@ -56,14 +56,14 @@ func (i *instrumentedServer) ListServices(ctx context.Context, namespace string)
 	return i.s.ListServices(ctx, namespace)
 }
 
-func (i *instrumentedServer) ListImages(ctx context.Context, spec update.ResourceSpec) (_ []v6.ImageStatus, err error) {
+func (i *instrumentedServer) ListImages(ctx context.Context, spec update.ResourceSpec, opts v6.ListImagesOptions) (_ []v6.ImageStatus, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "ListImages",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.s.ListImages(ctx, spec)
+	return i.s.ListImages(ctx, spec, opts)
 }
 
 func (i *instrumentedServer) UpdateManifests(ctx context.Context, spec update.Spec) (_ job.ID, err error) {

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -65,7 +65,7 @@ func (p *MockServer) ListServices(ctx context.Context, ns string) ([]v6.Controll
 	return p.ListServicesAnswer, p.ListServicesError
 }
 
-func (p *MockServer) ListImages(context.Context, update.ResourceSpec) ([]v6.ImageStatus, error) {
+func (p *MockServer) ListImages(context.Context, update.ResourceSpec, v6.ListImagesOptions) ([]v6.ImageStatus, error) {
 	return p.ListImagesAnswer, p.ListImagesError
 }
 
@@ -194,7 +194,7 @@ func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.Upst
 		t.Error("expected error from ListServices, got nil")
 	}
 
-	ims, err := client.ListImages(ctx, update.ResourceSpecAll)
+	ims, err := client.ListImages(ctx, update.ResourceSpecAll, v6.ListImagesOptions{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -202,7 +202,7 @@ func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.Upst
 		t.Error(fmt.Errorf("expected:\n%#v\ngot:\n%#v", mock.ListImagesAnswer, ims))
 	}
 	mock.ListImagesError = fmt.Errorf("list images error")
-	if _, err = client.ListImages(ctx, update.ResourceSpecAll); err == nil {
+	if _, err = client.ListImages(ctx, update.ResourceSpecAll, v6.ListImagesOptions{}); err == nil {
 		t.Error("expected error from ListImages, got nil")
 	}
 

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -33,7 +33,7 @@ func (bc baseClient) ListServices(context.Context, string) ([]v6.ControllerStatu
 	return nil, remote.UpgradeNeededError(errors.New("ListServices method not implemented"))
 }
 
-func (bc baseClient) ListImages(context.Context, update.ResourceSpec) ([]v6.ImageStatus, error) {
+func (bc baseClient) ListImages(context.Context, update.ResourceSpec, v6.ListImagesOptions) ([]v6.ImageStatus, error) {
 	return nil, remote.UpgradeNeededError(errors.New("ListImages method not implemented"))
 }
 

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -99,7 +99,7 @@ func (p *RPCClientV6) ListServices(ctx context.Context, namespace string) ([]v6.
 	return services, err
 }
 
-func (p *RPCClientV6) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6.ImageStatus, error) {
+func (p *RPCClientV6) ListImages(ctx context.Context, spec update.ResourceSpec, opts v6.ListImagesOptions) ([]v6.ImageStatus, error) {
 	var images []v6.ImageStatus
 	if err := requireServiceSpecKinds(spec, supportedKindsV6); err != nil {
 		return images, remote.UpgradeNeededError(err)

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -62,7 +62,7 @@ func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]v6.
 	return resp.Result, err
 }
 
-func (p *RPCClientV7) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6.ImageStatus, error) {
+func (p *RPCClientV7) ListImages(ctx context.Context, spec update.ResourceSpec, opts v6.ListImagesOptions) ([]v6.ImageStatus, error) {
 	var resp ListImagesResponse
 	if err := requireServiceSpecKinds(spec, supportedKindsV7); err != nil {
 		return resp.Result, remote.UpgradeNeededError(err)

--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -32,7 +32,7 @@ func NewClientV8(conn io.ReadWriteCloser) *RPCClientV8 {
 	return &RPCClientV8{NewClientV7(conn)}
 }
 
-func (p *RPCClientV8) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6.ImageStatus, error) {
+func (p *RPCClientV8) ListImages(ctx context.Context, spec update.ResourceSpec, opts v6.ListImagesOptions) ([]v6.ImageStatus, error) {
 	var resp ListImagesResponse
 	if err := requireServiceSpecKinds(spec, supportedKindsV8); err != nil {
 		return resp.Result, remote.UnsupportedResourceKind(err)

--- a/remote/rpc/server.go
+++ b/remote/rpc/server.go
@@ -89,7 +89,7 @@ type ListImagesResponse struct {
 }
 
 func (p *RPCServer) ListImages(spec update.ResourceSpec, resp *ListImagesResponse) error {
-	v, err := p.s.ListImages(context.Background(), spec)
+	v, err := p.s.ListImages(context.Background(), spec, v6.ListImagesOptions{})
 	resp.Result = v
 	if err != nil {
 		if err, ok := errors.Cause(err).(*fluxerr.Error); ok {

--- a/update/images.go
+++ b/update/images.go
@@ -14,10 +14,11 @@ import (
 	"github.com/weaveworks/flux/resource"
 )
 
-type infoMap map[image.CanonicalName][]image.Info
+type imageReposMap map[image.CanonicalName][]image.Info
 
-type ImageMap struct {
-	images infoMap
+// ImageRepos contains a map of image repositories to their images
+type ImageRepos struct {
+	imageRepos imageReposMap
 }
 
 // LatestImage returns the latest releasable image for a repository
@@ -26,8 +27,8 @@ type ImageMap struct {
 // in descending order of latestness.) If no such image exists,
 // returns a zero value and `false`, and the caller can decide whether
 // that's an error or not.
-func (m ImageMap) LatestImage(repo image.Name, tagGlob string) (image.Info, bool) {
-	for _, available := range m.images[repo.CanonicalName()] {
+func (r ImageRepos) LatestImage(repo image.Name, tagGlob string) (image.Info, bool) {
+	for _, available := range r.imageRepos[repo.CanonicalName()] {
 		tag := available.ID.Tag
 		// Ignore latest if and only if it's not what the user wants.
 		if !strings.EqualFold(tagGlob, "latest") && strings.EqualFold(tag, "latest") {
@@ -45,8 +46,8 @@ func (m ImageMap) LatestImage(repo image.Name, tagGlob string) (image.Info, bool
 
 // Available returns image.Info entries for all the images in the
 // named image repository.
-func (m ImageMap) Available(repo image.Name) []image.Info {
-	if canon, ok := m.images[repo.CanonicalName()]; ok {
+func (r ImageRepos) Available(repo image.Name) []image.Info {
+	if canon, ok := r.imageRepos[repo.CanonicalName()]; ok {
 		infos := make([]image.Info, len(canon))
 		for i := range canon {
 			infos[i] = canon[i]
@@ -73,50 +74,50 @@ func (cs controllerContainers) Containers(i int) []resource.Container {
 	return cs[i].Controller.ContainersOrNil()
 }
 
-// collectUpdateImages is a convenient shim to
-// `CollectAvailableImages`.
-func collectUpdateImages(registry registry.Registry, updateable []*ControllerUpdate, logger log.Logger) (ImageMap, error) {
-	return CollectAvailableImages(registry, controllerContainers(updateable), logger)
+// fetchUpdatableImageRepos is a convenient shim to
+// `FetchImageRepos`.
+func fetchUpdatableImageRepos(registry registry.Registry, updateable []*ControllerUpdate, logger log.Logger) (ImageRepos, error) {
+	return FetchImageRepos(registry, controllerContainers(updateable), logger)
 }
 
-// CollectAvailableImages finds all the known image metadata for
+// FetchImageRepos finds all the known image metadata for
 // containers in the controllers given.
-func CollectAvailableImages(reg registry.Registry, cs containers, logger log.Logger) (ImageMap, error) {
-	images := infoMap{}
+func FetchImageRepos(reg registry.Registry, cs containers, logger log.Logger) (ImageRepos, error) {
+	imageRepos := imageReposMap{}
 	for i := 0; i < cs.Len(); i++ {
 		for _, container := range cs.Containers(i) {
-			images[container.Image.CanonicalName()] = nil
+			imageRepos[container.Image.CanonicalName()] = nil
 		}
 	}
-	for name := range images {
-		imageRepo, err := reg.GetRepository(name.Name)
+	for repo := range imageRepos {
+		sortedRepoImages, err := reg.GetSortedRepositoryImages(repo.Name)
 		if err != nil {
 			// Not an error if missing. Use empty images.
 			if !fluxerr.IsMissing(err) {
-				logger.Log("err", errors.Wrapf(err, "fetching image metadata for %s", name))
+				logger.Log("err", errors.Wrapf(err, "fetching image metadata for %s", repo))
 				continue
 			}
 		}
-		images[name] = imageRepo
+		imageRepos[repo] = sortedRepoImages
 	}
-	return ImageMap{images}, nil
+	return ImageRepos{imageRepos}, nil
 }
 
-// Create a map of images. It will check that each image exists.
-func exactImages(reg registry.Registry, images []image.Ref) (ImageMap, error) {
-	m := infoMap{}
+// Create a map of image repos to images. It will check that each image exists.
+func exactImageRepos(reg registry.Registry, images []image.Ref) (ImageRepos, error) {
+	m := imageReposMap{}
 	for _, id := range images {
 		// We must check that the exact images requested actually exist. Otherwise we risk pushing invalid images to git.
 		exist, err := imageExists(reg, id)
 		if err != nil {
-			return ImageMap{}, errors.Wrap(image.ErrInvalidImageID, err.Error())
+			return ImageRepos{}, errors.Wrap(image.ErrInvalidImageID, err.Error())
 		}
 		if !exist {
-			return ImageMap{}, errors.Wrap(image.ErrInvalidImageID, fmt.Sprintf("image %q does not exist", id))
+			return ImageRepos{}, errors.Wrap(image.ErrInvalidImageID, fmt.Sprintf("image %q does not exist", id))
 		}
 		m[id.CanonicalName()] = []image.Info{{ID: id}}
 	}
-	return ImageMap{m}, nil
+	return ImageRepos{m}, nil
 }
 
 // Checks whether the given image exists in the repository.

--- a/update/images.go
+++ b/update/images.go
@@ -21,8 +21,8 @@ type ImageRepos struct {
 	imageRepos imageReposMap
 }
 
-// FindImageInfo retruns image.Info given an image ref. If the image cannot be
-// found, return the image.Info with only rhe ID.
+// FindImageInfo returns image.Info given an image ref. If the image cannot be
+// found, return the image.Info with only the ID.
 func (r ImageRepos) FindImageInfo(repo image.Name, ref image.Ref) image.Info {
 	images, ok := r.imageRepos[ref.CanonicalName()]
 	if !ok {
@@ -50,8 +50,8 @@ func (r ImageRepos) LatestFilteredImage(repo image.Name, tagGlob string) (image.
 	return image.Info{}, false
 }
 
-// FilteredAvailable returns image.Info engtries for all the images in the
-// names image repository which match the tagGlob.
+// FilteredAvailable returns image.Info entries for all the images in the
+// named image repository which match the tagGlob.
 func (r ImageRepos) FilteredAvailable(repo image.Name, tagGlob string) []image.Info {
 	var filtered []image.Info
 	for _, available := range r.Available(repo) {

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -20,18 +20,18 @@ var (
 // names (e.g., `index.docker.io/library/alpine`), but we ask
 // questions in terms of everyday names (e.g., `alpine`).
 func TestDecanon(t *testing.T) {
-	m := ImageMap{infoMap{
+	m := ImageRepos{imageReposMap{
 		name: infos,
 	}}
 
-	latest, ok := m.LatestImage(mustParseName("weaveworks/helloworld"), "*")
+	latest, ok := m.LatestFilteredImage(mustParseName("weaveworks/helloworld"), "*")
 	if !ok {
 		t.Error("did not find latest image")
 	} else if latest.ID.Name != mustParseName("weaveworks/helloworld") {
 		t.Error("name did not match what was asked")
 	}
 
-	latest, ok = m.LatestImage(mustParseName("index.docker.io/weaveworks/helloworld"), "*")
+	latest, ok = m.LatestFilteredImage(mustParseName("index.docker.io/weaveworks/helloworld"), "*")
 	if !ok {
 		t.Error("did not find latest image")
 	} else if latest.ID.Name != mustParseName("index.docker.io/weaveworks/helloworld") {
@@ -50,7 +50,7 @@ func TestDecanon(t *testing.T) {
 }
 
 func TestAvail(t *testing.T) {
-	m := ImageMap{infoMap{name: infos}}
+	m := ImageRepos{imageReposMap{name: infos}}
 	avail := m.Available(mustParseName("weaveworks/goodbyeworld"))
 	if len(avail) > 0 {
 		t.Errorf("did not expect available images, but got %#v", avail)

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -24,21 +24,23 @@ func TestDecanon(t *testing.T) {
 		name: infos,
 	}}
 
-	latest, ok := m.LatestFilteredImage(mustParseName("weaveworks/helloworld"), "*")
+	filteredImages := m.GetRepoImages(mustParseName("weaveworks/helloworld")).Filter("*")
+	latest, ok := filteredImages.Latest()
 	if !ok {
 		t.Error("did not find latest image")
 	} else if latest.ID.Name != mustParseName("weaveworks/helloworld") {
 		t.Error("name did not match what was asked")
 	}
 
-	latest, ok = m.LatestFilteredImage(mustParseName("index.docker.io/weaveworks/helloworld"), "*")
+	filteredImages = m.GetRepoImages(mustParseName("index.docker.io/weaveworks/helloworld")).Filter("*")
+	latest, ok = filteredImages.Latest()
 	if !ok {
 		t.Error("did not find latest image")
 	} else if latest.ID.Name != mustParseName("index.docker.io/weaveworks/helloworld") {
 		t.Error("name did not match what was asked")
 	}
 
-	avail := m.Available(mustParseName("weaveworks/helloworld"))
+	avail := m.GetRepoImages(mustParseName("weaveworks/helloworld"))
 	if len(avail) != len(infos) {
 		t.Errorf("expected %d available images, got %d", len(infos), len(avail))
 	}
@@ -51,7 +53,7 @@ func TestDecanon(t *testing.T) {
 
 func TestAvail(t *testing.T) {
 	m := ImageRepos{imageReposMap{name: infos}}
-	avail := m.Available(mustParseName("weaveworks/goodbyeworld"))
+	avail := m.GetRepoImages(mustParseName("weaveworks/goodbyeworld"))
 	if len(avail) > 0 {
 		t.Errorf("did not expect available images, but got %#v", avail)
 	}

--- a/update/release.go
+++ b/update/release.go
@@ -231,7 +231,7 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		for _, container := range containers {
 			currentImageID := container.Image
 
-			latestImage, ok := imageRepos.LatestImage(currentImageID.Name, "*")
+			latestImage, ok := imageRepos.LatestFilteredImage(currentImageID.Name, "*")
 			if !ok {
 				if currentImageID.CanonicalName() != singleRepo {
 					ignoredOrSkipped = ReleaseStatusIgnored

--- a/update/release.go
+++ b/update/release.go
@@ -231,7 +231,8 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		for _, container := range containers {
 			currentImageID := container.Image
 
-			latestImage, ok := imageRepos.LatestFilteredImage(currentImageID.Name, "*")
+			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).Filter("*")
+			latestImage, ok := filteredImages.Latest()
 			if !ok {
 				if currentImageID.CanonicalName() != singleRepo {
 					ignoredOrSkipped = ReleaseStatusIgnored


### PR DESCRIPTION
Part of #913 to allow a HTTP client to receive image summary information instead of fetching all of the images.

- Creates new fields in `containers`:
  - `LatestFiltered` - image.Info for the latest image
  - `AvailableImagesCount` - count of all available images
  - `NewAvailableImagesCount` - count of all new available images
  - `FilteredImagesCount` - count of all images after tag filter
  - `NewFilteredImagesCount` - count of all new images after tag filter

- Allows specifiying which containerFields to return in the response via a `?containerFields=...` query parameter
  - e.g. `images?containerFields=Name,Current,AvailableImagesCount`

- Refactors some of the variable names around image fetching to make it clearer what is happening (image repo stuff)
- Changes `ListImages` interface and so we will have to update this in WC service
- Don't require queryParams like `?service=` - defaults to `<all>`