### PR TITLE
Add Helm chart for Flux and Helm Operator

### DIFF
--- a/chart/flux/.helmignore
+++ b/chart/flux/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+appVersion: "1.3.1"
+description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control
+name: flux
+version: 0.1.0
+home: https://weave.works
+sources:
+- https://github.com/weaveworks/flux
+maintainers:
+  - name: stefanprodan
+    email: stefan@weave.works
+engine: gotpl
+icon: https://landscape.cncf.io/logos/flux.svg

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -85,12 +85,12 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
 | `image.repository` | Image repository | `quay.io/weaveworks/flux` 
 | `image.tag` | Image tag | `1.3.1` 
-| `image.pullPoliwell cy` | Image pull policy | `IfNotPresent` 
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` 
 | `resources` | CPU/memory resource requests/limits | None 
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used | `flux`
-| `service.type` | Service type to be used | `ClusterIP`
+| `service.type` | Service type to be used (exposing Flux API outside of th cluster is not advise) | `ClusterIP`
 | `service.port` | Service port to be used | `3030`
 | `git.url` | URL of git repo with Kubernetes manifests | None
 | `git.branch` | Branch of git repo to use for Kubernetes manifests | `master`

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -90,7 +90,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used | `flux`
-| `service.type` | Service type to be used (exposing Flux API outside of th cluster is not advise) | `ClusterIP`
+| `service.type` | Service type to be used (exposing the Flux API outside of the cluster is not advised) | `ClusterIP`
 | `service.port` | Service port to be used | `3030`
 | `git.url` | URL of git repo with Kubernetes manifests | None
 | `git.branch` | Branch of git repo to use for Kubernetes manifests | `master`

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -1,0 +1,129 @@
+# Flux
+
+Flux is a tool that automatically ensures that the state of a cluster matches the config in git. 
+It uses an operator in the cluster to trigger deployments inside Kubernetes, which means you don't need a separate CD tool. 
+It monitors all relevant image repositories, detects new images, triggers deployments and updates the desired running
+configuration based on that (and a configurable policy).
+
+## Introduction
+
+This chart bootstraps a [Flux](https://github.com/weaveworks/flux) deployment on 
+a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.9+
+
+## Installing the Chart
+
+Add the weaveworks repo:
+
+```
+helm repo add weaveworks https://weaveworks.github.io/flux
+```
+
+To install the chart with the release name `flux`:
+
+```console
+$ helm install --name flux \
+--set git.url=git@github.com:weaveworks/flux-example \
+--namespace flux \
+weaveworks/flux
+```
+
+To connect Flux to a Weave Cloud instance:
+
+```console
+helm install --name flux \
+--set token=YOUR_WEAVE_CLOUD_SERVICE_TOKEN \
+--namespace flux \
+weaveworks/flux
+```
+
+To install Flux with the Helm operator (alpha version):
+
+```console
+$ helm install --name flux \
+--set git.url=git@github.com:weaveworks/flux-helm-test \
+--set helmOperator.create=true \
+--namespace flux \
+weaveworks/flux
+```
+
+The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+### Setup Git deploy 
+
+At startup Flux generates a SSH key and logs the public key. 
+Find the SSH public key with:
+
+```bash
+kubectl -n flux logs deployment/flux | grep identity.pub
+```
+
+In order to sync your cluster state with GitHub you need to copy the public key and 
+create a deploy key with write access on your GitHub repository.
+Go to _Settings > Deploy keys_ click on _Add deploy key_, check 
+_Allow write access_, paste the Flux public key and click _Add key_.
+
+## Uninstalling the Chart
+
+To uninstall/delete the `flux` deployment:
+
+```console
+$ helm delete --purge flux
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release. 
+You should also remove the deploy key from your GitHub repository.
+
+## Configuration
+
+The following tables lists the configurable parameters of the Weave Flux chart and their default values.
+
+| Parameter                       | Description                                | Default                                                    |
+| ------------------------------- | ------------------------------------------ | ---------------------------------------------------------- |
+| `image.repository` | Image repository | `quay.io/weaveworks/flux` 
+| `image.tag` | Image tag | `1.3.1` 
+| `image.pullPoliwell cy` | Image pull policy | `IfNotPresent` 
+| `resources` | CPU/memory resource requests/limits | None 
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used | `flux`
+| `service.type` | Service type to be used | `ClusterIP`
+| `service.port` | Service port to be used | `3030`
+| `git.url` | URL of git repo with Kubernetes manifests | None
+| `git.branch` | Branch of git repo to use for Kubernetes manifests | `master`
+| `git.path` | Path within git repo to locate Kubernetes manifests (relative path) | None
+| `git.user` | Username to use as git committer | `Weave Flux`
+| `git.email` | Email to use as git committer | `support@weave.works`
+| `git.chartsPath` | Path within git repo to locate Helm charts (relative path) | `charts`
+| `git.pollInterval` | Period at which to poll git repo for new commits | `30s`
+| `helmOperator.create` | If `true`, install the Helm operator | `false`
+| `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator` 
+| `helmOperator.tag` | Helm operator image tag | `0.1.0-alpha` 
+| `helmOperator.pullPolicy` | Helm operator image pull policy | `IfNotPresent` 
+| `token` | Weave Cloud service token | None 
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
+
+```console
+$ helm upgrade --install --wait flux \
+--set git.url=git@github.com:stefanprodan/podinfo \
+--set git.path=deploy/auto-scaling \
+--namespace flux \
+weaveworks/flux
+```
+
+## Upgrade
+
+Update Weave Flux version with:
+
+```console
+helm upgrade --reuse-values flux \
+--set image.tag=1.3.2 \
+weaveworks/flux
+```
+
+
+

