### PR TITLE
Purge release on FHR delete

### DIFF
--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -246,7 +246,7 @@ func (r *Release) Install(checkout *helmgit.Checkout, releaseName string, fhr if
 	}
 }
 
-// Delete deletes Chart release
+// Delete purges a Chart release
 func (r *Release) Delete(name string) error {
 	ok, err := r.canDelete(name)
 	if !ok {
@@ -257,7 +257,7 @@ func (r *Release) Delete(name string) error {
 	}
 
 	r.Lock()
-	_, err = r.HelmClient.DeleteRelease(name)
+	_, err = r.HelmClient.DeleteRelease(name, k8shelm.DeletePurge(true))
 	r.Unlock()
 	if err != nil {
 		r.logger.Log("error", fmt.Sprintf("Release deletion error: %#v", err))


### PR DESCRIPTION
Currently, when a FluxHelmResource gets deleted, the corresponding Chart release is only marked as deleted in Tiller. This prevents our users to redeploy the same release at a later time. This PR adds the purge option to the delete operation.