### PR TITLE
update get started docs for flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,18 @@ If you want to learn more about Weave Cloud, you can see it in action on
 
 Get started by browsing through the documentation below:
 
-- [Introduction to Flux](/site/introduction.md)
-- [FAQ](/site/faq.md)
-- [How it works](/site/how-it-works.md)
-- [Installing Flux](/site/installing.md)
-- [Using Flux](/site/using.md)
-- [Upgrading to Flux v1](/site/upgrading-to-1.0.md)
-- [Troubleshooting](/site/troubleshooting.md)
+- Background about Flux
+  - [Introduction to Flux](/site/introduction.md)
+  - [FAQ](/site/faq.md)
+  - [How it works](/site/how-it-works.md)
+  - [Considerations regarding installing Flux](/site/installing.md)
+- Get Started with Flux
+  - [Standalone Flux](/site/standalone/installing.md)
+  - [Flux using Helm](/site/helm/installing.md)
+- Operating Flux
+  - [Using Flux](/site/using.md)
+  - [Troubleshooting](/site/troubleshooting.md)
+  - [Upgrading to Flux v1](/site/upgrading-to-1.0.md)
 
 ## Developer information
 

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -58,7 +58,7 @@ At startup Flux generates a SSH key and logs the public key.
 Find the SSH public key with:
 
 ```bash
-kubectl -n flux logs deployment/flux | grep identity.pub
+kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2
 ```
 
 In order to sync your cluster state with GitHub you need to copy the public key and 

