### PR TITLE
Correct flags parsing and report errors

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -60,7 +60,7 @@ func optionalVar(fs *pflag.FlagSet, value ssh.OptionalValue, name, usage string)
 
 func main() {
 	// Flag domain.
-	fs := pflag.NewFlagSet("default", pflag.ExitOnError)
+	fs := pflag.NewFlagSet("default", pflag.ContinueOnError)
 	fs.Usage = func() {
 		fmt.Fprintf(os.Stderr, "DESCRIPTION\n")
 		fmt.Fprintf(os.Stderr, "  fluxd is the agent of flux.\n")
@@ -116,7 +116,12 @@ func main() {
 		dockerConfig = fs.String("docker-config", "", "path to a docker config to use for image registry credentials")
 	)
 
-	fs.Parse(os.Args)
+	if err := fs.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n\n", err.Error())
+		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
+		fs.PrintDefaults()
+		os.Exit(2)
+	}
 
 	if *versionFlag {
 		fmt.Println(version)


### PR DESCRIPTION
 - don't supply the executable name to `flagset.Parse(...)` (it was
   probably being treated as a non-flag arg, which we don't check for)

 - if flags fail to parse, instead of just exiting, report the error,
   print the usage, _then_ exit, so the term or logs will indicate why
   it exited.

Fixes #1144.