### PR TITLE
Mount the sshdir into the helm-operator too

### DIFF
--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -24,6 +24,10 @@ spec:
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
       {{- end }}
       volumes:
+      - name: sshdir
+        configMap:
+          name: {{ template "flux.fullname" . }}-ssh-config
+          defaultMode: 0600
       - name: git-key
         secret:
           secretName: {{ template "flux.fullname" . }}-git-deploy
@@ -33,6 +37,10 @@ spec:
         image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
         imagePullPolicy: {{ .Values.helmOperator.pullPolicy }}
         volumeMounts:
+        - name: sshdir
+          mountPath: /root/.ssh/known_hosts
+          subPath: known_hosts
+          readOnly: true
         - name: git-key
           mountPath: /etc/fluxd/ssh
           readOnly: true

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -14,6 +14,14 @@ spec:
     spec:
       serviceAccount: flux
       volumes:
+      # The following volume is for using a customised known_hosts
+      # file file, which you will need to do if you host your own git
+      # repo rather than using github or the like. You'll also need to
+      # mount it into the container, below.
+      # - name: sshdir
+      #   configMap:
+      #     name: flux-ssh-config
+      #     defaultMode: 0600
       - name: git-key
         secret:
           secretName: flux-git-deploy
@@ -26,6 +34,12 @@ spec:
         image: quay.io/weaveworks/helm-operator:0.1.0-alpha
         imagePullPolicy: IfNotPresent
         volumeMounts:
+        # Include this if you need to mount a customised known_hosts
+        # file; you'll also need the volume declared above.
+        # - name: sshdir
+        # mountPath: /root/.ssh/known_hosts
+        # subPath: known_hosts
+        # readOnly: true
         - name: git-key
           mountPath: /etc/fluxd/ssh
           readOnly: true # this will be the case perforce in K8s >=1.10


### PR DESCRIPTION
What is this MR for ?

- Mounting the sshdir into the helm operator container

- The known_hosts is only mounted in the flux container thus far.

I'm not 100% sure that the `known_hosts` are meant to be available in the `helm-operator` but 
my guess is that they are. Perhaps someone can confirm?