### PR TITLE
Put baked-in SSH config in /etc/ssh

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -22,14 +22,11 @@ RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 COPY --from=quay.io/squaremo/kubeyaml:0.3.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
-# Add git hosts to known hosts file so when git ssh's using the deploy
-# key we don't get an unknown host warning.
-RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && \
-    ssh-keyscan github.com gitlab.com bitbucket.org >> ~/.ssh/known_hosts && \
-    chmod 600 ~/.ssh/known_hosts
+# Add git hosts to known hosts file so we can use
+# StrickHostKeyChecking with git+ssh
+RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
 # Add default SSH config, which points at the private key we'll mount
-COPY ./ssh_config /root/.ssh/config
-RUN chmod 600 /root/.ssh/config
+COPY ./ssh_config /etc/ssh/ssh_config
 
 COPY ./kubectl /usr/local/bin/
 COPY ./fluxd /usr/local/bin/


### PR DESCRIPTION
To be able to use a self-hosted (or unaccounted for) git server, you have to be able to put its host key in known_hosts in the fluxd container. This is because we make sure `StrictHostKeyChecking` is enabled for SSH.

At present we bake SSH config (ssh_config and known_hosts) into the flux image at the user-specific location, that is `/root/.ssh/`. This makes it fiddly to override known_hosts by mounting a configmap, because you have to specify subPath (which stops Kubernetes from updating the file when the configmap changes), or supply both files.

If we put our baked-in config at the global location (`/etc/ssh`), people are free to mount a configmap at `/root/.ssh` without the limitations above. This means we can unconditionally mount a (probably empty) configmap in the example and in Helm charts.