### PR TITLE
chart: improve instructions in the install notes

### DIFF
--- a/chart/flux/templates/NOTES.txt
+++ b/chart/flux/templates/NOTES.txt
@@ -10,10 +10,10 @@
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:3030
+  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:3030 &
 {{- end }}
 
 2. Get the Git deploy key by running these commands:
   export FLUX_POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl -n {{ .Release.Namespace }} logs $FLUX_POD | grep identity.pub
+  kubectl -n {{ .Release.Namespace }} logs $FLUX_POD | grep identity.pub | cut -d '"' -f2
 


### PR DESCRIPTION
 - send `port-forward` to the background so it doesn't hog the terminal
 - extract deploy key from log cleanly to minimise the risk of copy/paste mistakes