--- a/chart/flux/templates/NOTES.txt
+++ b/chart/flux/templates/NOTES.txt
@@ -1,0 +1,19 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "flux.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get svc -w {{ template "flux.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "flux.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:3030
+{{- end }}
+
+2. Get the Git deploy key by running these commands:
+  export FLUX_POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  kubectl -n {{ .Release.Namespace }} logs $FLUX_POD | grep identity.pub
+

--- a/chart/flux/templates/_helpers.tpl
+++ b/chart/flux/templates/_helpers.tpl
@@ -1,0 +1,43 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "flux.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "flux.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "flux.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "flux.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "flux.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "flux.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "flux.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "flux.serviceAccountName" . }}
+      {{- end }}
+      volumes:
+      - name: git-key
+        secret:
+          secretName: {{ template "flux.fullname" . }}-git-deploy
+          defaultMode: 0400
+      - name: git-keygen
+        emptyDir:
+          medium: Memory
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+          - name: http
+            containerPort: 3030
+            protocol: TCP
+          volumeMounts:
+          - name: git-key
+            mountPath: /etc/fluxd/ssh
+            readOnly: true
+          - name: git-keygen
+            mountPath: /var/fluxd/keygen
+          args:
+          - --ssh-keygen-dir=/var/fluxd/keygen
+          - --k8s-secret-name={{ template "flux.fullname" . }}-git-deploy
+          - --memcached-hostname={{ template "flux.fullname" . }}-memcached
+          - --git-url={{ .Values.git.url }}
+          - --git-branch={{ .Values.git.branch }}
+          - --git-path={{ .Values.git.path }}
+          - --git-user={{ .Values.git.user }}
+          - --git-email={{ .Values.git.email }}
+          - --git-poll-interval={{ .Values.git.pollInterval }}
+          - --sync-interval={{ .Values.git.pollInterval }}
+          {{- if .Values.token }}
+          - --connect=wss://cloud.weave.works/api/flux
+          - --token={{ .Values.token }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.helmOperator.create -}}
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fluxhelmreleases.helm.integrations.flux.weave.works
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  group: helm.integrations.flux.weave.works
+  names:
+    kind: FluxHelmRelease
+    listKind: FluxHelmReleaseList
+    plural: fluxhelmreleases
+  scope: Namespaced
+  version: v1alpha2
+{{- end -}}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.helmOperator.create -}}
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "flux.fullname" . }}-helm-operator
+  labels:
+    app: {{ template "flux.name" . }}-helm-operator
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "flux.name" . }}-helm-operator
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "flux.name" . }}-helm-operator
+        release: {{ .Release.Name }}
+    spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "flux.serviceAccountName" . }}
+      {{- end }}
+      volumes:
+      - name: git-key
+        secret:
+          secretName: {{ template "flux.fullname" . }}-git-deploy
+          defaultMode: 0400
+      containers:
+      - name: flux-helm-operator
+        image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
+        imagePullPolicy: {{ .Values.helmOperator.pullPolicy }}
+        volumeMounts:
+        - name: git-key
+          mountPath: /etc/fluxd/ssh
+          readOnly: true
+        args:
+        - --git-url={{ .Values.git.url }}
+        - --git-branch={{ .Values.git.branch }}
+        - --git-charts-path={{ .Values.git.chartsPath }}
+{{- end -}}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ template "flux.fullname" . }}-memcached
+  labels:
+    app: {{ template "flux.name" . }}-memcached
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ template "flux.name" . }}-memcached
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "flux.name" . }}-memcached
+        release: {{ .Release.Name }}
+    spec:
+      containers:
+      - name: memcached
+        image: memcached:1.4.25
+        imagePullPolicy: IfNotPresent
+        args:
+        - -m 64    # Maximum memory to use, in megabytes. 64MB is default.
+        - -p 11211    # Default port, but being explicit is nice.
+        - -vv    # This gets us to the level of request logs.
+        ports:
+        - name: memcached
+          containerPort: 11211
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "flux.fullname" . }}-memcached
+  labels:
+    app: {{ template "flux.name" . }}-memcached
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  clusterIP: None
+  ports:
+    - port: 11211
+      targetPort: memcached
+      protocol: TCP
+      name: memcached
+  selector:
+    app: {{ template "flux.name" . }}-memcached
+    release: {{ .Release.Name }}

