### PR TITLE
Add integration tests to test helm+flux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,8 @@ testdata/sidecar/sidecar-linux-amd64
 testdata/sidecar/.sidecar
 docker/fluxy-dumbconf.priv
 test/profiles
+test/deps
+test/bin/yq
+test/bin/kubectl
+test/bin/helm
+test/bin/minikube

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,44 @@
+# flux integration tests
+Integration tester for [flux](weaveworks/flux).
+
+This is a translation to Go of the bash script 
+[test-flux](https://github.com/weaveworks/flux/blob/master/test/bin/test-flux).
+
+# Usage
+
+```
+cd test && ./download-prereqs.sh && go test -tags integration_test -start-minikube=true
+```
+
+WARNING: This will blow away your existing minikube "minikube" profile.
+See below for why.
+
+## Current status
+
+The main differences with test-flux:
+- Not broken (see [#919](https://github.com/weaveworks/flux/issues/919))
+- By default doesn't start/delete minikube, assumes one is already running
+- Requires specific minikube and k8s versions
+- Deploys flux via a helm chart
+- Adds support for testing flux's helm-operator.
+
+## Background
+
+There's a PR ([#921](https://github.com/weaveworks/flux/pull/921)) which 
+attempts to fix some of the brokenness in test-flux.  I had many issues
+trying to get it to work for me, mostly relating to minikube and k8s.
+- the fix relies on subpath, which is broken in k8s 1.9 prior to 1.9.5
+  (see [#61076](https://github.com/kubernetes/kubernetes/issues/61076))
+- minikube with the default options has various problems in recent 
+  releases (0.26.0+)
+- minikube has broken the -profile option in recent releases
+  (see [#2717](https://github.com/kubernetes/minikube/issues/2717))
+- minikube with localkube doesn't support a 1.9 release >1.9.4
+- if I'm going to run minikube without localkube, I'd like to use the
+  latest and greatest
+
+What it boiled down to was that any fix I tried to make to test-flux would've
+been quiet disruptive already. Moreover, I was tired of the slow feedback
+loop from doing a minikube delete/start for each invocation, and I wanted to
+introduce more tests (e.g. for helm), and I've written enough shell to know
+when it's a good idea to stop and rewrite in a better language.

--- a/test/download-prereqs.sh
+++ b/test/download-prereqs.sh
@@ -22,7 +22,7 @@ helm_dl=$dldir/$helm_relname
 helm_bin=$bindir/helm
 
 curl -s -L -o $helm_dl -z $helm_dl $helm_base/$helm_relname
-test -f $helm_bin -o $helm_bin -ot $helm_dl || tar -z -x -f $helm_dl -C $bindir --strip-components 1 linux-$arch/helm
+test -f $helm_bin || test $helm_bin -ot $helm_dl || tar -z -x -f $helm_dl -C $bindir --strip-components 1 linux-$arch/helm
 
 # kubectl
 kubectl_base=https://storage.googleapis.com/kubernetes-release/release

--- a/test/download-prereqs.sh
+++ b/test/download-prereqs.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+set -e
+
+if [ `uname -o` != 'GNU/Linux' -o `uname -m` != 'x86_64' ]; then
+    echo "Sorry, this script only supports Linux amd64 for now." 1>&2
+    exit 1
+fi
+
+arch=amd64
+dldir="`dirname $0`/deps"
+bindir="`dirname $0`/bin"
+
+test -d "$dldir" || mkdir "$dldir"
+test -d "$bindir" || mkdir "$bindir"
+
+# helm
+helm_base=https://storage.googleapis.com/kubernetes-helm
+helm_version=v2.9.1
+helm_relname=helm-$helm_version-linux-$arch.tar.gz
+helm_dl=$dldir/$helm_relname
+helm_bin=$bindir/helm
+
+curl -s -L -o $helm_dl -z $helm_dl $helm_base/$helm_relname
+test -f $helm_bin -o $helm_bin -ot $helm_dl || tar -z -x -f $helm_dl -C $bindir --strip-components 1 linux-$arch/helm
+
+# kubectl
+kubectl_base=https://storage.googleapis.com/kubernetes-release/release
+kubectl_version=v1.10.3
+kubectl_relname=kubectl_linux-$arch
+kubectl_dl=$dldir/$kubectl_relname-$kubectl_version 
+kubectl_bin=$bindir/kubectl
+
+curl -s -L -o $kubectl_dl -z $kubectl_dl $kubectl_base/$kubectl_version/bin/linux/$arch/kubectl
+chmod 755 $kubectl_dl
+ln -f $kubectl_dl $kubectl_bin
+
+# minikube
+minikube_base=https://github.com/kubernetes/minikube/releases/download
+minikube_version=v0.27.0
+minikube_relname=minikube-linux-$arch
+minikube_dl=$dldir/$minikube_relname-$minikube_version 
+minikube_bin=$bindir/minikube
+
+curl -s -L -o $minikube_dl -z $minikube_dl $minikube_base/$minikube_version/$minikube_relname
+chmod 755 $minikube_dl
+ln -f $minikube_dl $minikube_bin
+
+# yq
+yq_base=https://github.com/mikefarah/yq/releases/download/
+yq_version=1.15.0
+yq_relname=yq_linux_$arch
+yq_dl=$dldir/$yq_relname-$yq_version 
+yq_bin=$bindir/yq
+
+curl -s -L -o $yq_dl -z $yq_dl $yq_base/$yq_version/$yq_relname
+chmod 755 $yq_dl
+ln -f $yq_dl $yq_bin

--- a/test/flux_test.go
+++ b/test/flux_test.go
@@ -1,0 +1,252 @@
+// +build integration_test
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"text/template"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/weaveworks/flux/image"
+)
+
+const (
+	k8sSetupTimeout   = 600 * time.Second
+	imageSetupTimeout = 30 * time.Second
+	gitSetupTimeout   = 10 * time.Second
+	syncTimeout       = 20 * time.Second
+	// releaseTimeout is how long we allow between seeing sync done and seeing
+	// a change made to a helm release.
+	releaseTimeout          = 10 * time.Second
+	automationUpdateTimeout = 180 * time.Second
+	fluxPort                = "30080"
+	gitRepoPathOnNode       = "/home/docker/flux.git"
+	helloworldImageTag      = "master-a000001"
+	sidecarImageTag         = "master-a000001"
+	appNamespace            = "default"
+	fluxSyncTag             = "flux-sync"
+)
+
+type (
+	// harness holds state that may be test-specific.
+	harness struct {
+		workdir
+		clusterIP string
+		t         *testing.T
+		repodir   string
+		clusterAPI
+		gitAPI
+		helmAPI
+	}
+)
+
+var (
+	helloworldImageName = image.Name{Domain: "quay.io", Image: "weaveworks/helloworld"}
+	sidecarImageName    = image.Name{Domain: "quay.io", Image: "weaveworks/sidecar"}
+)
+
+func newharness(t *testing.T) *harness {
+	testdir := filepath.Join(global.workdir.root, t.Name())
+	os.Mkdir(testdir, 0755)
+	repodir := filepath.Join(testdir, "repo")
+
+	h := &harness{
+		workdir:    global.workdir,
+		repodir:    repodir,
+		t:          t,
+		clusterIP:  global.clusterIP,
+		clusterAPI: minikube{mt: global.clusterAPI.(minikube).mt, lg: t},
+		helmAPI:    helm{ht: global.helmAPI.(helm).ht, lg: t},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), gitSetupTimeout)
+	h.initGitRepoOnNode(ctx)
+	cancel()
+
+	h.gitAPI = mustNewGit(t, repodir,
+		fmt.Sprintf(`ssh -i %s -o UserKnownHostsFile=%s`, h.sshKeyPath(), h.knownHostsPath()),
+		h.gitURL())
+	return h
+}
+
+func (h *harness) initGitRepoOnNode(ctx context.Context) {
+	h.clusterAPI.sshToNode(fmt.Sprintf(
+		`set -e; dir="%s"; if [ -d "$dir" ]; then rm -rf "$dir"; fi; git init --bare "$dir"`,
+		gitRepoPathOnNode))
+}
+
+func (h *harness) gitURL() string {
+	return fmt.Sprintf("ssh://docker@%s%s", h.clusterIP, gitRepoPathOnNode)
+}
+
+func (h *harness) fluxURL() string {
+	u := &url.URL{Scheme: "http", Host: h.clusterIP + ":" + fluxPort, Path: "/api/flux"}
+	return u.String()
+}
+
+func (h *harness) must(err error) {
+	h.t.Helper()
+	if err != nil {
+		h.t.Fatal(err)
+	}
+}
+
+func writeTemplate(destdir, tplpath string, values interface{}) (string, error) {
+	tpl, err := template.ParseFiles(tplpath)
+	if err != nil {
+		return "", fmt.Errorf("Unable to parse template %q: %v", tplpath, err)
+	}
+
+	base := filepath.Base(tplpath)
+	foutpath := filepath.Join(destdir, strings.TrimSuffix(base, ".tpl"))
+	fout, err := os.Create(foutpath)
+	if err != nil {
+		return "", fmt.Errorf("Unable to write template output %q: %v", foutpath, err)
+	}
+
+	err = tpl.ExecuteTemplate(fout, base, values)
+	if err != nil {
+		return "", fmt.Errorf("Unable to execute template %q: %v", tplpath, err)
+	}
+	err = fout.Close()
+	if err != nil {
+		return "", fmt.Errorf("Unable to close deployment %q: %v", foutpath, err)
+	}
+	return foutpath, nil
+}
+
+func writeHelloWorldDeployment(destdir string) (string, error) {
+	return writeTemplate(destdir, "nohelm/helloworld-deployment.yaml.tpl",
+		struct{ ImageTag string }{helloworldImageTag})
+}
+
+// func writeFluxDeployment(destdir string, giturl string) (string, error) {
+// 	return writeTemplate(destdir, "nohelm/flux-deploy-all.yaml.tpl",
+// 		struct {
+// 			FluxImage string
+// 			FluxPort  string
+// 			GitURL    string
+// 		}{fluxImage, fluxPort, giturl})
+// }
+
+func (h *harness) deployViaGit(ctx context.Context) {
+	_, err := writeHelloWorldDeployment(h.repodir)
+	if err != nil {
+		h.t.Fatal(err)
+	}
+	h.mustAddCommitPush()
+}
+
+func (h *harness) waitForSync(ctx context.Context, targetRevSource string) {
+	h.must(until(ctx, func(ictx context.Context) error {
+		h.mustFetch()
+		targetRev, err := h.revlist("-n", "1", targetRevSource)
+		if err != nil {
+			h.t.Fatalf("Unable to get latest rev for %s: %v", targetRevSource, err)
+		}
+		syncRev, _ := h.revlist("-n", "1", fluxSyncTag)
+		if syncRev != targetRev {
+			return fmt.Errorf("sync tag %q points at %q instead of target %s",
+				fluxSyncTag, syncRev, targetRev)
+		}
+		return nil
+	}))
+}
+
+func (h *harness) waitForUpstreamCommits(ctx context.Context, mincount int) {
+	h.must(until(ctx, func(ictx context.Context) error {
+		h.mustFetch()
+		strcount, _ := h.revlist("--count", "HEAD.."+fluxSyncTag)
+		if strcount == "" {
+			return fmt.Errorf("no output returned by git revlist")
+		}
+		count, err := strconv.Atoi(strings.TrimSpace(strcount))
+		if err != nil {
+			h.t.Fatalf("git rev-list --count returned a non-numeric output %q: %v", strcount, err)
+		}
+		if count < mincount {
+			return fmt.Errorf("Found %d commits instead of required minimum %d", count, mincount)
+		}
+		return nil
+	}))
+}
+
+func (h *harness) automate() {
+	// In this case, unlike services() we'll invoke fluxctl to enable automation.  From looking at the fluxctl
+	// source there's more going on than a simple API call.  And it's not like we have to parse the output.
+
+	execNoErr(context.TODO(), h.t, "fluxctl", "--url", h.fluxURL(), "automate",
+		fmt.Sprintf("--controller=%s:deployment/helloworld", appNamespace))
+}
+
+func (h *harness) applyFlux() {
+	// For now we've abandoned the original helmless approach used in flux's test/bin/test-flux;
+	// it complicates things to have to support both that and the install via helm chart, and it
+	// doesn't buy us anything.
+	h.installFluxChart(defaultPollInterval)
+
+	// h.kubectlIgnoreErrs(context.TODO(), h.t, fluxNamespace, "delete", "deploy", "flux", "memcached")
+	// out, err := writeFluxDeployment(h.repodir, h.gitURL())
+	// if err != nil {
+	// 	h.t.Fatal(err)
+	// }
+	// h.kubectlOrDie(context.TODO(), h.t, fluxNamespace, "apply", "-f", out)
+}
+
+func (h *harness) verifySyncAndSvcs(t *testing.T, targetRevSource, expectedHelloworldTag string, expectedSidecarTag string) {
+	expected := map[string]image.Ref{
+		"helloworld": image.Ref{helloworldImageName, expectedHelloworldTag},
+		"sidecar":    image.Ref{sidecarImageName, expectedSidecarTag},
+	}
+
+	var (
+		diff string
+		got  map[string]image.Ref
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
+	h.waitForSync(ctx, targetRevSource)
+	for got == nil || diff != "" {
+		got = fluxServices(ctx, h.fluxURL(), t, appNamespace, appNamespace+":deployment/helloworld")
+		diff = cmp.Diff(got, expected)
+	}
+	cancel()
+
+	if diff != "" {
+		t.Errorf("Expected %+v, got %+v, diff: %s", expected, got, diff)
+	}
+}
+
+// TestSync makes sure that the sync tag has been updated to reflect our repo's HEAD,
+// then compares what flux reports for our helloworld deployment versus what we expect.
+func TestSync(t *testing.T) {
+	h := newharness(t)
+	h.applyFlux()
+	h.deployViaGit(context.TODO())
+	h.verifySyncAndSvcs(t, "HEAD", helloworldImageTag, sidecarImageTag)
+}
+
+// TestAutomation does a regular sync, then enables automation and verifies that the
+// images get updated in k8s and that commits are pushed to the git repo.  The contents
+// of the commits are not verified.
+func TestAutomation(t *testing.T) {
+	h := newharness(t)
+	h.applyFlux()
+	h.deployViaGit(context.TODO())
+	h.verifySyncAndSvcs(t, "HEAD", helloworldImageTag, sidecarImageTag)
+
+	h.automate()
+	ctx, cancel := context.WithTimeout(context.Background(), automationUpdateTimeout)
+	h.waitForUpstreamCommits(ctx, 2)
+	cancel()
+
+	h.verifySyncAndSvcs(t, "refs/remotes/origin/master", "master-07a1b6b", "master-a000002")
+}

--- a/test/git.go
+++ b/test/git.go
@@ -1,0 +1,105 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+)
+
+type (
+	gitTool struct {
+		repodir string
+	}
+
+	git struct {
+		gitSSHCommand string
+		gitOriginURL  string
+		gt            gitTool
+		lg            logger
+	}
+
+	gitAPI interface {
+		mustFetch()
+		mustAddCommitPush()
+		revlist(args ...string) (string, error)
+	}
+)
+
+func (gt gitTool) common() []string {
+	return []string{"git", "-C", gt.repodir}
+}
+
+func (gt gitTool) initCmd() []string {
+	return []string{"git", "init", gt.repodir}
+}
+
+func (gt gitTool) cloneCmd(originURL string) []string {
+	return []string{"git", "clone", originURL, gt.repodir}
+}
+
+func (gt gitTool) addCmd(files ...string) []string {
+	return append(gt.common(),
+		append([]string{"add"}, files...)...)
+}
+
+func (gt gitTool) commitCmd(msg string) []string {
+	return append(gt.common(), []string{"commit", "-m", msg}...)
+}
+
+func (gt gitTool) pushCmd() []string {
+	return append(gt.common(), []string{"push", "-u", "origin", "master"}...)
+}
+
+func (gt gitTool) revlistCmd(args ...string) []string {
+	return append(gt.common(),
+		append([]string{"rev-list"}, args...)...)
+}
+
+func (gt gitTool) fetchCmd() []string {
+	return append(gt.common(), []string{"fetch", "--tags"}...)
+}
+
+func newGitTool(repodir string) (*gitTool, error) {
+	_, err := os.Stat(repodir)
+	if err == nil || !os.IsNotExist(err) {
+		return nil, fmt.Errorf("git repodir %s must not already exist", repodir)
+	}
+	return &gitTool{repodir: repodir}, nil
+}
+
+func mustNewGit(lg logger, repodir string, sshcmd string, origin string) git {
+	gt, err := newGitTool(repodir)
+	if err != nil {
+		lg.Fatalf("%v", err)
+	}
+
+	g := git{gt: *gt, lg: lg, gitSSHCommand: sshcmd, gitOriginURL: origin}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	g.cli().must(ctx, gt.cloneCmd(origin)...)
+	cancel()
+
+	return g
+}
+
+func (g git) cli() clicmd {
+	return newCli(g.lg, []string{"GIT_SSH_COMMAND=" + g.gitSSHCommand})
+}
+
+func (g git) mustFetch() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	g.cli().must(ctx, g.gt.fetchCmd()...)
+	cancel()
+}
+
+func (g git) mustAddCommitPush() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	g.cli().must(ctx, g.gt.addCmd(".")...)
+	g.cli().must(ctx, g.gt.commitCmd("deploy")...)
+	g.cli().must(ctx, g.gt.pushCmd()...)
+	cancel()
+}
+
+func (g git) revlist(args ...string) (string, error) {
+	return g.cli().run(context.Background(), g.gt.revlistCmd(args...)...)
+}

--- a/test/helm.go
+++ b/test/helm.go
@@ -1,0 +1,213 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"time"
+)
+
+const (
+	helmVersion                 = "v2.9.1"
+	tillerContactTimeoutSeconds = 5
+	tillerContactTimeout        = tillerContactTimeoutSeconds * time.Second
+	// Helm itself doesn't usually need much time to deploy, but if the cluster just
+	// came up that may change things.
+	tillerInitTimeout = 120 * time.Second
+)
+
+type (
+	helmTool struct {
+		profile  string
+		helmhome string
+	}
+
+	helmAPI interface {
+		tillerVersion() (string, error)
+		delete(releaseName string, purge bool) error
+		mustHistory(releaseName string) []helmHistory
+		mustGetValues(releaseName string, revision int) string
+		mustUpgrade(releaseName string, chartpath string, reuseValues bool,
+			valueSettings ...string)
+		mustInstall(namespace string, releaseName string, chartpath string,
+			valueSettings ...string)
+	}
+
+	helm struct {
+		ht helmTool
+		lg logger
+	}
+
+	helmHistory struct {
+		Chart       string `json:"chart"`
+		Description string `json:"description"`
+		Revision    int    `json:"revision"`
+		Status      string `json:"status"`
+		Updated     string `json:"updated"`
+	}
+)
+
+func (ht helmTool) common() []string {
+	return []string{"helm", "--kube-context", ht.profile,
+		"--home", ht.helmhome}
+}
+
+func (ht helmTool) initCmd() []string {
+	return append(ht.common(),
+		[]string{"init", "--wait", "--skip-refresh", "--upgrade", "--service-account", "tiller"}...)
+}
+
+func (ht helmTool) commonPostInit() []string {
+	return append(ht.common(),
+		[]string{"--tiller-connection-timeout",
+			fmt.Sprintf("%d", tillerContactTimeoutSeconds)}...)
+}
+
+func (ht helmTool) versionCmd(clientOrServer string) []string {
+	return append(ht.commonPostInit(), "version", "--"+clientOrServer)
+}
+
+func (ht helmTool) deleteCmd(releaseName string, purge bool) []string {
+	delArgs := []string{"delete"}
+	if purge {
+		delArgs = append(delArgs, "--purge")
+	}
+	delArgs = append(delArgs, releaseName)
+	return append(ht.commonPostInit(), delArgs...)
+}
+
+func (ht helmTool) upgradeCmd(
+	releaseName string,
+	chartpath string,
+	reuseValues bool,
+	valueSettings ...string) []string {
+
+	upgradeArgs := []string{"upgrade", releaseName, chartpath}
+	if reuseValues {
+		upgradeArgs = append(upgradeArgs, "--reuse-values")
+	}
+	for _, v := range valueSettings {
+		upgradeArgs = append(upgradeArgs, []string{"--set", v}...)
+	}
+	return append(ht.commonPostInit(), upgradeArgs...)
+}
+
+func (ht helmTool) installCmd(
+	namespace string,
+	releaseName string,
+	chartpath string,
+	valueSettings ...string) []string {
+
+	installArgs := []string{"install", "--namespace", namespace, "--name", releaseName}
+	for _, v := range valueSettings {
+		installArgs = append(installArgs, []string{"--set", v}...)
+	}
+	return append(ht.commonPostInit(), append(installArgs, chartpath)...)
+}
+
+func (ht helmTool) historyCmd(releaseName string) []string {
+	return append(ht.commonPostInit(), []string{"history", "-ojson", releaseName}...)
+}
+
+func (ht helmTool) getValuesCmd(releaseName string, revision int) []string {
+	return append(ht.commonPostInit(), []string{"get", "values", releaseName,
+		"--revision", fmt.Sprintf("%d", revision)}...)
+}
+
+func newHelmTool(profile string, helmhome string) (*helmTool, error) {
+	return &helmTool{profile: profile, helmhome: helmhome}, nil
+}
+
+func mustNewHelm(lg logger, profile string, helmhome string, k kubectlAPI) helm {
+	ht, err := newHelmTool(profile, helmhome)
+	if err != nil {
+		lg.Fatalf("%v", err)
+	}
+
+	h := helm{ht: *ht, lg: lg}
+	out := h.cli().must(context.Background(), h.ht.versionCmd("client")...)
+	clientVersion, err := parseHelmVersionString(out)
+	if err != nil || clientVersion != helmVersion {
+		lg.Fatalf("helm client version is %v but we require %v", out, helmVersion)
+	}
+
+	tillerVersion, err := h.tillerVersion()
+	if err != nil || tillerVersion != helmVersion {
+		h.mustInit(k)
+	}
+
+	tillerVersion, err = h.tillerVersion()
+	if err != nil || tillerVersion != helmVersion {
+		lg.Fatalf("running tiller version is %s but only %s is supported",
+			tillerVersion, helmVersion)
+	}
+	return h
+}
+
+func (h helm) cli() clicmd {
+	return newCli(h.lg, nil)
+}
+
+func parseHelmVersionString(s string) (string, error) {
+	re := regexp.MustCompile(`Version{SemVer: *"([^"]+)"`)
+	version := re.FindStringSubmatch(s)
+	if len(version) != 2 {
+		return "", fmt.Errorf("Error extracting tiller version from helm version output: %s", s)
+	}
+	return version[1], nil
+}
+
+func (h helm) tillerVersion() (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), tillerContactTimeout)
+	out, err := h.cli().run(ctx, h.ht.versionCmd("server")...)
+	cancel()
+	if err != nil {
+		return "", err
+	}
+	return parseHelmVersionString(out)
+}
+
+func (h helm) mustInit(k kubectlAPI) {
+	if err := k.create("kube-system", "sa", "tiller"); err != nil {
+		h.lg.Fatalf("Unable to create tiller serviceaccount: %v", err)
+	}
+	err := k.create("kube-system", "clusterrolebinding", "tiller-cluster-rule",
+		"--clusterrole=cluster-admin", "--serviceaccount=kube-system:tiller")
+	if err != nil {
+		h.lg.Fatalf("Unable to create tiller clusterrolebinding: %v", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), tillerInitTimeout)
+	h.cli().must(ctx, h.ht.initCmd()...)
+	cancel()
+}
+
+func (h helm) delete(releaseName string, purge bool) error {
+	_, err := h.cli().run(context.Background(), h.ht.deleteCmd(releaseName, purge)...)
+	return err
+}
+
+func (h helm) mustHistory(releaseName string) []helmHistory {
+	out := h.cli().must(context.Background(), h.ht.historyCmd(releaseName)...)
+
+	var hist []helmHistory
+	if err := json.Unmarshal([]byte(out), &hist); err != nil {
+		h.lg.Fatalf("Unable to parse helm history (error=%v): %q", err, out)
+	}
+
+	return hist
+}
+
+func (h helm) mustGetValues(releaseName string, revision int) string {
+	return h.cli().must(context.Background(), h.ht.getValuesCmd(releaseName, revision)...)
+}
+
+func (h helm) mustUpgrade(releaseName string, chartpath string, reuseValues bool, valueSettings ...string) {
+	h.cli().must(context.Background(),
+		h.ht.upgradeCmd(releaseName, chartpath, reuseValues, valueSettings...)...)
+}
+
+func (h helm) mustInstall(namespace string, releaseName string, chartpath string, valueSettings ...string) {
+	h.cli().must(context.Background(),
+		h.ht.installCmd(namespace, releaseName, chartpath, valueSettings...)...)
+}

