### PR TITLE
Clean up fully after git clones

### DIFF
--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -54,9 +54,13 @@ func Repo(t *testing.T) (*git.Repo, func()) {
 		t.Fatal(err)
 	}
 
-	return git.NewRepo(git.Remote{
+	mirror := git.NewRepo(git.Remote{
 		URL: "file://" + gitDir,
-	}), cleanup
+	})
+	return mirror, func() {
+		mirror.Clean()
+		cleanup()
+	}
 }
 
 // CheckoutWithConfig makes a standard repo, clones it, and returns

--- a/git/operations.go
+++ b/git/operations.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"context"
@@ -32,7 +31,7 @@ func config(ctx context.Context, workingDir, user, email string) error {
 }
 
 func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path string, err error) {
-	repoPath := filepath.Join(workingDir, "repo")
+	repoPath := workingDir
 	args := []string{"clone"}
 	if repoBranch != "" {
 		args = append(args, "--branch", repoBranch)
@@ -45,7 +44,7 @@ func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path st
 }
 
 func mirror(ctx context.Context, workingDir, repoURL string) (path string, err error) {
-	repoPath := filepath.Join(workingDir, "repo")
+	repoPath := workingDir
 	args := []string{"clone", "--mirror"}
 	args = append(args, repoURL, repoPath)
 	if err := execGitCmd(ctx, workingDir, nil, args...); err != nil {

--- a/git/repo.go
+++ b/git/repo.go
@@ -101,6 +101,18 @@ func (r *Repo) Dir() string {
 	return r.dir
 }
 
+// Clean removes the mirrored repo. Syncing may continue with a new
+// directory, so you may need to stop that first.
+func (r *Repo) Clean() {
+	r.mu.Lock()
+	if r.dir != "" {
+		os.RemoveAll(r.dir)
+	}
+	r.dir = ""
+	r.status = RepoNew
+	r.mu.Unlock()
+}
+
 // Status reports that readiness status of this Git repo: whether it
 // has been cloned, whether it is writable, and if not, the error
 // stopping it getting to the next state.


### PR DESCRIPTION
For both mirrors (in git/repo.go) and working clones (in
git/working.go) we created a temp directory, then cloned into a
_subdirectory_ of that. But when tidying up, we deleted the
subdirectory -- leaving lots of empty temp directories around.

This changes mirroring and cloning so that they simply use the templ
directory. It also adds a `Clean` method to Repo, so that they can be
cleaned up after tests. Result: you should see no /tmp/flux-git*
directories after running the tests.