### PR TITLE
Fix CronJob manifest verification

### DIFF
--- a/cluster/kubernetes/resource/cronjob.go
+++ b/cluster/kubernetes/resource/cronjob.go
@@ -15,7 +15,7 @@ type CronJobSpec struct {
 		Spec struct {
 			Template PodTemplate
 		}
-	}
+	} `yaml:"jobTemplate"`
 }
 
 func (c CronJob) Containers() []resource.Container {


### PR DESCRIPTION
This fixes the error

    verifying changes: failed to verify changes: updating container
    \"some-cronjob\" in resource \"default:cronjob/some-cronjob\" failed:
    container \"some-cronjob\" not found in workload

while verifying a CronJob file.

`yaml.Unmarshal` unmarshals from yaml fields into struct fields
according to their lowercase version. For the struct field `JobTemplate`
it is looking for `jobtemplate` while it is actually named
`jobTemplate`.

Fixes #1126 