--- a/test/helm/charts/weave-flux/.helmignore
+++ b/test/helm/charts/weave-flux/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/test/helm/charts/weave-flux/Chart.yaml
+++ b/test/helm/charts/weave-flux/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: "1.3.0"
+description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control
+name: weave-flux
+version: 0.2.0
+home: https://weave.works
+sources:
+- https://github.com/weaveworks/flux
+maintainers:
+  - name: stefanprodan
+    email: stefan@weave.works
+engine: gotpl
+icon: https://landscape.cncf.io/logos/weave-flux.svg

--- a/test/helm/charts/weave-flux/README.md
+++ b/test/helm/charts/weave-flux/README.md
@@ -1,0 +1,115 @@
+# Weave Flux OSS
+
+Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control.
+It is most useful when used as a deployment tool at the end of a Continuous Delivery pipeline. Flux will make sure that your new container images and config changes are propagated to the cluster.
+
+## Introduction
+
+This chart bootstraps a [Weave Flux](https://github.com/weaveworks/flux) deployment on 
+a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.7+
+
+## Installing the Chart
+
+To install the chart with the release name `cd`:
+
+```console
+$ helm install --name cd \
+--set git.url=git@github.com:weaveworks/flux-example \
+--namespace flux \
+./charts/weave-flux
+```
+
+To install Flux with the Helm operator:
+
+```console
+$ helm install --name cd \
+--set git.url=git@github.com:stefanprodan/weave-flux-helm-demo \
+--set git.user="Stefan Prodan" \
+--set git.email="stefan.prodan@gmail.com" \
+--set helmOperator.create=true \
+--namespace flux \
+./charts/weave-flux
+```
+
+Be aware that the Helm operator is alpha quality, DO NOT use it on a production cluster.
+
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Setup Git deploy 
+
+At startup Flux generates a SSH key and logs the public key. 
+Find the SSH public key with:
+
+```bash
+export FLUX_POD=$(kubectl get pods --namespace flux -l "app=weave-flux,release=cd" -o jsonpath="{.items[0].metadata.name}")
+kubectl -n flux logs $FLUX_POD | grep identity.pub | cut -d '"' -f2 | sed 's/.\{2\}$//'
+```
+
+In order to sync your cluster state with GitHub you need to copy the public key and 
+create a deploy key with write access on your GitHub repository.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `cd` deployment:
+
+```console
+$ helm delete --purge cd
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release. 
+You should also remove the deploy key from your GitHub repository.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Weave Flux chart and their default values.
+
+| Parameter                       | Description                                | Default                                                    |
+| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `image.repository` | Image repository | `quay.io/weaveworks/flux` 
+| `image.tag` | Image tag | `1.2.5` 
+| `image.pullPoliwell cy` | Image pull policy | `IfNotPresent` 
+| `resources` | CPU/memory resource requests/limits | None 
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used | `weave-flux`
+| `service.type` | Service type to be used | `ClusterIP`
+| `service.port` | Service port to be used | `3030`
+| `git.url` | URL of git repo with Kubernetes manifests | None
+| `git.branch` | Branch of git repo to use for Kubernetes manifests | `master`
+| `git.path` | Path within git repo to locate Kubernetes manifests (relative path) | None
+| `git.user` | Username to use as git committer | `Weave Flux`
+| `git.email` | Email to use as git committer | `support@weave.works`
+| `git.chartsPath` | Path within git repo to locate Helm charts (relative path) | `charts`
+| `git.pollInterval` | Period at which to poll git repo for new commits | `30s`
+| `helmOperator.create` | If `true`, install the Helm operator | `false`
+| `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator` 
+| `helmOperator.tag` | Helm operator image tag | `master-6f427cb` 
+| `helmOperator.pullPolicy` | Helm operator image pull policy | `IfNotPresent` 
+| `token` | Weave Cloud service token | None 
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```console
+$ helm upgrade --install --wait cd \
+--set git.url=git@github.com:stefanprodan/podinfo \
+--set git.path=deploy/auto-scaling \
+--namespace flux \
+./charts/weave-flux
+```
+
+## Upgrade
+
+Update Weave Flux version with:
+
+```console
+helm upgrade --reuse-values cd \
+--set image.tag=1.2.6 \
+./charts/weave-flux
+```
+
+
+

--- a/test/helm/charts/weave-flux/templates/NOTES.txt
+++ b/test/helm/charts/weave-flux/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "weave-flux.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "weave-flux.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "weave-flux.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "weave-flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:3030
+{{- end }}
+
+2. Get the Git deploy key by running these commands:
+  export FLUX_POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "weave-flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl -n {{ .Release.Namespace }} logs $FLUX_POD | grep identity.pub | cut -d '"' -f2 | sed 's/.\{2\}$//'
+

--- a/test/helm/charts/weave-flux/templates/_helpers.tpl
+++ b/test/helm/charts/weave-flux/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "weave-flux.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "weave-flux.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "weave-flux.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "weave-flux.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "weave-flux.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/test/helm/charts/weave-flux/templates/deployment.yaml
+++ b/test/helm/charts/weave-flux/templates/deployment.yaml
@@ -1,0 +1,78 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "weave-flux.fullname" . }}
+  labels:
+    app: {{ template "weave-flux.name" . }}
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "weave-flux.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "weave-flux.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "weave-flux.serviceAccountName" . }}
+      {{- end }}
+      volumes:
+      - name: git-key
+        secret:
+          secretName: flux-git-deploy
+          defaultMode: 0400
+      - name: ssh-known-hosts
+        configMap:
+          name: ssh-known-hosts
+          items:
+          - key: known_hosts
+            path: known_hosts
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - name: http
+            containerPort: 3030
+            protocol: TCP
+          volumeMounts:
+          - name: git-key
+            mountPath: /etc/fluxd/ssh
+            readOnly: true
+          - name: ssh-known-hosts
+            mountPath: /root/.ssh/known_hosts
+            subPath: known_hosts
+          args:
+          - --k8s-secret-name=flux-git-deploy
+          - --memcached-hostname={{ template "weave-flux.fullname" . }}-memcached
+          - --git-url={{ .Values.git.url }}
+          - --git-branch={{ .Values.git.branch }}
+          - --git-path={{ .Values.git.path }}
+          - --git-user={{ .Values.git.user }}
+          - --git-email={{ .Values.git.email }}
+          - --git-poll-interval={{ .Values.git.pollInterval }}
+          - --sync-interval={{ .Values.git.pollInterval }}
+          {{- if .Values.token }}
+          - --connect=wss://cloud.weave.works/api/flux
+          - --token={{ .Values.token }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/test/helm/charts/weave-flux/templates/helm-operator-crd.yaml
+++ b/test/helm/charts/weave-flux/templates/helm-operator-crd.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.helmOperator.create -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fluxhelmreleases.helm.integrations.flux.weave.works
+  labels:
+    app: {{ template "weave-flux.name" . }}
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: helm.integrations.flux.weave.works
+  names:
+    kind: FluxHelmRelease
+    listKind: FluxHelmReleaseList
+    plural: fluxhelmreleases
+  scope: Namespaced
+  version: v1alpha2
+{{- end -}}

--- a/test/helm/charts/weave-flux/templates/helm-operator-deployment.yaml
+++ b/test/helm/charts/weave-flux/templates/helm-operator-deployment.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.helmOperator.create -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "weave-flux.fullname" . }}-helm-operator
+  labels:
+    app: {{ template "weave-flux.name" . }}-helm-operator
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "weave-flux.name" . }}-helm-operator
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "weave-flux.name" . }}-helm-operator
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "weave-flux.serviceAccountName" . }}
+      {{- end }}
+      volumes:
+      - name: git-key
+        secret:
+          secretName: flux-git-deploy
+          defaultMode: 0400
+      - name: ssh-known-hosts
+        configMap:
+          name: ssh-known-hosts
+          items:
+          - key: known_hosts
+            path: known_hosts
+      containers:
+      - name: flux-helm-operator
+        image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
+        imagePullPolicy: {{ .Values.helmOperator.pullPolicy }}
+        volumeMounts:
+        - name: git-key
+          mountPath: /etc/fluxd/ssh
+          readOnly: true
+        - name: ssh-known-hosts
+          mountPath: /root/.ssh/known_hosts
+          subPath: known_hosts
+        args:
+        - --git-url={{ .Values.git.url }}
+        - --git-branch={{ .Values.git.branch }}
+        - --git-charts-path={{ .Values.git.chartsPath }}
+{{- end -}}

--- a/test/helm/charts/weave-flux/templates/memcached.yaml
+++ b/test/helm/charts/weave-flux/templates/memcached.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "weave-flux.fullname" . }}-memcached
+  labels:
+    app: {{ template "weave-flux.name" . }}-memcached
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ template "weave-flux.name" . }}-memcached
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "weave-flux.name" . }}-memcached
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: memcached
+        image: memcached:1.4.25
+        imagePullPolicy: IfNotPresent
+        args:
+        - -m 64    # Maximum memory to use, in megabytes. 64MB is default.
+        - -p 11211    # Default port, but being explicit is nice.
+        - -vv    # This gets us to the level of request logs.
+        ports:
+        - name: memcached
+          containerPort: 11211
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "weave-flux.fullname" . }}-memcached
+  labels:
+    app: {{ template "weave-flux.name" . }}-memcached
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 11211
+      targetPort: memcached
+      protocol: TCP
+      name: memcached
+  selector:
+    app: {{ template "weave-flux.name" . }}-memcached
+    release: {{ .Release.Name }}

--- a/test/helm/charts/weave-flux/templates/rbac.yaml
+++ b/test/helm/charts/weave-flux/templates/rbac.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "weave-flux.fullname" . }}
+  labels:
+    app: {{ template "weave-flux.name" . }}
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "weave-flux.fullname" . }}
+  labels:
+    app: {{ template "weave-flux.name" . }}
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "weave-flux.fullname" . }}
+subjects:
+  - name: {{ template "weave-flux.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/test/helm/charts/weave-flux/templates/secret.yaml
+++ b/test/helm/charts/weave-flux/templates/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "weave-flux.fullname" . }}-git-deploy
+type: Opaque

--- a/test/helm/charts/weave-flux/templates/service.yaml
+++ b/test/helm/charts/weave-flux/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "weave-flux.fullname" . }}
+  labels:
+    app: {{ template "weave-flux.name" . }}
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      nodePort: {{ .Values.service.nodePort }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "weave-flux.name" . }}
+    release: {{ .Release.Name }}

--- a/test/helm/charts/weave-flux/templates/serviceaccount.yaml
+++ b/test/helm/charts/weave-flux/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "weave-flux.serviceAccountName" . }}
+  labels:
+    app: {{ template "weave-flux.name" . }}
+    chart: {{ template "weave-flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/test/helm/charts/weave-flux/values.yaml
+++ b/test/helm/charts/weave-flux/values.yaml
@@ -1,0 +1,65 @@
+# Default values for weave-flux.
+
+# Weave Cloud service token
+token: ""
+
+replicaCount: 1
+
+image:
+  repository: quay.io/weaveworks/flux
+  tag: 1.3.0
+  pullPolicy: IfNotPresent
+
+service:
+  type: NodePort
+  port: 3030
+  nodePort: 30080
+
+helmOperator:
+  create: false
+  repository: quay.io/weaveworks/helm-operator
+  tag: 0.1.0-alpha
+  pullPolicy: IfNotPresent
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+resources: {}
+  # If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+git:
+  # URL of git repo with Kubernetes manifests; e.g. git@github.com:weaveworks/flux-example
+  url: ""
+  # Branch of git repo to use for Kubernetes manifests
+  branch: "master"
+  # Path within git repo to locate Kubernetes manifests (relative path)
+  path: ""
+  # Username to use as git committer
+  user: "Weave Flux"
+  # Email to use as git committer
+  email: "support@weave.works"
+  # Path within git repo to locate Helm charts (relative path)
+  chartsPath: "charts"
+  # Period at which to poll git repo for new commits
+  pollInterval: "5s"

--- a/test/helm/repo/charts/helloworld/.helmignore
+++ b/test/helm/repo/charts/helloworld/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/test/helm/repo/charts/helloworld/Chart.yaml
+++ b/test/helm/repo/charts/helloworld/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: helloworld
+version: 0.1.0

--- a/test/helm/repo/charts/helloworld/templates/_helpers.tpl
+++ b/test/helm/repo/charts/helloworld/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "helloworld.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "helloworld.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "helloworld.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/test/helm/repo/charts/helloworld/templates/deployment.yaml
+++ b/test/helm/repo/charts/helloworld/templates/deployment.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "helloworld.fullname" . }}
+  labels:
+    app: {{ template "helloworld.name" . }}
+    chart: {{ template "helloworld.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "helloworld.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "helloworld.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: helloworld
+          image: "quay.io/weaveworks/helloworld:{{ .Values.image.helloworldtag }}"
+          args:
+            - "-msg={{ .Values.hellomessage }}"
+          ports:
+            - containerPort: 80
+        - name: sidecar
+          image: "quay.io/weaveworks/sidecar:{{ .Values.image.sidecartag }}"
+          args:
+            - -addr=:8080
+          ports:
+            - containerPort: 8080

--- a/test/helm/repo/charts/helloworld/templates/service.yaml
+++ b/test/helm/repo/charts/helloworld/templates/service.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "helloworld.fullname" . }}
+  labels:
+    app: {{ template "helloworld.name" . }}
+    chart: {{ template "helloworld.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: NodePort
+  ports:
+    - port: {{ .Values.service.helloworld.port }}
+      nodePort: {{ .Values.service.helloworld.port }}
+      targetPort: 80
+      protocol: TCP
+      name: hello
+    - port: {{ .Values.service.sidecar.port }}
+      nodePort: {{ .Values.service.sidecar.port }}
+      targetPort: 8080
+      protocol: TCP
+      name: side
+  selector:
+    app: {{ template "helloworld.name" . }}
+    release: {{ .Release.Name }}

--- a/test/helm/repo/charts/helloworld/values.yaml
+++ b/test/helm/repo/charts/helloworld/values.yaml
@@ -1,0 +1,18 @@
+# Default values for helloworld.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 2
+
+image:
+  helloworldtag: "master-a000001"
+  sidecartag: "master-a000001"
+  
+service:
+  helloworld:
+    port: 30030
+  sidecar:
+    port: 30031
+
+hellomessage: Ahoy
+

--- a/test/helm/repo/namespaces/test1.yaml
+++ b/test/helm/repo/namespaces/test1.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: test1

--- a/test/helm/repo/releases/helloworld.yaml
+++ b/test/helm/repo/releases/helloworld.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: helloworld
+  namespace: test1
+  labels:
+    chart: helloworld
+spec:
+  chartGitPath: helloworld
+  releaseName: test1
+  values:
+    image:
+      helloworldtag: "master-a000001"
+      sidecartag: "master-a000001"
+    replicaCount: 1

--- a/test/helm_test.go
+++ b/test/helm_test.go
@@ -130,7 +130,7 @@ func TestChartUpdateViaGit(t *testing.T) {
 
 	// obviously this should work if the above works, it's just to
 	// contrast with the Dial invocation below
-	_, err := net.Dial("tcp", fmt.Sprintf("%s:%d", h.clusterIP, defaultSidecarPort))
+	_, err := net.DialTimeout("tcp", fmt.Sprintf("%s:%d", h.clusterIP, defaultSidecarPort), 5*time.Second)
 	h.must(err)
 
 	newMessage := "salut"
@@ -144,7 +144,7 @@ func TestChartUpdateViaGit(t *testing.T) {
 	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, newMessage+"\n"))
 	h.must(httpGetReturns(h.clusterIP, newSidecarPort, "I am a sidecar\n"))
 
-	_, err = net.Dial("tcp", fmt.Sprintf("%s:%d", h.clusterIP, defaultSidecarPort))
+	_, err = net.DialTimeout("tcp", fmt.Sprintf("%s:%d", h.clusterIP, defaultSidecarPort), 5*time.Second)
 	if err == nil {
 		t.Errorf("old sidecar port %d still open", defaultSidecarPort)
 	}

--- a/test/helm_test.go
+++ b/test/helm_test.go
@@ -1,0 +1,177 @@
+// +build integration_test
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+const (
+	defaultHelloworldPort = 30030
+	defaultSidecarPort    = 30031
+	releaseName1          = "test1"
+	defaultPollInterval   = 5 * time.Second
+	yq                    = "bin/yq"
+)
+
+func (h *harness) installFluxChart(pollinterval time.Duration) {
+	h.helmAPI.delete(helmFluxRelease, true)
+	// Hack until #1009 is fixed.
+	h.helmAPI.delete(releaseName1, true)
+	h.helmAPI.mustInstall(fluxNamespace, helmFluxRelease, "helm/charts/weave-flux",
+		"helmOperator.create=true",
+		"git.url="+h.gitURL(),
+		"git.chartsPath=charts",
+		"image.tag=latest",
+		"helmOperator.tag=latest",
+		"git.pollInterval="+pollinterval.String())
+}
+
+func (h *harness) gitAddCommitPushSync() {
+	ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
+	h.mustAddCommitPush()
+	h.waitForSync(ctx, "HEAD")
+	cancel()
+}
+
+func (h *harness) pushNewHelmFluxRepo(ctx context.Context) {
+	execNoErr(ctx, h.t, "cp", "-rT", "helm/repo", h.repodir)
+	h.gitAddCommitPushSync()
+}
+
+func (h *harness) initHelmTest(pollinterval time.Duration) {
+	h.installFluxChart(pollinterval)
+	h.pushNewHelmFluxRepo(context.Background())
+}
+
+func (h *harness) lastHelmRelease(releaseName string) helmHistory {
+	// There may be one or two history entries, depending on timing.  It
+	// seems there's an unnecessary upgrade happening, but only once.
+	hist := h.helmAPI.mustHistory(releaseName)
+	if len(hist) == 0 {
+		h.t.Errorf("error getting last helm history entry, none found")
+		return helmHistory{}
+	}
+	return hist[len(hist)-1]
+}
+
+func (h *harness) helmReleaseDeployed(hist helmHistory, releaseName string, minRevision int) error {
+	if hist.Revision < minRevision {
+		return fmt.Errorf("helm release revision of %q is %d, smaller than our min of %d", releaseName, hist.Revision, minRevision)
+	}
+	if hist.Status != "DEPLOYED" {
+		return fmt.Errorf("helm release status of %q is %q rather than DEPLOYED", releaseName, hist.Status)
+	}
+	return nil
+}
+
+func (h *harness) helmReleaseHasValue(releaseName string, minRevision int, key, val string) error {
+	hist := h.lastHelmRelease(releaseName)
+	if err := h.helmReleaseDeployed(hist, releaseName, minRevision); err != nil {
+		return err
+	}
+
+	valstr := h.helmAPI.mustGetValues(releaseName, hist.Revision)
+	yqout := strings.TrimSpace(strOrDie(
+		envExecStdin(context.Background(), h.t, nil, strings.NewReader(valstr), yq, "r", "-", key)))
+	if val != yqout {
+		return fmt.Errorf("expected value for %q is %q, got %q", key, val, yqout)
+	}
+	return nil
+}
+
+func (h *harness) assertHelmReleaseDeployed(releaseName string, minRevision int) int {
+	var hist helmHistory
+	ctx, cancel := context.WithTimeout(context.Background(), releaseTimeout)
+	defer cancel()
+	h.must(until(ctx, func(ictx context.Context) error {
+		hist = h.lastHelmRelease(releaseName)
+		return h.helmReleaseDeployed(hist, releaseName, minRevision)
+	}))
+	return hist.Revision
+}
+
+func (h *harness) assertHelmReleaseHasValue(timeout time.Duration, releaseName string, minRevision int, key, val string) {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	h.must(until(ctx, func(ictx context.Context) error {
+		return h.helmReleaseHasValue(releaseName, minRevision, key, val)
+	}))
+}
+
+func (h *harness) updateGitYaml(relpath string, yamlpath string, value string) {
+	execNoErr(context.Background(), h.t, yq, "w", "-i",
+		filepath.Join(h.repodir, relpath), yamlpath, value)
+}
+
+func TestChart(t *testing.T) {
+	h := newharness(t)
+	h.initHelmTest(defaultPollInterval)
+
+	h.assertHelmReleaseDeployed(releaseName1, 1)
+
+	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, "Ahoy\n"))
+	h.must(httpGetReturns(h.clusterIP, defaultSidecarPort, "I am a sidecar\n"))
+}
+
+func TestChartUpdateViaGit(t *testing.T) {
+	h := newharness(t)
+	h.initHelmTest(defaultPollInterval)
+
+	initialRevision := h.assertHelmReleaseDeployed(releaseName1, 1)
+	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, "Ahoy\n"))
+	h.must(httpGetReturns(h.clusterIP, defaultSidecarPort, "I am a sidecar\n"))
+
+	// obviously this should work if the above works, it's just to
+	// contrast with the Dial invocation below
+	_, err := net.Dial("tcp", fmt.Sprintf("%s:%d", h.clusterIP, defaultSidecarPort))
+	h.must(err)
+
+	newMessage := "salut"
+	newSidecarPort := defaultSidecarPort + 2
+	h.updateGitYaml("releases/helloworld.yaml", "spec.values.hellomessage", newMessage)
+	h.updateGitYaml("releases/helloworld.yaml", "spec.values.service.sidecar.port",
+		fmt.Sprintf("%d", newSidecarPort))
+	h.gitAddCommitPushSync()
+
+	h.assertHelmReleaseDeployed(releaseName1, initialRevision+1)
+	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, newMessage+"\n"))
+	h.must(httpGetReturns(h.clusterIP, newSidecarPort, "I am a sidecar\n"))
+
+	_, err = net.Dial("tcp", fmt.Sprintf("%s:%d", h.clusterIP, defaultSidecarPort))
+	if err == nil {
+		t.Errorf("old sidecar port %d still open", defaultSidecarPort)
+	}
+}
+
+func TestChartUpdateViaHelm(t *testing.T) {
+	h := newharness(t)
+	pollInterval := 20 * time.Second
+	h.initHelmTest(pollInterval)
+
+	initialRevision := h.assertHelmReleaseDeployed(releaseName1, 1)
+	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, "Ahoy\n"))
+	h.must(httpGetReturns(h.clusterIP, defaultSidecarPort, "I am a sidecar\n"))
+
+	key, val := "hellomessage", "greetings"
+	h.helmAPI.mustUpgrade(releaseName1,
+		filepath.Join(h.repodir, "charts", "helloworld"),
+		true, fmt.Sprintf("%s=%s", key, val))
+
+	h.assertHelmReleaseHasValue(releaseTimeout, releaseName1, initialRevision+1, key, val)
+	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, val+"\n"))
+
+	// TODO specify minrevision more precisely
+	h.assertHelmReleaseHasValue(releaseTimeout+pollInterval, releaseName1, initialRevision+1, key, "null")
+	h.must(httpGetReturns(h.clusterIP, defaultHelloworldPort, "Ahoy\n"))
+}
+
+// TODO tests:
+// - chart with README template
+// - deploy chart directly via helm, verify not touched by flux

--- a/test/kubectl.go
+++ b/test/kubectl.go
@@ -28,7 +28,7 @@ func (kt kubectlTool) common() []string {
 }
 
 func (kt kubectlTool) versionCmd() []string {
-	return []string{"kubectl", "version"}
+	return append(kt.common(), []string{"version"}...)
 }
 
 func (kt kubectlTool) createCmd(namespace string) []string {

--- a/test/kubectl.go
+++ b/test/kubectl.go
@@ -1,0 +1,89 @@
+package test
+
+import (
+	"context"
+	"regexp"
+	"time"
+)
+
+type (
+	kubectlTool struct {
+		profile string
+	}
+
+	kubectlAPI interface {
+		kubeVersion() string
+		create(namespace string, args ...string) error
+		delete(namespace string, args ...string) error
+	}
+
+	kubectl struct {
+		kt kubectlTool
+		lg logger
+	}
+)
+
+func (kt kubectlTool) common() []string {
+	return []string{"kubectl", "--context", kt.profile}
+}
+
+func (kt kubectlTool) versionCmd() []string {
+	return []string{"kubectl", "version"}
+}
+
+func (kt kubectlTool) createCmd(namespace string) []string {
+	return append(kt.common(), []string{"--namespace", namespace, "create"}...)
+}
+
+func (kt kubectlTool) deleteCmd(namespace string) []string {
+	return append(kt.common(), []string{"--namespace", namespace, "delete"}...)
+}
+
+func newKubectlTool(profile string) (*kubectlTool, error) {
+	return &kubectlTool{profile: profile}, nil
+}
+
+func mustNewKubectl(lg logger, profile string) kubectl {
+	kt, err := newKubectlTool(profile)
+	if err != nil {
+		lg.Fatalf("%v", err)
+	}
+
+	k := kubectl{kt: *kt, lg: lg}
+	runningVersion := k.kubeVersion()
+	if runningVersion != k8sVersion {
+		lg.Fatalf("running kubernetes version is %s but only %s is supported"+
+			", see https://github.com/kubernetes/kubernetes/issues/61076",
+			runningVersion, k8sVersion)
+	}
+	return k
+}
+
+func (k kubectl) cli() clicmd {
+	return newCli(k.lg, nil)
+}
+
+func (k kubectl) kubeVersion() string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	out := k.cli().must(ctx, k.kt.versionCmd()...)
+	cancel()
+
+	re := regexp.MustCompile(`Server Version:.*?GitVersion: *"([^"]+)"`)
+	version := re.FindStringSubmatch(out)
+	if len(version) != 2 {
+		k.lg.Fatalf("Unable to extract kubernetes cluster version from kubectl version output: %s", out)
+	}
+	return version[1]
+}
+
+func (k kubectl) create(namespace string, args ...string) error {
+	_, err := k.cli().run(context.Background(),
+		append(k.kt.createCmd(namespace), args...)...)
+	return err
+}
+
+func (k kubectl) delete(namespace string, args ...string) error {
+	_, err := k.cli().run(context.Background(),
+		append(k.kt.deleteCmd(namespace), args...)...)
+	return err
+}