--- a/site/helm/installing.md
+++ b/site/helm/installing.md
@@ -1,0 +1,171 @@
+---
+title: Installing Weave Flux using Helm
+menu_order: 20
+---
+
+# Get started with Flux using Helm
+
+If you are using Helm already, this guide is for you. By the end
+you will have Helm installing Flux in the cluster and deploying
+any code changes for you.
+
+## Prerequisites
+
+You will need to have Kubernetes set up. To get up and running fast,
+you might want to use `minikube` or `kubeadm`. Any other Kubernetes
+setup will work as well though.
+
+*Note:* If you are using `minikube`, be sure to start the
+cluster with `--bootstrapper=kubeadm` so you are using RBAC.
+
+Download Helm:
+
+- On MacOS:
+
+  ```sh
+  brew install kubernetes-helm
+  ```
+
+- On Linux:
+  - Download the [latest release](https://github.com/kubernetes/helm/releases/latest), unpack the
+    tarball and put the binary in your `$PATH`.
+
+Now create a service account and a cluster role binding for Tiller:
+
+```sh
+kubectl -n kube-system create sa tiller
+
+kubectl create clusterrolebinding tiller-cluster-rule \
+    --clusterrole=cluster-admin \
+    --serviceaccount=kube-system:tiller
+```
+
+Deploy Tiller in `kube-system` namespace:
+
+```sh
+helm init --skip-refresh --upgrade --service-account tiller
+```
+
+## Install Weave Flux
+
+Add the Flux repository of Weaveworks:
+
+```sh
+helm repo add weaveworks https://weaveworks.github.io/flux
+```
+
+In this next step you install Weave Flux using `helm`. Simply:
+
+ 1. Fork [flux-helm-test](https://github.com/weaveworks/flux-helm-test)
+    on Github and
+ 1. install Weave Flux and its Helm Operator by specifying your fork
+    URL.
+
+*Just make sure you replace `YOURUSER` with your GitHub username in
+the command below:*
+
+```sh
+helm install --name flux \
+--set helmOperator.create=true \
+--set git.url=git@github.com:YOURUSER/flux-helm-test \
+--set git.chartsPath=charts \
+--namespace flux \
+weaveworks/flux
+```
+
+Allow some time for all containers to get up and running. If you're
+impatient, run the following command and see the pod creation
+process.
+
+```sh
+watch kubectl get pods --all-namespaces
+```
+
+You will notice that `flux` and `flux-helm-operator` will start
+turning up in the `flux` namespace.
+
+## Giving write access
+
+For the real benefits of GitOps, Flux will need acccess to your
+git repository to update configuration if necessary. To facilitate
+that you will need to add a deploy key to your fork of the
+repository.
+
+This is pretty straight-forward as Flux generates a SSH key and
+logs the public key at startup. Find the SSH public key with:
+
+```sh
+FLUX_POD=$(kubectl get pods --namespace flux -l "app=flux,release=flux" -o jsonpath="{.items[0].metadata.name}")
+kubectl -n flux logs $FLUX_POD | grep identity.pub | cut -d '"' -f2
+```
+
+In order to sync your cluster state with git you need to copy the
+public key and create a deploy key with write access on your GitHub
+repository.
+
+Open GitHub, navigate to your fork, go to **Setting > Deploy keys**,
+click on **Add deploy key**, give it a name, check **Allow write
+access**, paste the Flux public key and click **Add key**.
+
+(Or replace `YOURUSER` with your Github ID in this url:
+`https://github.com/YOURUSER/flux-helm-test/settings/keys/new` and
+paste the key there.)
+
+Once Flux has confirmed access to the repository, it will start
+deploying the workloads of `flux-helm-test`. After a while you
+will be able to see the Helm releases listed like so:
+
+```sh
+helm list --namespace test
+```
+
+## Committing a small change
+
+`flux-helm-test` is a very simple example in which two services
+(mongodb and mariadb) are deployed. Here we will simply update the
+version of mongodb to a newer version to see if Flux will pick this
+up and update our cluster.
+
+The easiest way is to update your fork of `flux-helm-test` and
+change the `image` argument.
+
+Replace `YOURUSER` in `https://github.com/YOURUSER/flux-helm-test/edit/master/releases/mongodb_release.yaml`
+with your Github ID, open the URL in your browser, edit the file,
+change the `image:` line to the following:
+
+```yaml
+ image: bitnami/mongodb:3.7.9-r13
+```
+
+Commit the change to your `master` branch. It will now get
+automatically deployed to your cluster.
+
+You can check out the Flux logs with:
+
+```sh
+kubectl -n flux logs deployment/flux -f
+```
+
+The default sync frequency for Flux using the Helm chart is
+30 seconds. This can be tweaked easily. By observing the logs
+you can see when the change landed in in the cluster.
+
+## Confirm the change landed
+
+To access our webservice and check out its welcome message, simply
+run:
+
+```sh
+kubectl describe -n test deployment.apps/mongodb-database-mongodb | grep Image
+```
+
+## Conclusion
+
+As you can see, the actual steps to set up Flux, get our app
+deployed, give Flux access to it and see modifications land are
+very straight-forward and are a quite natural work-flow.
+
+# Next
+
+As a next step, you might want to dive deeper into [how to control
+Flux](site/using.md).

--- a/site/installing.md
+++ b/site/installing.md
@@ -3,24 +3,6 @@ title: Installing Weave Flux
 menu_order: 30
 ---
 
-We recommend that you install Flux with Weave Cloud, our hosted service
-for accelerating cloud native development. Using Flux in conjunction
-with
-[Weave Cloud](https://www.weave.works/solution/cloud/) has the following
-benefits:
-
-* A comprehensive dashboard, allowing control of Flux without the CLI
-  application
-* Extra features not available in the open source version, like Slack
-  notifications
-* Tight integration with other Weave Cloud services
-  ([Scope](https://www.weave.works/solution/troubleshooting-dashboard/)
-  and
-  [Cortex](https://www.weave.works/solution/prometheus-monitoring/))
-* Fully hosted and managed by experts at Weaveworks
-* Simpler install and operation
-* Enterprise support
-
 # Prerequisites for Flux
 
 All you need is a Kubernetes cluster and a git repo. The git repo
@@ -28,24 +10,13 @@ contains [manifests][k8s-manifests] (as YAML files) describing what
 should run in the cluster. Flux imposes
 [some requirements](/site/requirements.md) on these files.
 
-# Installing via Weave Cloud
+# Installing Weave Flux
 
-Sign up with [Weave Cloud](https://cloud.weave.works) and create an
-instance to represent your cluster.
-
-If you're already using Scope or Cortex to look at a cluster, you can
-choose that instance instead of creating one. But make sure that this
-instance is pointing to the same physical cluster, or else Flux and
-Cortex will show conflicting information (e.g. different containers
-running).
-
-Click on the "Deploy" button and follow the instructions to install
-Flux.
-
-# Standalone
-
-Alternatively, you can [install Flux without Weave Cloud on your own
+Here are the instructions to [install Flux on your own
 cluster](./standalone/installing.md).
+
+If you are using Helm, we have a [separate section about
+this](./helm/liinstalling.md).
 
 # Next
 

--- a/site/introduction.md
+++ b/site/introduction.md
@@ -61,11 +61,6 @@ Clear visibility of the state of a cluster is key for maintaining
 operational systems. Developers can be confident in their changes by
 observing a predictable series of deployment events.
 
-## Weave Cloud
-
-These features, and more, integrate tightly with the rest of [Weave 
-Cloud](https://cloud.weave.works).
-
 ## Next
 
 _Find out more about [Flux's features](/site/how-it-works.md)._

--- a/site/standalone/installing.md
+++ b/site/standalone/installing.md
@@ -3,167 +3,120 @@ title: Installing Weave Flux Manually
 menu_order: 10
 ---
 
-Flux comes in several parts:
+# Get started with Flux
 
--   the command-line client **fluxctl**
--   the daemon, **flux** which maintains the state of the cluster
--   a service, which runs in Weave Cloud
+This short guide shows a self-contained example of Flux and just
+takes a couple of minutes to get set up. By the end you will
+have Flux running in your cluster and it will be deploying any
+code changes for you.
 
-But you don't need the last to use Flux; you can just run the daemon
-and connect to it with the command line client. This page describes
-how.
+_Note:_ If you would like to install Flux using Helm, refer to the
+[Helm section](../helm/installing.md).
 
-# Quick Install
+## Prerequisites
 
-Clone the Flux repo and edit the example configuration in
-[deploy/flux-deployment.yaml](../../deploy/flux-deployment.yaml). Then
-create all the resources defined in the
-[deploy directory](../../deploy/).
+You will need to have Kubernetes set up. For a quick local test,
+you can use `minikube` or `kubeadm`. Any other Kubernetes setup
+will work as well though.
 
-```
-$EDITOR ./deploy/flux-deployment.yaml
-kubectl apply -f ./deploy
-```
+## Set up Flux
 
-### Helm users
+Get Flux:
 
-Create all resources defined in the
-[deploy-helm directory](../../deploy-helm/):
-```
-$EDITOR ./deploy-helm/helm-operator-deployment.yaml
-kubectl apply -f ./deploy-helm
+```sh
+git clone https://github.com/weaveworks/flux
+cd flux
 ```
 
-Next, download the latest version of the fluxctl client [from github](https://github.com/weaveworks/flux/releases).
+Now you can go ahead and edit Flux's deployment manifest. At the very
+least you will have to change the `--git-url` parameter to point to
+the config repository for the workloads you want Flux to deploy for
+you. You are going to need access to this repository.
 
-Continue to [setup flux](./setup.md)
-
----
-
-# Detailed Description
-
-The deployment installs Flux and its dependencies. First, change to
-the directory with the examples configuration.
-
-### Note
-
-Helm users also need content of the deploy-helm directory.
-
-```
-cd deploy
+```sh
+$EDITOR deploy/flux-deployment.yaml
 ```
 
-## Memcache
+In our example we are going to use
+[flux-example](https://github.com/weaveworks/flux-example). If you
+want to use that too, be sure to create a fork of it on Github and
+add the git URL to the config file above.
 
-Flux uses memcache to cache docker registry requests.
+In the next step, deploy Flux to the cluster:
 
-```
-kubectl create -f memcache-dep.yaml -f memcache-svc.yaml
-```
-
-## Flux deployment
-
-You will need to create a secret in which Flux will store its SSH
-key. The daemon won't start without this present.
-
-```
-kubectl create -f flux-secret.yaml
+```sh
+kubectl apply -f deploy
 ```
 
-The Kubernetes deployment configuration file
-[flux-deployment.yaml](../../deploy/flux-deployment.yaml) runs the
-Flux daemon, but you'll need to edit it first, at least to supply your
-own configuration repo (the `--git-repo` argument).
+Allow some time for all containers to get up and running. If you're
+impatient, run the following command and see the pod creation
+process.
 
-```
-$EDITOR flux-deployment.yaml
-kubectl create -f flux-deployment.yaml
+```sh
+watch kubectl get pods --all-namespaces
 ```
 
-### Note for Kubernetes >=1.6 with role-based access control (RBAC)
+## Giving write access
 
-You will need to provide fluxd with a service account which can access
-the namespaces you want to use Flux with. To do this, consult the
-example service account given in
-[flux-account.yaml](../../deploy/flux-account.yaml) (which
-puts essentially no constraints on the account) and the
-[RBAC documentation](https://kubernetes.io/docs/admin/authorization/rbac/),
-and create a service account in whichever namespace you put fluxd
-in. You may need to alter the `namespace: default` lines, if you adapt
-the example.
+At startup Flux generates a SSH key and logs the public key. Find
+the SSH public key with:
 
-You will need to explicitly tell fluxd to use that service account by
-uncommenting and possible adapting the line `# serviceAccountName:
-flux` in the file `fluxd-deployment.yaml` before applying it.
-
-## Flux API service
-
-To make the pod accessible to the command-line client `fluxctl`, you
-will need to expose the API outside the cluster.
-
-A simple way to do this is to piggy-back on `kubectl port-forward`,
-assuming you can access the Kubernetes API:
-
-```
-fluxpod=$(kubectl get pod -l name=flux -o name | awk -F / '{ print $2; }')
-kubectl port-forward "$fluxpod" 10080:3030 &
-export FLUX_URL="http://localhost:10080/api/flux"
-fluxctl list-controllers --all-namespaces
+```sh
+kubectl logs deployment/flux | grep identity.pub | cut -d '"' -f2
 ```
 
-### Local endpoint
+*Note:* If you have downloaded [fluxctl](../using.md) already, you can use
+`fluxctl identity` as well.
 
-**Beware**: this exposes the Flux API, unauthenticated, over an
-insecure channel. Do not do this _unless_ you are operating Flux
-entirely locally; and arguably, only to try it out.
+In order to sync your cluster state with git you need to copy the
+public key and create a deploy key with write access on your GitHub
+repository.
 
-If you are running Flux locally, e.g., in minikube, you can use a
-service with a
-[`NodePort`](http://kubernetes.io/docs/user-guide/services/#type-nodeport).
+Open GitHub, navigate to your fork, go to **Setting > Deploy keys**,
+click on **Add deploy key**, give it a name, check **Allow write
+access**, paste the Flux public key and click **Add key**.
 
-An example manifest is given in
-[flux-nodeport.yaml](../../deploy/flux-nodeport.yaml).
+(Or replace `YOURUSER` with your Github ID in this url:
+`https://github.com/YOURUSER/flux-example/settings/keys/new` and
+paste the key there.)
 
-Then you can access the API on the `NodePort`, by retrieving the port
-number (this example assumes you are using minikube):
+## Committing a small change
 
-```
-fluxport=$(kubectl get svc flux --template '{{ index .spec.ports 0 "nodePort" }}')
-export FLUX_URL="http://$(minikube ip):$fluxport/api/flux"
-fluxctl list-controllers --all-namespaces
-```
+In this example we are using a simple example of a webservice and
+change its configuration to use a different message. The easiest
+way is to your fork of `flux-example` and change the `msg` argument.
 
-### Remote endpoint
+Replace `YOURUSER` in
+`https://github.com/YOURUSER/flux-example/blob/master/helloworld-deploy.yaml`
+with your Github ID), open the URL in your browser, edit the file,
+change the argument value and commit the file.
 
-```
-export POD_NAME=$(kubectl get pods --namespace default -l "name=flux" -o jsonpath="{.items[0].metadata.name}")
-kubectl port-forward $POD_NAME 3030:3030
-export FLUX_URL="http://127.0.0.1:3030/api/flux"
-fluxctl list-controllers --all-namespaces
-```
+You can check out the Flux logs with:
 
-## fluxctl
-
-This allows you to control Flux from the command line, and if you're
-not connecting it to Weave Cloud, is the only way of working with
-Flux.
-
-Download the latest version of the fluxctl client
-[from github](https://github.com/weaveworks/flux/releases).
-
-## Helm operator (Helm users only)
-
-The Kubernetes deployment configuration file
-[helm-operator-deployment.yaml](../../deploy-helm/helm-operator-deployment.yaml) runs the
-helm operator, but you'll need to edit it first, at least to supply your
-own configuration repo (the `--git-repo` as for flux and the `--git-charts-path`
-argument).
-
-```
-$EDITOR helm-operator-deployment.yaml
-kubectl create -f flux-helm-release-crd.yaml -f helm-operator-deployment.yaml
+```sh
+kubectl -n default logs deployment/flux -f
 ```
 
-# Next
+The default sync frequency is 5 minutes. This can be tweaked easily.
+By observing the logs you can see when the change landed in in the
+cluster.
 
-Continue to [setup flux](./setup.md)
+## Confirm the change landed
+
+To access our webservice and check out its welcome message, simply
+run:
+
+```sh
+kubectl port-forward deployment/helloworld 8080:80 &
+curl localhost:8080
+```
+
+## Conclusion
+
+As you can see, the actual steps to set up Flux, get our app
+deployed, give Flux access to it and see modifications land are
+very straight-forward and are a quite natural work-flow.
+
+As a next step, you might want to dive deeper into [how to control
+Flux](site/using.md) or check out [more sophisticated
+setups](site/setup.md).

--- a/site/standalone/setup.md
+++ b/site/standalone/setup.md
@@ -1,23 +1,12 @@
 ---
-title: Setup Weave Flux Manually
+title: Customising the deployment
 menu_order: 20
 ---
 
-# Connecting fluxctl to the daemon
+# Customising the deployment
 
-You need to tell `fluxctl` where to find the Flux API. If you're using
-minikube, say, you can get the IP address of the host, and the port,
-with
-
-```
-$ flux_host=$(minikube ip)
-$ flux_port=$(kubectl get svc flux --template '{{ index .spec.ports 0 "nodePort" }}')
-$ export FLUX_URL=http://$flux_host:$flux_port/api/flux
-```
-
-Exporting `FLUX_URL` is enough for `fluxctl` to know how to contact
-the daemon. You could alternatively supply the `--url` argument each
-time.
+The deployment installs Flux and its dependencies. First, change to
+the directory with the examples configuration.
 
 # Customising the daemon configuration
 
@@ -28,14 +17,24 @@ manifests. This is achieved by setting the `--git-url` and
 `--git-branch` arguments in the
 [`flux-deployment.yaml`](../../deploy/flux-deployment.yaml) manifest.
 
-### Helm users
+## Memcache
 
-You need to connect the helm-operator to the same repository, pointing
-the helm-operator to the git path containing Charts. This is achieved by
-setting the `--git-url` and `--git-branch` arguments to the same values
-as for flux and setting the `--git-charts-path` argument in the
-[`helm-operator-deployment.yaml`](../../deploy-helm/helm-operator-deployment.yaml)
-manifest.
+Flux uses memcache to cache docker registry requests.
+
+```sh
+kubectl create -f memcache-dep.yaml -f memcache-svc.yaml
+```
+
+## Flux deployment
+
+You will need to create a secret in which Flux will store its SSH
+key. The daemon won't start without this present.
+
+The `flux` logs should show that it has now connected to the
+repository and synchronised the cluster.
+
+When using Kubernetes, this key is stored as a Kubernetes secret. You
+can restart `flux` and it will continue to use the same key.
 
 ## Add an SSH deploy key to the repository
 
@@ -50,70 +49,35 @@ You have two options:
 If you don't specify a key to use, Flux will create one for you. Obtain
 the public key through fluxctl:
 
-```sh
-$ fluxctl identity
-ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDCN2ECqUFMR413CURbLBcG41fLY75SfVZCd3LCsJBClVlEcMk4lwXxA3X4jowpv2v4Jw2qqiWKJepBf2UweBLmbWYicHc6yboj5o297//+ov0qGt/uRuexMN7WUx6c93VFGV7Pjd60Yilb6GSF8B39iEVq7GQUC1OZRgQnKZWLSQ==
-0c:de:7d:47:52:cf:87:61:52:db:e3:b8:d8:1a:b5:ac
-+---[RSA 1024]----+
-|            ..=  |
-|             + B |
-|      .     . +.=|
-|     . + .   oo o|
-|      . S . .o.. |
-|           .=.o  |
-|           o =   |
-|            +    |
-|           E     |
-+------[MD5]------+
-```
-
-Alternatively, you can see the public key in the `flux` log.
-
-The public key will need to be given to the service hosting the Git
-repository. For example, in GitHub you would create an SSH deploy key
-in the repository, supplying that public key.
-
-The `flux` logs should show that it has now connected to the
-repository and synchronised the cluster.
-
-When using Kubernetes, this key is stored as a Kubernetes secret. You
-can restart `flux` and it will continue to use the same key.
-
 ### 2. Specify a key to use
 
 Create a Kubernetes Secret from a private key:
 
-```
+```sh
 kubectl create secret generic flux-git-deploy --from-file=identity=/path/to/private_key
 ```
 
-Now add the secret to the `flux-deployment.yaml` manifest:
+The Kubernetes deployment configuration file
+[flux-deployment.yaml](../../deploy/flux-deployment.yaml) runs the
+Flux daemon, but you'll need to edit it first, at least to supply your
+own configuration repo (the `--git-repo` argument).
 
-```
-    ...
-    spec:
-      volumes:
-      - name: git-key
-        secret:
-          secretName: flux-git-deploy
-```
-
-And add a volume mount for the container:
-
-```
-    ...
-    spec:
-      containers:
-      - name: fluxd
-        volumeMounts:
-        - name: git-key
-          mountPath: /etc/fluxd/ssh
+```sh
+$EDITOR flux-deployment.yaml
+kubectl create -f flux-deployment.yaml
 ```
 
-You can customise the paths and names of the chosen key with the
-arguments (examples with defaults): `--k8s-secret-name=flux-git-deploy`,
-`--k8s-secret-volume-mount-path=/etc/fluxd/ssh` and
-`--k8s-secret-data-key=identity`
+### Note for Kubernetes >=1.6 with role-based access control (RBAC)
+
+You will need to provide fluxd with a service account which can access
+the namespaces you want to use Flux with. To do this, consult the
+example service account given in
+[flux-account.yaml](../../deploy/flux-account.yaml) (which
+puts essentially no constraints on the account) and the
+[RBAC documentation](https://kubernetes.io/docs/admin/authorization/rbac/),
+and create a service account in whichever namespace you put fluxd
+in. You may need to alter the `namespace: default` lines, if you adapt
+the example.
 
 Using an SSH key allows you to maintain control of the repository. You
 can revoke permission for `flux` to access the repository at any time
@@ -169,3 +133,6 @@ to mount it into the container. The example deployment manifest
 includes an example of doing this, commented out. Uncomment that (it
 assumes you used the name above for the ConfigMap) and reapply the
 manifest.
+You will need to explicitly tell fluxd to use that service account by
+uncommenting and possible adapting the line `# serviceAccountName:
+flux` in the file `fluxd-deployment.yaml` before applying it.

--- a/site/using.md
+++ b/site/using.md
@@ -7,7 +7,140 @@ All of the features of Flux are accessible from within
 [Weave Cloud](https://cloud.weave.works).
 
 However, `fluxctl` provides an equivalent API that can be used from
-the command line. The `--help` for `fluxctl` is described below.
+the command line.
+
+Download the latest version of the fluxctl client
+[from github](https://github.com/weaveworks/flux/releases).
+
+The `--help` for `fluxctl` is described below.
+
+# Connecting fluxctl to the daemon
+
+You need to tell `fluxctl` where to find the Flux API and to make
+the pod accessible to the command-line client `fluxctl`, you
+will need to expose the API outside the cluster.
+
+A simple way to do this is to piggy-back on `kubectl port-forward`,
+assuming you can access the Kubernetes API:
+
+```sh
+fluxpod=$(kubectl get pod -l name=flux -o name | awk -F / '{ print $2; }')
+kubectl port-forward "$fluxpod" 10080:3030 &
+export FLUX_URL="http://localhost:10080/api/flux"
+```
+
+Exporting `FLUX_URL` is enough for `fluxctl` to know how to contact
+the daemon. You could alternatively supply the `--url` argument
+each time.
+
+## Flux API service
+
+Now you can easily query the Flux API:
+
+```sh
+fluxctl list-controllers --all-namespaces
+```
+
+### Local endpoint
+
+**Beware**: this exposes the Flux API, unauthenticated, over an
+insecure channel. Do not do this _unless_ you are operating Flux
+entirely locally; and arguably, only to try it out.
+
+If you are running Flux locally, e.g., in minikube, you can use a
+service with a
+[`NodePort`](http://kubernetes.io/docs/user-guide/services/#type-nodeport).
+
+An example manifest is given in
+[flux-nodeport.yaml](../../deploy/flux-nodeport.yaml).
+
+Then you can access the API on the `NodePort`, by retrieving the port
+number (this example assumes you are using minikube):
+
+```sh
+fluxport=$(kubectl get svc flux --template '{{ index .spec.ports 0 "nodePort" }}')
+export FLUX_URL="http://$(minikube ip):$fluxport/api/flux"
+fluxctl list-controllers --all-namespaces
+```
+
+## Add an SSH deploy key to the repository
+
+Flux connects to the repository using an SSH key. You have two
+options:
+
+### 1. Allow flux to generate a key for you.
+
+If you don't specify a key to use, Flux will create one for you. Obtain
+the public key through fluxctl:
+
+```sh
+$ fluxctl identity
+ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAgQDCN2ECqUFMR413CURbLBcG41fLY75SfVZCd3LCsJBClVlEcMk4lwXxA3X4jowpv2v4Jw2qqiWKJepBf2UweBLmbWYicHc6yboj5o297//+ov0qGt/uRuexMN7WUx6c93VFGV7Pjd60Yilb6GSF8B39iEVq7GQUC1OZRgQnKZWLSQ==
+0c:de:7d:47:52:cf:87:61:52:db:e3:b8:d8:1a:b5:ac
++---[RSA 1024]----+
+|            ..=  |
+|             + B |
+|      .     . +.=|
+|     . + .   oo o|
+|      . S . .o.. |
+|           .=.o  |
+|           o =   |
+|            +    |
+|           E     |
++------[MD5]------+
+```
+
+Alternatively, you can see the public key in the `flux` log.
+
+The public key will need to be given to the service hosting the Git
+repository. For example, in GitHub you would create an SSH deploy key
+in the repository, supplying that public key.
+
+The `flux` logs should show that it has now connected to the
+repository and synchronised the cluster.
+
+When using Kubernetes, this key is stored as a Kubernetes secret. You
+can restart `flux` and it will continue to use the same key.
+
+### 2. Specify a key to use
+
+Create a Kubernetes Secret from a private key:
+
+```sh
+kubectl create secret generic flux-git-deploy --from-file /path/to/identity
+```
+
+Now add the secret to the `flux-deployment.yaml` manifest:
+
+```yaml
+    ...
+    spec:
+      volumes:
+      - name: git-key
+        secret:
+          secretName: flux-git-deploy
+```
+
+And add a volume mount for the container:
+
+```yaml
+    ...
+    spec:
+      containers:
+      - name: fluxd
+        volumeMounts:
+        - name: git-key
+          mountPath: /etc/fluxd/ssh
+```
+
+You can customise the paths and names of the chosen key with the
+arguments (examples with defaults): `--k8s-secret-name=flux-git-deploy`,
+`--k8s-secret-volume-mount-path=/etc/fluxd/ssh` and
+`--k8s-secret-data-key=identity`
+
+Using an SSH key allows you to maintain control of the repository. You
+can revoke permission for `flux` to access the repository at any time
+by removing the deploy key.
 
 ```sh
 fluxctl helps you deploy your code.
@@ -258,11 +391,6 @@ If your pod contains multiple containers then you tag each container individuall
 ```
 fluxctl policy --controller=default:deployment/helloworld --tag='helloworld=prod-*' --tag='sidecar=prod-*'
 ``` 
-
-## Actions triggered through Weave Cloud
-
-Weave Cloud UI sends user parameter, value of which is the username (email) of the user logged into
-Weave Cloud.
 
 ## Actions triggered through `fluxctl`
 


### PR DESCRIPTION
This is not done yet, but I'd like to get feedback anyway.

I wanted to add self-contained examples for getting started with Flux and provide a more straight-forward navigation for this. Right now I'd go from the main page to site/installing.md to site/standalone/installing.md which would get me flux with flux-example, it refers to helm in places, expects minikube in others, takes me to setup.md and explains more sophisticated bits. All in all, the current navigation is not straight-forward.

I hope to make this a bit clearer with the following:

 - README.md: doc nav is a more categorised and directly links to "get started with standalone flux" and "get started with flux using helm" docs
 - site/standalone/installing.md: is a self-contained, minimal example which shows me in 5-10 minutes that flux is actually working
 - site/helm/installing.md: will do the same as above, this is still WIP - collect all helm bits here as well
 - site/standalone/setup.md: collects notes about more sophisticated setups
 - site/using.md: collects all information about controlling flux, e.g. `fluxctl` use and more

As I said, the content is not 100% done yet (particularly the helm bits), but I'd appreciate a review if the general structure and direction is making sense.