--- a/chart/flux/templates/rbac.yaml
+++ b/chart/flux/templates/rbac.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - nonResourceURLs:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "flux.fullname" . }}
+subjects:
+  - name: {{ template "flux.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/chart/flux/templates/secret.yaml
+++ b/chart/flux/templates/secret.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "flux.fullname" . }}-git-deploy
+type: Opaque

--- a/chart/flux/templates/service.yaml
+++ b/chart/flux/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ template "flux.name" . }}
+    release: {{ .Release.Name }}

--- a/chart/flux/templates/serviceaccount.yaml
+++ b/chart/flux/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "flux.serviceAccountName" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -1,0 +1,64 @@
+# Default values for flux.
+
+# Weave Cloud service token
+token: ""
+
+replicaCount: 1
+
+image:
+  repository: quay.io/weaveworks/flux
+  tag: 1.3.1
+  pullPolicy: IfNotPresent
+
+service:
+  type: ClusterIP
+  port: 3030
+
+helmOperator:
+  create: false
+  repository: quay.io/weaveworks/helm-operator
+  tag: 0.1.0-alpha
+  pullPolicy: IfNotPresent
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+resources: {}
+  # If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+git:
+  # URL of git repo with Kubernetes manifests; e.g. git@github.com:weaveworks/flux-example
+  url: ""
+  # Branch of git repo to use for Kubernetes manifests
+  branch: "master"
+  # Path within git repo to locate Kubernetes manifests (relative path)
+  path: ""
+  # Username to use as git committer
+  user: "Weave Flux"
+  # Email to use as git committer
+  email: "support@weave.works"
+  # Path within git repo to locate Helm charts (relative path)
+  chartsPath: "charts"
+  # Period at which to poll git repo for new commits
+  pollInterval: "30s"

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -212,7 +213,7 @@ func main() {
 
 		logger := log.With(logger, "component", "cluster")
 		logger.Log("identity", privateKeyPath)
-		logger.Log("identity.pub", publicKey.Key)
+		logger.Log("identity.pub", strings.TrimSpace(publicKey.Key))
 		logger.Log("host", restClientConfig.Host, "version", clusterVersion)
 
 		kubectl := *kubernetesKubectl


### PR DESCRIPTION
This PR implements a Helm chart for Flux and optionally the Flux Helm Operator.

```bash
$ helm install --name flux \
--set git.url=git@github.com:weaveworks/flux-helm-test \
--set helmOperator.create=true \
--namespace flux \
./chart/flux
```

More options are available, check the chart readme.