### PR TITLE
Sort resources using dependency order before applying

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ build/.%.done: docker/Dockerfile.%
 		-f build/docker/$*/Dockerfile.$* ./build/docker/$*
 	touch $@
 
-build/.flux.done: build/fluxd build/kubectl docker/ssh_config
+build/.flux.done: build/fluxd build/kubectl docker/ssh_config docker/kubeconfig
 build/.helm-operator.done: build/helm-operator build/kubectl docker/ssh_config
 
 build/fluxd: $(FLUXD_DEPS)

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -93,30 +93,6 @@ func isAddon(obj namespacedLabeled) bool {
 
 // --- /add ons
 
-type changeSet struct {
-	nsObjs   map[string][]*apiObject
-	noNsObjs map[string][]*apiObject
-}
-
-func makeChangeSet() changeSet {
-	return changeSet{
-		nsObjs:   make(map[string][]*apiObject),
-		noNsObjs: make(map[string][]*apiObject),
-	}
-}
-
-func (c *changeSet) stage(cmd string, o *apiObject) {
-	if o.hasNamespace() {
-		c.nsObjs[cmd] = append(c.nsObjs[cmd], o)
-	} else {
-		c.noNsObjs[cmd] = append(c.noNsObjs[cmd], o)
-	}
-}
-
-type Applier interface {
-	apply(log.Logger, changeSet) cluster.SyncError
-}
-
 // Cluster is a handle to a Kubernetes API server.
 // (Typically, this code is deployed into the same cluster.)
 type Cluster struct {

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -43,13 +43,15 @@ type extendedClient struct {
 
 // --- internal types for keeping track of syncing
 
+type metadata struct {
+	Name      string `yaml:"name"`
+	Namespace string `yaml:"namespace"`
+}
+
 type apiObject struct {
 	resource.Resource
-	Kind     string `yaml:"kind"`
-	Metadata struct {
-		Name      string `yaml:"name"`
-		Namespace string `yaml:"namespace"`
-	} `yaml:"metadata"`
+	Kind     string   `yaml:"kind"`
+	Metadata metadata `yaml:"metadata"`
 }
 
 // A convenience for getting an minimal object from some bytes.

--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"sort"
 	"strings"
 	"time"
 
@@ -16,23 +17,15 @@ import (
 )
 
 type changeSet struct {
-	nsObjs   map[string][]*apiObject
-	noNsObjs map[string][]*apiObject
+	objs map[string][]*apiObject
 }
 
 func makeChangeSet() changeSet {
-	return changeSet{
-		nsObjs:   make(map[string][]*apiObject),
-		noNsObjs: make(map[string][]*apiObject),
-	}
+	return changeSet{objs: make(map[string][]*apiObject)}
 }
 
 func (c *changeSet) stage(cmd string, o *apiObject) {
-	if o.hasNamespace() {
-		c.nsObjs[cmd] = append(c.nsObjs[cmd], o)
-	} else {
-		c.noNsObjs[cmd] = append(c.noNsObjs[cmd], o)
-	}
+	c.objs[cmd] = append(c.objs[cmd], o)
 }
 
 // Applier is something that will apply a changeset to the cluster.
@@ -78,9 +71,50 @@ func (c *Kubectl) connectArgs() []string {
 	return args
 }
 
+// rankOfKind returns an int denoting the position of the given kind
+// in the partial ordering of Kubernetes resources, according to which
+// kinds depend on which (derived by hand).
+func rankOfKind(kind string) int {
+	switch kind {
+	// Namespaces answer to NOONE
+	case "Namespace":
+		return 0
+	// These don't go in namespaces; or do, but don't depend on anything else
+	case "ServiceAccount", "ClusterRole", "Role", "PersistentVolume", "Service":
+		return 1
+	// These depend on something above, but not each other
+	case "ResourceQuota", "LimitRange", "Secret", "ConfigMap", "RoleBinding", "ClusterRoleBinding", "PersistentVolumeClaim", "Ingress":
+		return 2
+	// Same deal, next layer
+	case "DaemonSet", "Deployment", "ReplicationController", "ReplicaSet", "Job", "CronJob", "StatefulSet":
+		return 3
+	// Assumption: anything not mentioned isn't depended _upon_, so
+	// can come last.
+	default:
+		return 4
+	}
+}
+
+type applyOrder []*apiObject
+
+func (objs applyOrder) Len() int {
+	return len(objs)
+}
+
+func (objs applyOrder) Swap(i, j int) {
+	objs[i], objs[j] = objs[j], objs[i]
+}
+
+func (objs applyOrder) Less(i, j int) bool {
+	ranki, rankj := rankOfKind(objs[i].Kind), rankOfKind(objs[j].Kind)
+	if ranki == rankj {
+		return objs[i].Metadata.Name < objs[j].Metadata.Name
+	}
+	return ranki < rankj
+}
+
 func (c *Kubectl) apply(logger log.Logger, cs changeSet) (errs cluster.SyncError) {
-	f := func(m map[string][]*apiObject, cmd string, args ...string) {
-		objs := m[cmd]
+	f := func(objs []*apiObject, cmd string, args ...string) {
 		if len(objs) == 0 {
 			return
 		}
@@ -96,15 +130,19 @@ func (c *Kubectl) apply(logger log.Logger, cs changeSet) (errs cluster.SyncError
 		}
 	}
 
-	// When deleting resources we must ensure any resource in a non-default
-	// namespace is deleted before the namespace that it is in. Since namespace
-	// resources don't specify a namespace, this ordering guarantees that.
-	f(cs.nsObjs, "delete")
-	f(cs.noNsObjs, "delete", "--namespace", "default")
-	// Likewise, when applying resources we must ensure the namespace is applied
-	// first, so we run the commands the other way round.
-	f(cs.noNsObjs, "apply", "--namespace", "default")
-	f(cs.nsObjs, "apply")
+	// When deleting objects, the only real concern is that we don't
+	// try to delete things that have already been deleted by
+	// Kubernete's GC -- most notably, resources in a namespace which
+	// is also being deleted. GC does not have the dependency ranking,
+	// but we can use it as a shortcut to avoid the above problem at
+	// least.
+	objs := cs.objs["delete"]
+	sort.Sort(sort.Reverse(applyOrder(objs)))
+	f(objs, "delete")
+
+	objs = cs.objs["apply"]
+	sort.Sort(applyOrder(objs))
+	f(objs, "apply")
 	return errs
 }
 

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -31,6 +31,7 @@ RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && \
 COPY ./ssh_config /root/.ssh/config
 RUN chmod 600 /root/.ssh/config
 
+COPY ./kubeconfig /root/.kube/config
 COPY ./kubectl /usr/local/bin/
 COPY ./fluxd /usr/local/bin/
 

--- a/docker/kubeconfig
+++ b/docker/kubeconfig
@@ -1,0 +1,12 @@
+apiVersion: v1
+clusters: []
+contexts:
+- context:
+    cluster: ""
+    namespace: default
+    user: ""
+  name: default
+current-context: default
+kind: Config
+preferences: {}
+users: []


### PR DESCRIPTION
Kubernetes resource kinds have a partial order relation of (loosely) "may refer to": a Deployment may mount a ConfigMap as a volume; most resources are scoped to a namespace; a RoleBinding refers to a Role or ClusterRole; and so on.
    
Usually, you want the referenced resources to be created or changed before the referring resources. In general, Kubernetes is designed so that it will sort itself out eventually, but things go more smoothly if things are present before they are needed.

Here I've boiled the ordering down to a small number of ranks, with each rank containing kinds that refer only to kinds in the ranks before. When applying resources, they are sorted by rank, so that resources that depend on other resources will get updated or created after those others.

We _used_ to separate resources into those that don't mention a namespace and those that do, before applying each set in turn. This was for two reasons:
 - namespaces don't have a namespace, so these would come first
 - we wanted to supply a `--namespace` argument to kubectl, because otherwise un-namespaced resources would be created in the same namespace as flux; but, if you supply that argument, applying anything that _does_ have a namespace can be an error.

If we give kubectl a context by putting one in `/root/.kube/config` though, we don't have to use the `--namespace` argument, and can apply everything together.