### PR TITLE
Remove unused Gopkg.toml constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,3 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 [[constraint]]
   name = "k8s.io/helm"
   version = "v2.8.1"
-
-[[constraint]]
-  name = "google.golang.org/grpc"
-  revision = "b610ffd3f8786563002bd5b6a9951d56f64a4921"


### PR DESCRIPTION
Resolves this warning when running `dep ensure`:
```
Warning: the following project(s) have [[constraint]] stanzas in Gopkg.toml:

  ✗  google.golang.org/grpc

However, these projects are not direct dependencies of the current project:
they are not imported in any .go files, nor are they in the 'required' list in
Gopkg.toml. Dep only applies [[constraint]] rules to direct dependencies, so
these rules will have no effect.

Either import/require packages from these projects so that they become direct
dependencies, or convert each [[constraint]] to an [[override]] to enforce rules
on these projects, if they happen to be transitive dependencies.
```