### PR TITLE
Rewrite whole files, and thereby deal with multidocs and Lists properly

### DIFF
--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -204,8 +204,8 @@ func TestLoadSome(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
-	if len(objs) != len(testfiles.ServiceMap(dir)) {
-		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testfiles.ServiceMap(dir)), len(testfiles.Files), objs)
+	if len(objs) != len(testfiles.ResourceMap) {
+		t.Errorf("expected %d objects from %d files, got result:\n%#v", len(testfiles.ResourceMap), len(testfiles.Files), objs)
 	}
 }
 

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -45,11 +45,13 @@ func WriteTestFiles(dir string) error {
 // ResourceMap is the map of resource names to relative paths, which
 // must correspond with `Files` below.
 var ResourceMap = map[flux.ResourceID]string{
-	flux.MustParseResourceID("default:deployment/helloworld"):       "helloworld-deploy.yaml",
-	flux.MustParseResourceID("default:deployment/locked-service"):   "locked-service-deploy.yaml",
-	flux.MustParseResourceID("default:deployment/test-service"):     "test/test-service-deploy.yaml",
-	flux.MustParseResourceID("default:deployment/www-example-io"):   "multi.yaml",
-	flux.MustParseResourceID("default:service/www-example-service"): "multi.yaml",
+	flux.MustParseResourceID("default:deployment/helloworld"):     "helloworld-deploy.yaml",
+	flux.MustParseResourceID("default:deployment/locked-service"): "locked-service-deploy.yaml",
+	flux.MustParseResourceID("default:deployment/test-service"):   "test/test-service-deploy.yaml",
+	flux.MustParseResourceID("default:deployment/multi-deploy"):   "multi.yaml",
+	flux.MustParseResourceID("default:service/multi-service"):     "multi.yaml",
+	flux.MustParseResourceID("default:deployment/list-deploy"):    "list.yaml",
+	flux.MustParseResourceID("default:service/list-service"):      "list.yaml",
 }
 
 // ServiceMap ... given a base path, construct the map representing
@@ -60,14 +62,16 @@ func ServiceMap(dir string) map[flux.ResourceID][]string {
 		flux.MustParseResourceID("default:deployment/helloworld"):     []string{filepath.Join(dir, "helloworld-deploy.yaml")},
 		flux.MustParseResourceID("default:deployment/locked-service"): []string{filepath.Join(dir, "locked-service-deploy.yaml")},
 		flux.MustParseResourceID("default:deployment/test-service"):   []string{filepath.Join(dir, "test/test-service-deploy.yaml")},
-		flux.MustParseResourceID("default:deployment/www-example-io"): []string{filepath.Join(dir, "multi.yaml")},
+		flux.MustParseResourceID("default:deployment/multi-deploy"):   []string{filepath.Join(dir, "multi.yaml")},
+		flux.MustParseResourceID("default:deployment/list-deploy"):    []string{filepath.Join(dir, "list.yaml")},
 	}
 }
 
 var Files = map[string]string{
 	"garbage": "This should just be ignored, since it is not YAML",
 	// Some genuine manifests
-	"helloworld-deploy.yaml": `apiVersion: extensions/v1beta1
+	"helloworld-deploy.yaml": `---
+apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
   name: helloworld
@@ -136,42 +140,75 @@ spec:
         - containerPort: 80
 `,
 	// A multidoc, since we support those now
-	"multi.yaml": `apiVersion: apps/v1beta1
+	"multi.yaml": `---
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   annotations:
     flux.weave.works/automated: "true"
-  name: www-example-io
+  name: multi-deploy
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        app : www-example-io
+        app : multi-app
     spec:
       containers:
-        - name: www-example-io
+        - name: hello
           image: quay.io/weaveworks/helloworld:master-a000001
           imagePullPolicy: Always
           ports:
           - containerPort: 80
-      imagePullSecrets:
-      - name: imagesecret
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: www-example-io
-  name: www-example-service
+  name: multi-service
 spec:
   type: NodePort
   ports:
-  - name: www-example-io
-    port: 80
+  - port: 80
     protocol: TCP
   selector:
-    app: www-example-io
+    app: multi-app
+`,
+
+	// A List resource
+	"list.yaml": `---
+apiVersion: v1
+kind: List
+items:
+- apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: list-deploy
+  spec:
+    replicas: 1
+    template:
+      metadata:
+        labels:
+          app : list-app
+      spec:
+        containers:
+          - name: hello
+            image: quay.io/weaveworks/helloworld:master-a000001
+            imagePullPolicy: Always
+            ports:
+            - containerPort: 80
+- apiVersion: v1
+  kind: Service
+  metadata:
+    labels:
+      app: list-app
+    name: list-service
+  spec:
+    type: NodePort
+    ports:
+    - port: 80
+      protocol: TCP
+    selector:
+      app: list-app
 `,
 
 	// A tricksy chart directory, which should be skipped entirely. Adapted from

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -42,13 +42,25 @@ func WriteTestFiles(dir string) error {
 
 // ----- DATA
 
-// ServiceMap ... given a base path, construct the map representing the services
-// given in the test data.
+// ResourceMap is the map of resource names to relative paths, which
+// must correspond with `Files` below.
+var ResourceMap = map[flux.ResourceID]string{
+	flux.MustParseResourceID("default:deployment/helloworld"):       "helloworld-deploy.yaml",
+	flux.MustParseResourceID("default:deployment/locked-service"):   "locked-service-deploy.yaml",
+	flux.MustParseResourceID("default:deployment/test-service"):     "test/test-service-deploy.yaml",
+	flux.MustParseResourceID("default:deployment/www-example-io"):   "multi.yaml",
+	flux.MustParseResourceID("default:service/www-example-service"): "multi.yaml",
+}
+
+// ServiceMap ... given a base path, construct the map representing
+// the services given in the test data. Must be kept in sync with
+// `Files` below. TODO(michael): derive from ResourceMap, or similar.
 func ServiceMap(dir string) map[flux.ResourceID][]string {
 	return map[flux.ResourceID][]string{
 		flux.MustParseResourceID("default:deployment/helloworld"):     []string{filepath.Join(dir, "helloworld-deploy.yaml")},
 		flux.MustParseResourceID("default:deployment/locked-service"): []string{filepath.Join(dir, "locked-service-deploy.yaml")},
 		flux.MustParseResourceID("default:deployment/test-service"):   []string{filepath.Join(dir, "test/test-service-deploy.yaml")},
+		flux.MustParseResourceID("default:deployment/www-example-io"): []string{filepath.Join(dir, "multi.yaml")},
 	}
 }
 
@@ -122,6 +134,44 @@ spec:
         - -msg=Ahoy
         ports:
         - containerPort: 80
+`,
+	// A multidoc, since we support those now
+	"multi.yaml": `apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    flux.weave.works/automated: "true"
+  name: www-example-io
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app : www-example-io
+    spec:
+      containers:
+        - name: www-example-io
+          image: quay.io/weaveworks/helloworld:master-a000001
+          imagePullPolicy: Always
+          ports:
+          - containerPort: 80
+      imagePullSecrets:
+      - name: imagesecret
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: www-example-io
+  name: www-example-service
+spec:
+  type: NodePort
+  ports:
+  - name: www-example-io
+    port: 80
+    protocol: TCP
+  selector:
+    app: www-example-io
 `,
 
 	// A tricksy chart directory, which should be skipped entirely. Adapted from

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -329,8 +329,8 @@ func TestDaemon_NotifyChange(t *testing.T) {
 		t.Errorf("Sync was not called once, was called %d times", syncCalled)
 	} else if syncDef == nil {
 		t.Errorf("Sync was called with a nil syncDef")
-	} else if len(syncDef.Actions) != len(testfiles.ServiceMap("unimportant")) {
-		t.Errorf("Sync was not called with the %d actions, was called with: %d", len(testfiles.Files), len(syncDef.Actions))
+	} else if len(syncDef.Actions) != len(testfiles.ResourceMap) {
+		t.Errorf("Expected Sync called with %d actions (resources), was called with %d", len(testfiles.ResourceMap), len(syncDef.Actions))
 	}
 
 	// Check that history was written to

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/cluster/kubernetes"
 	kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
+	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 	"github.com/weaveworks/flux/event"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/git/gittest"
@@ -97,11 +98,11 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ResourceIDs{
-		flux.MustParseResourceID("default:deployment/locked-service"),
-		flux.MustParseResourceID("default:deployment/test-service"),
-		flux.MustParseResourceID("default:deployment/helloworld")}
-	expectedServiceIDs.Sort()
+	expectedResourceIDs := flux.ResourceIDs{}
+	for id, _ := range testfiles.ResourceMap {
+		expectedResourceIDs = append(expectedResourceIDs, id)
+	}
+	expectedResourceIDs.Sort()
 	k8s.SyncFunc = func(def cluster.SyncDef) error {
 		syncCalled++
 		syncDef = &def
@@ -115,8 +116,8 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 		t.Errorf("Sync was not called once, was called %d times", syncCalled)
 	} else if syncDef == nil {
 		t.Errorf("Sync was called with a nil syncDef")
-	} else if len(syncDef.Actions) != len(expectedServiceIDs) {
-		t.Errorf("Sync was not called with the %d actions, was called with: %d", len(expectedServiceIDs)*2, len(syncDef.Actions))
+	} else if len(syncDef.Actions) != len(expectedResourceIDs) {
+		t.Errorf("Sync was not called with %d actions (resources), was called with %d", len(expectedResourceIDs), len(syncDef.Actions))
 	}
 
 	// The emitted event has all service ids
@@ -128,10 +129,10 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 	} else if es[0].Type != event.EventSync {
 		t.Errorf("Unexpected event type: %#v", es[0])
 	} else {
-		gotServiceIDs := es[0].ServiceIDs
-		flux.ResourceIDs(gotServiceIDs).Sort()
-		if !reflect.DeepEqual(gotServiceIDs, []flux.ResourceID(expectedServiceIDs)) {
-			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotServiceIDs, expectedServiceIDs)
+		gotResourceIDs := es[0].ServiceIDs
+		flux.ResourceIDs(gotResourceIDs).Sort()
+		if !reflect.DeepEqual(gotResourceIDs, []flux.ResourceID(expectedResourceIDs)) {
+			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotResourceIDs, expectedResourceIDs)
 		}
 	}
 	// It creates the tag at HEAD
@@ -166,11 +167,11 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ResourceIDs{
-		flux.MustParseResourceID("default:deployment/locked-service"),
-		flux.MustParseResourceID("default:deployment/test-service"),
-		flux.MustParseResourceID("default:deployment/helloworld")}
-	expectedServiceIDs.Sort()
+	expectedResourceIDs := flux.ResourceIDs{}
+	for id, _ := range testfiles.ResourceMap {
+		expectedResourceIDs = append(expectedResourceIDs, id)
+	}
+	expectedResourceIDs.Sort()
 	k8s.SyncFunc = func(def cluster.SyncDef) error {
 		syncCalled++
 		syncDef = &def
@@ -186,8 +187,8 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 		t.Errorf("Sync was not called once, was called %d times", syncCalled)
 	} else if syncDef == nil {
 		t.Errorf("Sync was called with a nil syncDef")
-	} else if len(syncDef.Actions) != len(expectedServiceIDs) {
-		t.Errorf("Sync was not called with the %d actions, was called with: %d", len(expectedServiceIDs)*2, len(syncDef.Actions))
+	} else if len(syncDef.Actions) != len(expectedResourceIDs) {
+		t.Errorf("Sync was not called with %d actions, was called with: %d", len(expectedResourceIDs), len(syncDef.Actions))
 	}
 
 	// The emitted event has no service ids
@@ -259,11 +260,11 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 
 	syncCalled := 0
 	var syncDef *cluster.SyncDef
-	expectedServiceIDs := flux.ResourceIDs{
-		flux.MustParseResourceID("default:deployment/locked-service"),
-		flux.MustParseResourceID("default:deployment/test-service"),
-		flux.MustParseResourceID("default:deployment/helloworld")}
-	expectedServiceIDs.Sort()
+	expectedResourceIDs := flux.ResourceIDs{}
+	for id, _ := range testfiles.ResourceMap {
+		expectedResourceIDs = append(expectedResourceIDs, id)
+	}
+	expectedResourceIDs.Sort()
 	k8s.SyncFunc = func(def cluster.SyncDef) error {
 		syncCalled++
 		syncDef = &def
@@ -277,8 +278,8 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 		t.Errorf("Sync was not called once, was called %d times", syncCalled)
 	} else if syncDef == nil {
 		t.Errorf("Sync was called with a nil syncDef")
-	} else if len(syncDef.Actions) != len(expectedServiceIDs) {
-		t.Errorf("Sync was not called with the %d actions, was called with: %d", len(expectedServiceIDs)*2, len(syncDef.Actions))
+	} else if len(syncDef.Actions) != len(expectedResourceIDs) {
+		t.Errorf("Sync was not called with %d actions, was called with %d", len(expectedResourceIDs), len(syncDef.Actions))
 	}
 
 	// The emitted event has no service ids
@@ -290,11 +291,11 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 	} else if es[0].Type != event.EventSync {
 		t.Errorf("Unexpected event type: %#v", es[0])
 	} else {
-		gotServiceIDs := es[0].ServiceIDs
-		flux.ResourceIDs(gotServiceIDs).Sort()
+		gotResourceIDs := es[0].ServiceIDs
+		flux.ResourceIDs(gotResourceIDs).Sort()
 		// Event should only have changed service ids
-		if !reflect.DeepEqual(gotServiceIDs, []flux.ResourceID{flux.MustParseResourceID("default:deployment/helloworld")}) {
-			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotServiceIDs, []flux.ResourceID{flux.MustParseResourceID("default/helloworld")})
+		if !reflect.DeepEqual(gotResourceIDs, []flux.ResourceID{flux.MustParseResourceID("default:deployment/helloworld")}) {
+			t.Errorf("Unexpected event service ids: %#v, expected: %#v", gotResourceIDs, []flux.ResourceID{flux.MustParseResourceID("default:deployment/helloworld")})
 		}
 	}
 	// It moves the tag

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -135,6 +135,31 @@ func setup(t *testing.T) (*git.Checkout, func()) {
 	return gittest.Checkout(t)
 }
 
+var ignoredNotIncluded = update.ControllerResult{
+	Status: update.ReleaseStatusIgnored,
+	Error:  update.NotIncluded,
+}
+
+var ignoredNotInRepo = update.ControllerResult{
+	Status: update.ReleaseStatusIgnored,
+	Error:  update.NotInRepo,
+}
+
+var ignoredNotInCluster = update.ControllerResult{
+	Status: update.ReleaseStatusIgnored,
+	Error:  update.NotInCluster,
+}
+
+var skippedNotInCluster = update.ControllerResult{
+	Status: update.ReleaseStatusSkipped,
+	Error:  update.NotInCluster,
+}
+
+var skippedNotInRepo = update.ControllerResult{
+	Status: update.ReleaseStatusSkipped,
+	Error:  update.NotInRepo,
+}
+
 func Test_FilterLogic(t *testing.T) {
 	cluster := mockCluster(hwSvc, lockedSvc) // no testsvc in cluster, but it _is_ in repo
 	notInRepoService := "default:deployment/notInRepo"
@@ -169,14 +194,9 @@ func Test_FilterLogic(t *testing.T) {
 						},
 					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
+				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/www-example-io"): ignoredNotIncluded,
 			},
 		}, {
 			Name: "exclude specific service",
@@ -206,10 +226,8 @@ func Test_FilterLogic(t *testing.T) {
 					Status: update.ReleaseStatusIgnored,
 					Error:  update.Excluded,
 				},
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.NotInCluster,
-				},
+				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/www-example-io"): skippedNotInCluster,
 			},
 		}, {
 			Name: "update specific image",
@@ -235,6 +253,10 @@ func Test_FilterLogic(t *testing.T) {
 					Error:  update.DifferentImage,
 				},
 				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
+					Status: update.ReleaseStatusSkipped,
+					Error:  update.NotInCluster,
+				},
+				flux.MustParseResourceID("default:deployment/www-example-io"): update.ControllerResult{
 					Status: update.ReleaseStatusSkipped,
 					Error:  update.NotInCluster,
 				},
@@ -270,10 +292,8 @@ func Test_FilterLogic(t *testing.T) {
 					Status: update.ReleaseStatusSkipped,
 					Error:  update.Locked,
 				},
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.NotInCluster,
-				},
+				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/www-example-io"): skippedNotInCluster,
 			},
 		},
 		{
@@ -304,10 +324,8 @@ func Test_FilterLogic(t *testing.T) {
 					Status: update.ReleaseStatusSkipped,
 					Error:  update.Locked,
 				},
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.NotInCluster,
-				},
+				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/www-example-io"): skippedNotInCluster,
 			},
 		},
 		{
@@ -319,22 +337,11 @@ func Test_FilterLogic(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 			},
 			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
-				flux.MustParseResourceID(notInRepoService): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.NotInRepo,
-				},
+				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/www-example-io"): ignoredNotIncluded,
+				flux.MustParseResourceID(notInRepoService):                    skippedNotInRepo,
 			},
 		},
 	} {
@@ -379,14 +386,9 @@ func Test_ImageStatus(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 			},
 			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
+				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/www-example-io"): ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
 					Status: update.ReleaseStatusIgnored,
 					Error:  update.DoesNotUseImage,
@@ -405,14 +407,9 @@ func Test_ImageStatus(t *testing.T) {
 					Status: update.ReleaseStatusSkipped,
 					Error:  update.ImageUpToDate,
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.NotIncluded,
-				},
+				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/www-example-io"): ignoredNotIncluded,
 			},
 		},
 	} {

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -345,14 +345,16 @@ func Test_FilterLogic(t *testing.T) {
 			},
 		},
 	} {
-		checkout, cleanup := setup(t)
-		defer cleanup()
-		testRelease(t, tst.Name, &ReleaseContext{
-			cluster:   cluster,
-			manifests: mockManifests,
-			registry:  mockRegistry,
-			repo:      checkout,
-		}, tst.Spec, tst.Expected)
+		t.Run(tst.Name, func(t *testing.T) {
+			checkout, cleanup := setup(t)
+			defer cleanup()
+			testRelease(t, &ReleaseContext{
+				cluster:   cluster,
+				manifests: mockManifests,
+				registry:  mockRegistry,
+				repo:      checkout,
+			}, tst.Spec, tst.Expected)
+		})
 	}
 }
 
@@ -413,19 +415,21 @@ func Test_ImageStatus(t *testing.T) {
 			},
 		},
 	} {
-		checkout, cleanup := setup(t)
-		defer cleanup()
-		ctx := &ReleaseContext{
-			cluster:   cluster,
-			manifests: mockManifests,
-			repo:      checkout,
-			registry:  upToDateRegistry,
-		}
-		testRelease(t, tst.Name, ctx, tst.Spec, tst.Expected)
+		t.Run(tst.Name, func(t *testing.T) {
+			checkout, cleanup := setup(t)
+			defer cleanup()
+			ctx := &ReleaseContext{
+				cluster:   cluster,
+				manifests: mockManifests,
+				repo:      checkout,
+				registry:  upToDateRegistry,
+			}
+			testRelease(t, ctx, tst.Spec, tst.Expected)
+		})
 	}
 }
 
-func testRelease(t *testing.T, name string, ctx *ReleaseContext, spec update.ReleaseSpec, expected update.Result) {
+func testRelease(t *testing.T, ctx *ReleaseContext, spec update.ReleaseSpec, expected update.Result) {
 	results, err := Release(ctx, spec, log.NewNopLogger())
 	if err != nil {
 		t.Fatal(err)
@@ -433,7 +437,7 @@ func testRelease(t *testing.T, name string, ctx *ReleaseContext, spec update.Rel
 	if !reflect.DeepEqual(expected, results) {
 		exp, _ := json.Marshal(expected)
 		got, _ := json.Marshal(results)
-		t.Errorf("%s\n--- expected ---\n%s\n--- got ---\n%s\n", name, string(exp), string(got))
+		t.Errorf("--- expected ---\n%s\n--- got ---\n%s\n", string(exp), string(got))
 	}
 }
 

--- a/update/automated.go
+++ b/update/automated.go
@@ -107,12 +107,6 @@ func (a *Automated) calculateImageUpdates(rc ReleaseContext, candidates []*Contr
 				// the format of the image name as it is in the
 				// resource (e.g., to avoid canonicalising it)
 				newImageID := currentImageID.WithNewTag(change.ImageID.Tag)
-				var err error
-				u.ManifestBytes, err = rc.Manifests().UpdateImage(u.ManifestBytes, u.ResourceID, container.Name, newImageID)
-				if err != nil {
-					return nil, err
-				}
-
 				containerUpdates = append(containerUpdates, ContainerUpdate{
 					Container: container.Name,
 					Current:   currentImageID,

--- a/update/release.go
+++ b/update/release.go
@@ -251,12 +251,6 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 			// appears in the manifest, whereas what we have is the
 			// canonical form.
 			newImageID := currentImageID.WithNewTag(latestImage.ID.Tag)
-
-			u.ManifestBytes, err = rc.Manifests().UpdateImage(u.ManifestBytes, u.ResourceID, container.Name, newImageID)
-			if err != nil {
-				return nil, err
-			}
-
 			containerUpdates = append(containerUpdates, ContainerUpdate{
 				Container: container.Name,
 				Current:   currentImageID,

--- a/update/service.go
+++ b/update/service.go
@@ -7,12 +7,11 @@ import (
 )
 
 type ControllerUpdate struct {
-	ResourceID    flux.ResourceID
-	Controller    cluster.Controller
-	Resource      resource.Workload
-	ManifestPath  string
-	ManifestBytes []byte
-	Updates       []ContainerUpdate
+	ResourceID   flux.ResourceID
+	Controller   cluster.Controller
+	Resource     resource.Workload
+	ManifestPath string
+	Updates      []ContainerUpdate
 }
 
 type ControllerFilter interface {


### PR DESCRIPTION
Although the manifest update procedures can now deal with multidocs and List resources, the release code was still reading in *just* the bytes for the particular manifest, and writing that back to the original path. This meant that any multidoc or List resource file would get overwritten by the single manifest.

Thankfully, an alert user noticed that automated releases were failing verification -- this fixes #1136.
