### PR TITLE
Support FluxHelmRelease resources in fluxd

### DIFF
--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i squaremo/kubeyaml:latest "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.3.0 "$@"

--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.3.0 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.3.1 "$@"

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -8,6 +8,7 @@ import (
 	k8syaml "github.com/ghodss/yaml"
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
+	ifclient "github.com/weaveworks/flux/integrations/client/clientset/versioned"
 	"gopkg.in/yaml.v2"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -39,6 +40,7 @@ type extendedClient struct {
 	v1beta1extensions.ExtensionsV1beta1Interface
 	v1beta1apps.StatefulSetsGetter
 	v1beta1batch.CronJobsGetter
+	ifclient.Interface
 }
 
 // --- internal types for keeping track of syncing
@@ -131,6 +133,7 @@ type Cluster struct {
 
 // NewCluster returns a usable cluster.
 func NewCluster(clientset k8sclient.Interface,
+	ifclientset ifclient.Interface,
 	applier Applier,
 	sshKeyRing ssh.KeyRing,
 	logger log.Logger) *Cluster {
@@ -142,6 +145,7 @@ func NewCluster(clientset k8sclient.Interface,
 			clientset.Extensions(),
 			clientset.AppsV1beta1(),
 			clientset.BatchV1beta1(),
+			ifclientset,
 		},
 		applier:    applier,
 		logger:     logger,

--- a/cluster/kubernetes/resource/fluxhelmrelease.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease.go
@@ -2,89 +2,56 @@ package resource
 
 import (
 	"fmt"
-	"io"
 
-	"github.com/weaveworks/flux"
-	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha2"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/resource"
-	apiv1 "k8s.io/api/core/v1"
 )
 
+// FluxHelmRelease echoes the generated type for the custom resource
+// definition. It's here so we can 1. get `baseObject` in there, and
+// 3. control the YAML serialisation of fields, which we can't do
+// (easily?) with the generated type.
 type FluxHelmRelease struct {
 	baseObject
-	Spec ifv1.FluxHelmReleaseSpec
+	Spec struct {
+		ChartGitPath string `yaml:"chartGitPath"`
+		Values       map[string]interface{}
+	}
 }
 
+// Containers returns the containers that are defined in the
+// FluxHelmRelease. At present, this assumes only one image in the
+// Spec.Values, which is then named for the chart. If there is no such
+// field, or it is not parseable as an image ref, no containers are
+// returned.
 func (fhr FluxHelmRelease) Containers() []resource.Container {
-	containers, err := fhr.createFluxFHRContainers()
-	if err != nil {
-		// log ?
-	}
-	return containers
-}
-
-// CreateK8sContainers creates a list of k8s containers as
-func CreateK8sFHRContainers(spec ifv1.FluxHelmReleaseSpec) []apiv1.Container {
-	containers := []apiv1.Container{}
-
-	values := spec.Values
-	if len(values) == 0 {
-		return containers
-	}
-
-	imgInfo, ok := values["image"]
-
-	// image info appears on the top level, so is associated directly with the chart
-	if ok {
-		imgInfoStr, ok := imgInfo.(string)
-		if !ok {
-			return containers
+	values := fhr.Spec.Values
+	if imgInfo, ok := values["image"]; ok {
+		imgInfoStr := imgInfo.(string)
+		imageRef, err := image.ParseRef(imgInfoStr)
+		if err != nil {
+			return nil
 		}
-
-		cont := apiv1.Container{Name: spec.ChartGitPath, Image: imgInfoStr}
-		containers = append(containers, cont)
-
-		return containers
+		return []resource.Container{
+			{Name: fhr.Spec.ChartGitPath, Image: imageRef},
+		}
 	}
-
-	return []apiv1.Container{}
-}
-
-func TryFHRUpdate(def []byte, resourceID flux.ResourceID, container string, newImage image.Ref, out io.Writer) error {
-	fmt.Println("FAKE Updating image tag info for FHR special")
-	fmt.Println("=========================================")
-	fmt.Println("\t\t*** in tryFHRUpdate")
-	fmt.Printf("\t\t*** container: %s\n", container)
-	fmt.Printf("\t\t*** newImage: %+v\n", newImage)
-
-	fmt.Println("Updating image tag info for FHR special")
-	fmt.Println("=========================================")
 
 	return nil
 }
 
-// assumes only one image in the Spec.Values
-func (fhr FluxHelmRelease) createFluxFHRContainers() ([]resource.Container, error) {
+// SetContainerImage mutates this resource by setting the `image`
+// field of `values`, per the interpretation in `Containers` above. NB
+// we can get away with a value-typed receiver because we set a map
+// entry.
+func (fhr FluxHelmRelease) SetContainerImage(container string, ref image.Ref) error {
+	if container != fhr.Spec.ChartGitPath {
+		return fmt.Errorf("container %q not in resource; found only container %q", container, fhr.Spec.ChartGitPath)
+	}
 	values := fhr.Spec.Values
-	containers := []resource.Container{}
-
-	if len(values) == 0 {
-		return containers, nil
+	if _, ok := values["image"]; ok { // minor shortcut -- assume it's a string
+		values["image"] = ref.String()
+		return nil
 	}
-
-	imgInfo, ok := values["image"]
-
-	// image info appears on the top level, so is associated directly with the chart
-	if ok {
-		imgInfoStr := imgInfo.(string)
-		imageRef, err := image.ParseRef(imgInfoStr)
-		if err != nil {
-			return containers, err
-		}
-		containers = append(containers, resource.Container{Name: fhr.Spec.ChartGitPath, Image: imageRef})
-		return containers, nil
-	}
-
-	return []resource.Container{}, nil
+	return fmt.Errorf("did not find 'image' field in resource")
 }

--- a/cluster/kubernetes/resource/fluxhelmrelease.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease.go
@@ -1,0 +1,90 @@
+package resource
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/weaveworks/flux"
+	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha2"
+	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/resource"
+	apiv1 "k8s.io/api/core/v1"
+)
+
+type FluxHelmRelease struct {
+	baseObject
+	Spec ifv1.FluxHelmReleaseSpec
+}
+
+func (fhr FluxHelmRelease) Containers() []resource.Container {
+	containers, err := fhr.createFluxFHRContainers()
+	if err != nil {
+		// log ?
+	}
+	return containers
+}
+
+// CreateK8sContainers creates a list of k8s containers as
+func CreateK8sFHRContainers(spec ifv1.FluxHelmReleaseSpec) []apiv1.Container {
+	containers := []apiv1.Container{}
+
+	values := spec.Values
+	if len(values) == 0 {
+		return containers
+	}
+
+	imgInfo, ok := values["image"]
+
+	// image info appears on the top level, so is associated directly with the chart
+	if ok {
+		imgInfoStr, ok := imgInfo.(string)
+		if !ok {
+			return containers
+		}
+
+		cont := apiv1.Container{Name: spec.ChartGitPath, Image: imgInfoStr}
+		containers = append(containers, cont)
+
+		return containers
+	}
+
+	return []apiv1.Container{}
+}
+
+func TryFHRUpdate(def []byte, resourceID flux.ResourceID, container string, newImage image.Ref, out io.Writer) error {
+	fmt.Println("FAKE Updating image tag info for FHR special")
+	fmt.Println("=========================================")
+	fmt.Println("\t\t*** in tryFHRUpdate")
+	fmt.Printf("\t\t*** container: %s\n", container)
+	fmt.Printf("\t\t*** newImage: %+v\n", newImage)
+
+	fmt.Println("Updating image tag info for FHR special")
+	fmt.Println("=========================================")
+
+	return nil
+}
+
+// assumes only one image in the Spec.Values
+func (fhr FluxHelmRelease) createFluxFHRContainers() ([]resource.Container, error) {
+	values := fhr.Spec.Values
+	containers := []resource.Container{}
+
+	if len(values) == 0 {
+		return containers, nil
+	}
+
+	imgInfo, ok := values["image"]
+
+	// image info appears on the top level, so is associated directly with the chart
+	if ok {
+		imgInfoStr := imgInfo.(string)
+		imageRef, err := image.ParseRef(imgInfoStr)
+		if err != nil {
+			return containers, err
+		}
+		containers = append(containers, resource.Container{Name: fhr.Spec.ChartGitPath, Image: imageRef})
+		return containers, nil
+	}
+
+	return []resource.Container{}, nil
+}

--- a/cluster/kubernetes/resource/load.go
+++ b/cluster/kubernetes/resource/load.go
@@ -62,6 +62,7 @@ func Load(base, atLeastOne string, more ...string) (map[string]resource.Resource
 			return objs, err
 		}
 	}
+
 	return objs, nil
 }
 

--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -118,6 +118,12 @@ func unmarshalKind(base baseObject, bytes []byte) (resource.Resource, error) {
 		var list List
 		unmarshalList(base, &raw, &list)
 		return &list, nil
+	case "FluxHelmRelease":
+		var fhr = FluxHelmRelease{baseObject: base}
+		if err := yaml.Unmarshal(bytes, &fhr); err != nil {
+			return nil, err
+		}
+		return &fhr, nil
 	case "":
 		// If there is an empty resource (due to eg an introduced comment),
 		// we are returning nil for the resource and nil for an error

--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"fmt"
 
+	ifv1 "github.com/weaveworks/flux/apis/helm.integrations.flux.weave.works/v1alpha2"
 	apiapps "k8s.io/api/apps/v1beta1"
 	apibatch "k8s.io/api/batch/v1beta1"
 	apiv1 "k8s.io/api/core/v1"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
+	k8sresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/resource"
 )
@@ -32,6 +34,7 @@ func init() {
 	resourceKinds["daemonset"] = &daemonSetKind{}
 	resourceKinds["deployment"] = &deploymentKind{}
 	resourceKinds["statefulset"] = &statefulSetKind{}
+	resourceKinds["fluxhelmrelease"] = &fluxHelmReleaseKind{}
 }
 
 type podController struct {
@@ -270,4 +273,49 @@ func makeCronJobPodController(cronJob *apibatch.CronJob) podController {
 }
 
 /////////////////////////////////////////////////////////////////////////////
-//
+// helm.integrations.flux.weave.works/v1alpha2 FluxHelmRelease
+
+type fluxHelmReleaseKind struct{}
+
+func (fhr *fluxHelmReleaseKind) getPodController(c *Cluster, namespace, name string) (podController, error) {
+	fluxHelmRelease, err := c.client.HelmV1alpha2().FluxHelmReleases(namespace).Get(name, meta_v1.GetOptions{})
+	if err != nil {
+		return podController{}, err
+	}
+
+	return makeFluxHelmReleasePodController(fluxHelmRelease), nil
+}
+
+func (fhr *fluxHelmReleaseKind) getPodControllers(c *Cluster, namespace string) ([]podController, error) {
+	fluxHelmReleases, err := c.client.HelmV1alpha2().FluxHelmReleases(namespace).List(meta_v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var podControllers []podController
+	for _, f := range fluxHelmReleases.Items {
+		podControllers = append(podControllers, makeFluxHelmReleasePodController(&f))
+	}
+
+	return podControllers, nil
+}
+
+func makeFluxHelmReleasePodController(fluxHelmRelease *ifv1.FluxHelmRelease) podController {
+	containers := k8sresource.CreateK8sFHRContainers(fluxHelmRelease.Spec)
+
+	podTemplate := apiv1.PodTemplateSpec{
+		ObjectMeta: fluxHelmRelease.ObjectMeta,
+		Spec: apiv1.PodSpec{
+			Containers:       containers,
+			ImagePullSecrets: []apiv1.LocalObjectReference{},
+		},
+	}
+
+	return podController{
+		apiVersion:  "helm.integrations.flux.weave.works/v1alpha2",
+		kind:        "FluxHelmRelease",
+		name:        fluxHelmRelease.ObjectMeta.Name,
+		status:      StatusReady,
+		podTemplate: podTemplate,
+		apiObject:   fluxHelmRelease}
+}

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -49,6 +49,7 @@ func TestUpdates(t *testing.T) {
 		{"single quotes", case8resource, case8containers, case8image, case8, case8out},
 		{"in multidoc", case9resource, case9containers, case9image, case9, case9out},
 		{"in kubernetes List resource", case10resource, case10containers, case10image, case10, case10out},
+		{"FluxHelmRelease (simple image encoding)", case11resource, case11containers, case11image, case11, case11out},
 	} {
 		testUpdate(t, c)
 	}
@@ -515,7 +516,7 @@ spec:
       labels:
         name: authfe
       annotations:
-        prometheus.io.port: '8080'
+        prometheus.io.port: "8080"
     spec:
       # blank comment spacers in the following
       containers:
@@ -576,7 +577,7 @@ spec:
     spec:
       containers:
       - name: weave
-        image: weaveworks/weave-kube:2.2.1
+        image: 'weaveworks/weave-kube:2.2.1'
 `
 
 const case9 = `---
@@ -781,4 +782,41 @@ items:
     - port: 80
     selector:
       name: helloworld
+`
+
+const case11 = `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    image: bitnami/mariadb:10.1.30-r1
+    persistence:
+      enabled: false
+`
+
+const case11resource = "maria:fluxhelmrelease/mariadb"
+const case11image = "bitnami/mariadb:10.1.33"
+
+var case11containers = []string{"mariadb"}
+
+const case11out = `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    image: bitnami/mariadb:10.1.33
+    persistence:
+      enabled: false
 `

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -803,7 +803,7 @@ spec:
 const case11resource = "maria:fluxhelmrelease/mariadb"
 const case11image = "bitnami/mariadb:10.1.33"
 
-var case11containers = []string{"mariadb"}
+var case11containers = []string{"chart-image"}
 
 const case11out = `---
 apiVersion: helm.integrations.flux.weave.works/v1alpha2

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/pflag"
+	k8sifclient "github.com/weaveworks/flux/integrations/client/clientset/versioned"
 	k8sclient "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -182,6 +183,12 @@ func main() {
 			os.Exit(1)
 		}
 
+		ifclientset, err := k8sifclient.NewForConfig(restClientConfig)
+		if err != nil {
+			logger.Log("error", fmt.Sprintf("Error building integrations clientset: %v", err))
+			os.Exit(1)
+		}
+
 		serverVersion, err := clientset.ServerVersion()
 		if err != nil {
 			logger.Log("err", err)
@@ -229,7 +236,7 @@ func main() {
 		logger.Log("kubectl", kubectl)
 
 		kubectlApplier := kubernetes.NewKubectl(kubectl, restClientConfig)
-		k8sInst := kubernetes.NewCluster(clientset, kubectlApplier, sshKeyRing, logger)
+		k8sInst := kubernetes.NewCluster(clientset, ifclientset, kubectlApplier, sshKeyRing, logger)
 
 		if err := k8sInst.Ping(); err != nil {
 			logger.Log("ping", err)

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -19,7 +19,7 @@ ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.3.0 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.3.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 # Add git hosts to known hosts file so when git ssh's using the deploy

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -19,7 +19,7 @@ ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.2.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.3.0 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 # Add git hosts to known hosts file so when git ssh's using the deploy

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -88,7 +88,9 @@ func VerifyChanges(before map[string]resource.Resource, updates []*update.Contro
 			return verificationError("resource %q mentioned in update is not a workload", update.ResourceID.String())
 		}
 		for _, containerUpdate := range update.Updates {
-			wl.SetContainerImage(containerUpdate.Container, containerUpdate.Target)
+			if err := wl.SetContainerImage(containerUpdate.Container, containerUpdate.Target); err != nil {
+				return verificationError("updating container %q in resource %q failed: %s", containerUpdate.Container, update.ResourceID.String(), err.Error())
+			}
 		}
 	}
 

--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -25,7 +25,7 @@ type clientV8 interface {
 
 var _ clientV8 = &RPCClientV8{}
 
-var supportedKindsV8 = []string{"deployment", "daemonset", "statefulset", "cronjob"}
+var supportedKindsV8 = []string{"deployment", "daemonset", "statefulset", "cronjob", "fluxhelmrelease"}
 
 // NewClient creates a new rpc-backed implementation of the server.
 func NewClientV8(conn io.ReadWriteCloser) *RPCClientV8 {


### PR DESCRIPTION
This adds support for treating FluxHelmRelease releases as workloads (i.e., things that refer to images and result in pods being created). They will appear in ListImages and ListServices API results, and can be updated and automated like other workloads.

Fixes #985.
