### PR TITLE
Include labels in ListServices response

### DIFF
--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -35,6 +35,7 @@ type ControllerStatus struct {
 	Containers []Container
 	ReadOnly   ReadOnlyReason
 	Status     string
+	Labels     map[string]string
 	Automated  bool
 	Locked     bool
 	Ignore     bool

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -34,6 +34,7 @@ type Controller struct {
 	// control of the platform. In the case of Kubernetes, we simply
 	// omit these controllers; but this may not always be the case.
 	IsSystem bool
+	Labels   map[string]string
 
 	Containers ContainersOrExcuse
 }

--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -59,6 +59,7 @@ func (pc podController) toClusterController(resourceID flux.ResourceID) cluster.
 	return cluster.Controller{
 		ID:         resourceID,
 		Status:     pc.status,
+		Labels:     pc.GetLabels(),
 		Containers: cluster.ContainersOrExcuse{Containers: clusterContainers, Excuse: excuse},
 	}
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -117,6 +117,7 @@ func (d *Daemon) ListServices(ctx context.Context, namespace string) ([]v6.Contr
 			Containers: containers2containers(service.ContainersOrNil()),
 			ReadOnly:   readOnly,
 			Status:     service.Status,
+			Labels:     service.Labels,
 			Automated:  policies.Contains(policy.Automated),
 			Locked:     policies.Contains(policy.Locked),
 			Ignore:     policies.Contains(policy.Ignore),


### PR DESCRIPTION
Many (most?) Helm charts label resources with `heritage: Tiller`. An
easy win is to forward labels through the flux API, so that consumers
of the API can interpret the above label, when present, as indicating
that Helm created the resource.