--- a/test/minikube.go
+++ b/test/minikube.go
@@ -96,7 +96,7 @@ func (m minikube) version() string {
 }
 
 func (m minikube) delete() {
-	m.cli().must(context.Background(), m.mt.deleteCmd()...)
+	m.cli().run(context.Background(), m.mt.deleteCmd()...)
 }
 
 func (m minikube) start() {

--- a/test/minikube.go
+++ b/test/minikube.go
@@ -1,0 +1,125 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const (
+	minikubeProfile = "minikube"
+	minikubeVersion = "v0.27.0"
+	k8sVersion      = "v1.9.6" // need post-1.9.4 due to https://github.com/kubernetes/kubernetes/issues/61076
+)
+
+type (
+	minikubeTool struct {
+		profile string
+	}
+
+	minikubeAPI interface {
+		version() string
+		delete()
+		start()
+	}
+
+	minikube struct {
+		mt minikubeTool
+		lg logger
+	}
+
+	clusterAPI interface {
+		sshKeyPath() string
+		loadDockerImage(string)
+		sshToNode(cmd string) error
+		nodeIP() string
+	}
+)
+
+func (mt minikubeTool) common() []string {
+	return []string{"minikube", "--profile", mt.profile}
+}
+
+func (mt minikubeTool) versionCmd() []string {
+	return append(mt.common(), "version")
+}
+
+func (mt minikubeTool) deleteCmd() []string {
+	return append(mt.common(), "delete")
+}
+
+func (mt minikubeTool) startCmd() []string {
+	return append(mt.common(), "start")
+}
+
+func (mt minikubeTool) ipCmd() []string {
+	return append(mt.common(), "ip")
+}
+
+func (mt minikubeTool) sshCmd(cmd string) []string {
+	return append(mt.common(), []string{"ssh", "--", cmd}...)
+}
+
+func (mt minikubeTool) dockerEnvCmd() []string {
+	return append(mt.common(), "docker-env")
+}
+
+func newMinikubeTool(profile string) (*minikubeTool, error) {
+	if profile != minikubeProfile {
+		return nil, fmt.Errorf("Profiles other than %q broken, see https://github.com/kubernetes/minikube/issues/2717", minikubeProfile)
+	}
+
+	return &minikubeTool{profile: profile}, nil
+}
+
+func mustNewMinikube(lg logger, profile string) minikube {
+	mt, err := newMinikubeTool(profile)
+	if err != nil {
+		lg.Fatalf("%v", err)
+	}
+
+	m := minikube{mt: *mt, lg: lg}
+	version := strings.TrimSpace(m.version())
+	if version != fmt.Sprintf("minikube version: %s", minikubeVersion) {
+		lg.Fatalf("`minikube version` returned %q, but these tests only support version %s",
+			version, minikubeVersion)
+	}
+	return m
+}
+
+func (m minikube) cli() clicmd {
+	return newCli(m.lg, nil)
+}
+
+func (m minikube) version() string {
+	return m.cli().must(context.Background(), m.mt.versionCmd()...)
+}
+
+func (m minikube) delete() {
+	m.cli().must(context.Background(), m.mt.deleteCmd()...)
+}
+
+func (m minikube) start() {
+	m.cli().must(context.Background(), append(m.mt.startCmd(), []string{
+		"--bootstrapper", "kubeadm",
+		"--keep-context", "--kubernetes-version", k8sVersion}...)...)
+}
+
+func (m minikube) sshKeyPath() string {
+	return fmt.Sprintf("%s/.minikube/machines/%s/id_rsa", homedir(), m.mt.profile)
+}
+
+func (m minikube) loadDockerImage(imageName string) {
+	shcmd := fmt.Sprintf(`docker save %s | (eval $(%s) && docker load)`, imageName,
+		strings.Join(m.mt.dockerEnvCmd(), " "))
+	m.cli().must(context.Background(), "sh", "-c", shcmd)
+}
+
+func (m minikube) sshToNode(cmd string) error {
+	_, err := m.cli().run(context.Background(), m.mt.sshCmd(cmd)...)
+	return err
+}
+
+func (m minikube) nodeIP() string {
+	return strings.TrimSpace(m.cli().must(context.Background(), m.mt.ipCmd()...))
+}

--- a/test/nohelm/flux-deploy-all.yaml.tpl
+++ b/test/nohelm/flux-deploy-all.yaml.tpl
@@ -1,0 +1,97 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: memcached
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: memcached
+    spec:
+      containers:
+      - name: memcached
+        image: memcached:1.4.25
+        imagePullPolicy: IfNotPresent
+        args:
+        - -m 64    # Maximum memory to use, in megabytes. 64MB is default.
+        - -p 11211    # Default port, but being explicit is nice.
+        - -vv    # This gets us to the level of request logs.
+        ports:
+        - name: clients
+          containerPort: 11211
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: memcached
+spec:
+  # The memcache client uses DNS to get a list of memcached servers and then
+  # uses a consistent hash of the key to determine which server to pick.
+  clusterIP: None
+  ports:
+    - name: memcached
+      port: 11211
+  selector:
+    name: memcached
+---
+# Expose flux to fluxctl
+apiVersion: v1
+kind: Service
+metadata:
+  name: flux
+spec:
+  type: NodePort
+  ports:
+    - port: 80
+      targetPort: 3030
+      nodePort: {{ .FluxPort }} # Hardwired for test harness access
+  selector:
+    name: flux
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: flux
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: flux
+    spec:
+      volumes:
+      - name: git-key
+        secret:
+          secretName: flux-git-deploy
+          defaultMode: 256
+      - name: ssh-known-hosts
+        configMap:
+          name: ssh-known-hosts
+          items:
+          - key: known_hosts
+            path: known_hosts
+      containers:
+      - name: flux
+        # Require locally built image
+        image: {{ .FluxImage }}
+        imagePullPolicy: Never
+        ports:
+        - containerPort: 3030 # informational
+        volumeMounts:
+        - name: git-key
+          mountPath: /etc/fluxd/ssh
+        - name: ssh-known-hosts
+          mountPath: /root/.ssh/known_hosts
+          subPath: known_hosts
+
+        args:
+        # Access minikube hosted config repo by ssh
+        - --git-url={{ .GitURL }}
+        - --git-branch=master
+        # Tune up to make tests run quicker
+        - --registry-poll-interval=10s
+        - --git-poll-interval=10s

--- a/test/nohelm/helloworld-deployment.yaml.tpl
+++ b/test/nohelm/helloworld-deployment.yaml.tpl
@@ -1,0 +1,25 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: helloworld
+spec:
+  minReadySeconds: 5
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        name: helloworld
+    spec:
+      containers:
+      - name: helloworld
+        image: quay.io/weaveworks/helloworld:{{ .ImageTag }}
+        args:
+        - -msg=Ahoy
+        ports:
+        - containerPort: 80
+      - name: sidecar
+        image: quay.io/weaveworks/sidecar:{{ .ImageTag }}
+        args:
+        - -addr=:8080
+        ports:
+        - containerPort: 8080

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -1,0 +1,144 @@
+// +build integration_test
+
+package test
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	fluxImage         = "quay.io/weaveworks/flux:latest"
+	fluxOperatorImage = "quay.io/weaveworks/helm-operator:latest"
+	fluxNamespace     = "flux"
+	helmFluxRelease   = "cd"
+)
+
+type (
+	// setup is generally concerned with things that apply globally, and don't
+	// depend on harness state.
+	workdir struct {
+		root          string
+		sshKnownHosts string
+	}
+
+	setup struct {
+		workdir
+		profile   string
+		clusterIP string
+		clusterAPI
+		kubectlAPI
+		helmAPI
+	}
+)
+
+var (
+	global setup
+)
+
+func newsetup(profile string) *setup {
+	dir, err := ioutil.TempDir("", "fluxtest")
+	if err != nil {
+		log.Fatalf("Error creating tempdir: %v", err)
+	}
+
+	return &setup{
+		workdir: workdir{root: dir},
+		profile: profile,
+	}
+}
+
+func (s *setup) clean() error {
+	return os.RemoveAll(s.workdir.root)
+}
+
+func (w workdir) knownHostsPath() string {
+	return filepath.Join(w.root, "ssh-known-hosts")
+}
+
+func (s *setup) must(err error) {
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+}
+
+func (s *setup) ssh(namespace string) {
+	knownHostsContent := execNoErr(context.TODO(), nil, "ssh-keyscan", s.clusterIP)
+	ioutil.WriteFile(s.knownHostsPath(), []byte(knownHostsContent), 0600)
+
+	s.kubectlAPI.create("", "namespace", namespace)
+
+	secretName := "flux-git-deploy"
+	s.kubectlAPI.delete(namespace, "secret", secretName)
+	s.must(s.kubectlAPI.create(namespace, "secret", "generic", secretName, "--from-file",
+		fmt.Sprintf("identity=%s", s.sshKeyPath())))
+
+	configMapName := "ssh-known-hosts"
+	s.kubectlAPI.delete(namespace, "configmap", configMapName)
+	s.must(s.kubectlAPI.create(namespace, "configmap", configMapName, "--from-file",
+		fmt.Sprintf("known_hosts=%s", s.knownHostsPath())))
+}
+
+func setupPath() {
+	cwd, err := os.Getwd()
+	if err != nil {
+		log.Fatalf("cannot get working directory: %v", err)
+	}
+	envpath := os.Getenv("PATH")
+	if envpath == "" {
+		envpath = filepath.Join(cwd, "bin")
+	} else {
+		envpath = filepath.Join(cwd, "bin") + ":" + envpath
+	}
+	os.Setenv("PATH", envpath)
+}
+
+func TestMain(m *testing.M) {
+	var (
+		flagKeepWorkdir = flag.Bool("keep-workdir", false,
+			"don't delete workdir on exit")
+		flagStartMinikube = flag.Bool("start-minikube", false,
+			"start minikube (or delete and start if it already exists)")
+		flagMinikubeProfile = flag.String("minikube-profile", "minikube",
+			"minikube profile to use, don't change until we have a fix for https://github.com/kubernetes/minikube/issues/2717")
+	)
+	flag.Parse()
+	log.Printf("Testing with keep-workdir=%v, start-minikube=%v, minikube-profile=%v",
+		*flagKeepWorkdir, *flagStartMinikube, *flagMinikubeProfile)
+
+	setupPath()
+
+	global = *newsetup(*flagMinikubeProfile)
+	if !*flagKeepWorkdir {
+		defer global.clean()
+	}
+
+	minikube := mustNewMinikube(stdLogger{}, *flagMinikubeProfile)
+	if *flagStartMinikube {
+		minikube.delete()
+		minikube.start()
+	}
+
+	global.clusterAPI = minikube
+	global.clusterIP = minikube.nodeIP()
+	global.kubectlAPI = mustNewKubectl(stdLogger{}, *flagMinikubeProfile)
+	global.helmAPI = mustNewHelm(stdLogger{}, *flagMinikubeProfile,
+		global.workdir.root, global.kubectlAPI)
+
+	global.loadDockerImage(fluxImage)
+	global.loadDockerImage(fluxOperatorImage)
+
+	global.ssh(fluxNamespace)
+
+	// Make sure that if helm flux is sitting around due to a previous failed
+	// test, it won't interfere with upcoming tests.
+	global.helmAPI.delete(helmFluxRelease, true)
+
+	os.Exit(m.Run())
+}

