### PR TITLE
Use golang 1.10 in CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/weaveworks/flux
     docker:
-      - image: circleci/golang:1.8
+      - image: circleci/golang:1.10
       - image: memcached
     steps:
       - checkout


### PR DESCRIPTION
Apparently CircleCI has ended support for Go 1.8. We may as well leapfrog 1.9, to 1.10.