### PR TITLE
Revert "Clean up fully after git clones"

### DIFF
--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -54,13 +54,9 @@ func Repo(t *testing.T) (*git.Repo, func()) {
 		t.Fatal(err)
 	}
 
-	mirror := git.NewRepo(git.Remote{
+	return git.NewRepo(git.Remote{
 		URL: "file://" + gitDir,
-	})
-	return mirror, func() {
-		mirror.Clean()
-		cleanup()
-	}
+	}), cleanup
 }
 
 // CheckoutWithConfig makes a standard repo, clones it, and returns

--- a/git/operations.go
+++ b/git/operations.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"context"
@@ -31,7 +32,7 @@ func config(ctx context.Context, workingDir, user, email string) error {
 }
 
 func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path string, err error) {
-	repoPath := workingDir
+	repoPath := filepath.Join(workingDir, "repo")
 	args := []string{"clone"}
 	if repoBranch != "" {
 		args = append(args, "--branch", repoBranch)
@@ -44,7 +45,7 @@ func clone(ctx context.Context, workingDir, repoURL, repoBranch string) (path st
 }
 
 func mirror(ctx context.Context, workingDir, repoURL string) (path string, err error) {
-	repoPath := workingDir
+	repoPath := filepath.Join(workingDir, "repo")
 	args := []string{"clone", "--mirror"}
 	args = append(args, repoURL, repoPath)
 	if err := execGitCmd(ctx, workingDir, nil, args...); err != nil {

--- a/git/repo.go
+++ b/git/repo.go
@@ -101,18 +101,6 @@ func (r *Repo) Dir() string {
 	return r.dir
 }
 
-// Clean removes the mirrored repo. Syncing may continue with a new
-// directory, so you may need to stop that first.
-func (r *Repo) Clean() {
-	r.mu.Lock()
-	if r.dir != "" {
-		os.RemoveAll(r.dir)
-	}
-	r.dir = ""
-	r.status = RepoNew
-	r.mu.Unlock()
-}
-
 // Status reports that readiness status of this Git repo: whether it
 // has been cloned, whether it is writable, and if not, the error
 // stopping it getting to the next state.


### PR DESCRIPTION
Reverts weaveworks/flux#1138, so it can be merged into master again, since that merge didn't (and won't) complete its build in CI, because CircleCI apparently dropped Go 1.8 support over the weekend.