### PR TITLE
Make it easier to mount known_hosts from a ConfigMap in Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -99,6 +99,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `git.email` | Email to use as git committer | `support@weave.works`
 | `git.chartsPath` | Path within git repo to locate Helm charts (relative path) | `charts`
 | `git.pollInterval` | Period at which to poll git repo for new commits | `30s`
+| `ssh.known_hosts`  | The contents of an SSH `known_hosts` file, if you need to supply host key(s) |
 | `helmOperator.create` | If `true`, install the Helm operator | `false`
 | `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator` 
 | `helmOperator.tag` | Helm operator image tag | `0.1.0-alpha` 

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -23,6 +23,10 @@ spec:
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
       {{- end }}
       volumes:
+      - name: sshdir
+        configMap:
+          name: {{ template "flux.fullname" . }}-ssh-config
+          defaultMode: 0600
       - name: git-key
         secret:
           secretName: {{ template "flux.fullname" . }}-git-deploy
@@ -39,6 +43,9 @@ spec:
             containerPort: 3030
             protocol: TCP
           volumeMounts:
+          - name: sshdir
+            mountPath: /root/.ssh
+            readOnly: true
           - name: git-key
             mountPath: /etc/fluxd/ssh
             readOnly: true

--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "flux.fullname" . }}-ssh-config
+data:
+  known_hosts: {{ .Values.ssh.known_hosts }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -62,3 +62,8 @@ git:
   chartsPath: "charts"
   # Period at which to poll git repo for new commits
   pollInterval: "30s"
+
+ssh:
+  # Overrides for git over SSH. If you use your own git server, you
+  # will likely need to provide a host key for it in this field.
+  known_hosts: ""


### PR DESCRIPTION
Addresses #1113, and helps with #1101 by making the chart usable from the integration test (I think).

WIP until I've actually tried the Helm chart install myself.