--- a/test/setup_test.go
+++ b/test/setup_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 const (
@@ -123,6 +124,9 @@ func TestMain(m *testing.M) {
 	if *flagStartMinikube {
 		minikube.delete()
 		minikube.start()
+		// This sleep is a hack until we find a better way to determine
+		// when the cluster is stable.
+		time.Sleep(60 * time.Second)
 	}
 
 	global.clusterAPI = minikube

--- a/test/tools.go
+++ b/test/tools.go
@@ -1,0 +1,98 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os/exec"
+)
+
+type (
+	logger interface {
+		Logf(string, ...interface{})
+		Errorf(string, ...interface{})
+		Fatalf(string, ...interface{})
+		Name() string
+		Helper()
+	}
+
+	clicmd interface {
+		// run executes the tool and returns the result
+		run(ctx context.Context, args ...string) (string, error)
+		// input executes the tool feeding it input on stdin
+		input(ctx context.Context, in string, args ...string) (string, error)
+		// output executes the tool and returns the result, empty on failure
+		output(ctx context.Context, args ...string) string
+		// must executes the tool and returns the result, dying on failure
+		must(ctx context.Context, args ...string) string
+	}
+
+	cmdrunner struct {
+		env []string
+		lg  logger
+	}
+
+	stdLogger struct{}
+)
+
+func (l stdLogger) Name() string {
+	return ""
+}
+
+func (l stdLogger) Fatalf(s string, args ...interface{}) {
+	log.Fatalf(s, args...)
+}
+
+func (l stdLogger) Errorf(s string, args ...interface{}) {
+	log.Printf("Error: "+s, args...)
+}
+
+func (l stdLogger) Logf(s string, args ...interface{}) {
+	log.Printf(s, args...)
+}
+
+func (l stdLogger) Helper() {}
+
+func newCli(lg logger, env []string) clicmd {
+	return cmdrunner{lg: lg, env: env}
+}
+
+func stdCli() clicmd {
+	return newCli(stdLogger{}, nil)
+}
+
+func (cr cmdrunner) run(ctx context.Context, args ...string) (string, error) {
+	return cr.input(ctx, "", args...)
+}
+
+func (cr cmdrunner) input(ctx context.Context, in string, args ...string) (string, error) {
+	cr.lg.Helper()
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+	cmd.Env = cr.env
+	if cmd.Env != nil {
+		cr.lg.Logf("running %v with env=%v", cmd.Args, cmd.Env)
+	} else {
+		cr.lg.Logf("running %v", cmd.Args)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("error running %v: %v\nOutput:\n%s", cmd.Args, err, out)
+	}
+	return string(out), err
+}
+
+func (cr cmdrunner) output(ctx context.Context, args ...string) string {
+	out, err := cr.run(ctx, args...)
+	if err != nil {
+		return ""
+	}
+	return out
+}
+
+func (cr cmdrunner) must(ctx context.Context, args ...string) string {
+	out, err := cr.run(ctx, args...)
+	if err != nil {
+		cr.lg.Fatalf("%v", err)
+	}
+	return out
+}

--- a/test/user.go
+++ b/test/user.go
@@ -1,0 +1,30 @@
+// +build go1.9
+
+// require go1.9 for os/user without cgo
+
+package test
+
+import (
+	"log"
+	"os/user"
+)
+
+func getuser() user.User {
+	u, err := user.Current()
+	if err != nil {
+		log.Fatalf("can't get current user: %v", err)
+	}
+	return *u
+}
+
+func username() string {
+	return getuser().Username
+}
+
+func homedir() string {
+	u := getuser()
+	if u.HomeDir == "" {
+		log.Fatal("user homedir is empty")
+	}
+	return u.HomeDir
+}

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -1,0 +1,133 @@
+// +build integration_test
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/weaveworks/flux/api/v6"
+	transport "github.com/weaveworks/flux/http"
+	"github.com/weaveworks/flux/http/client"
+	"github.com/weaveworks/flux/image"
+)
+
+func strOrDie(s string, err error) string {
+	if err != nil {
+		log.Fatal(err)
+	}
+	return s
+}
+
+func ignoreErr(s string, err error) string {
+	if err != nil {
+		return ""
+	}
+	return s
+}
+
+func envExec(ctx context.Context, t *testing.T, env []string, command string, args ...string) (string, error) {
+	return envExecStdin(ctx, t, env, strings.NewReader(""), command, args...)
+}
+
+func envExecStdin(ctx context.Context, t *testing.T, env []string, stdin io.Reader, command string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Env = env
+	cmd.Stdin = stdin
+	if t != nil {
+		t.Logf("running %v", cmd.Args)
+	} else {
+		log.Printf("running %v", cmd.Args)
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		err = fmt.Errorf("error running %v: %v\nOutput:\n%s", cmd.Args, err, out)
+	}
+	return string(out), err
+}
+
+func envExecNoErr(ctx context.Context, t *testing.T, env []string, command string, args ...string) string {
+	out, err := envExec(ctx, t, env, command, args...)
+	return strOrDie(string(out), err)
+}
+
+func execNoErr(ctx context.Context, t *testing.T, command string, args ...string) string {
+	return envExecNoErr(ctx, t, nil, command, args...)
+}
+
+func until(ctx context.Context, f func(context.Context) error) error {
+	var err error
+	ticker := time.NewTicker(time.Second)
+	for {
+		select {
+		case <-ticker.C:
+			err = f(ctx)
+			if err == nil {
+				return nil
+			}
+		case <-ctx.Done():
+			return fmt.Errorf("timed out, last error: %v", err)
+		}
+	}
+}
+
+func fluxServicesAPICall(ctx context.Context, fluxURL string, namespace string) ([]v6.ControllerStatus, error) {
+	api := client.New(http.DefaultClient, transport.NewAPIRouter(), fluxURL, "")
+	var controllers []v6.ControllerStatus
+	return controllers, until(ctx, func(ictx context.Context) error {
+		var err error
+		controllers, err = api.ListServices(ictx, namespace)
+		return err
+	})
+}
+
+// fluxServices asks flux for the services it's managing, return a map from container name to id.
+func fluxServices(ctx context.Context, fluxURL string, t *testing.T, namespace string, id string) map[string]image.Ref {
+	controllers, err := fluxServicesAPICall(ctx, fluxURL, namespace)
+	if err != nil {
+		t.Errorf("failed to fetch controllers from flux agent: %v", err)
+	}
+
+	result := make(map[string]image.Ref)
+	for _, controller := range controllers {
+		if controller.ID.String() == id {
+			for _, c := range controller.Containers {
+				result[c.Name] = c.Current.ID
+			}
+		}
+	}
+
+	return result
+}
+
+func httpGet(ctx context.Context, url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	return string(body), err
+}
+
+func httpGetReturns(host string, port int, expected string) error {
+	url := fmt.Sprintf("http://%s:%d", host, port)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	return until(ctx, func(ictx context.Context) error {
+		got, err := httpGet(ictx, url)
+		if err != nil || got != expected {
+			return fmt.Errorf("service check on %d failed, got %q, error: %v", port, got, err)
+		}
+		return nil
+	})
+}

--- a/test/util_test.go
+++ b/test/util_test.go
@@ -109,7 +109,11 @@ func fluxServices(ctx context.Context, fluxURL string, t *testing.T, namespace s
 }
 
 func httpGet(ctx context.Context, url string) (string, error) {
-	resp, err := http.Get(url)
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+	resp, err := http.DefaultClient.Do(req.WithContext(ctx))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
See the README for more details.  This fixes #919, and adds tests for flux+helm.  Besides the tests copied from test-flux (test that the sync tag gets updated, test that automation works) it adds tests to ensure that charts in the git repo get deployed, that changes made to charts in the git repo result in a helm release upgrade, and that helm changes made outside of git get reverted.