### PR TITLE
Include more information re "git repo not ready"

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -81,8 +81,9 @@ func (d *Daemon) getPolicyResourceMap(ctx context.Context) (policy.ResourceMap, 
 
 	// The reason something is missing from the map differs depending
 	// on the state of the git repo.
+	_, notReady := err.(git.NotReadyError)
 	switch {
-	case err == git.ErrNotReady:
+	case notReady:
 		globalReadOnly = v6.ReadOnlyNotReady
 	case err == git.ErrNoConfig:
 		globalReadOnly = v6.ReadOnlyNoRepo

--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -108,17 +108,14 @@ func execCommand(cmd string, args ...string) error {
 }
 
 func WaitForRepoReady(r *git.Repo, t *testing.T) {
-	retries := 5
+	retries := 30
 	for {
-		s, err := r.Status()
-		if err != nil {
-			t.Fatal(err)
-		}
+		s, _ := r.Status()
 		if s == git.RepoReady {
 			return
 		}
 		if retries == 0 {
-			t.Fatalf("repo was not ready after 5 seconds")
+			t.Fatalf("repo was not ready after 3 seconds")
 			return
 		}
 		retries--

--- a/git/repo.go
+++ b/git/repo.go
@@ -123,8 +123,8 @@ func (r *Repo) Clean() {
 }
 
 // Status reports that readiness status of this Git repo: whether it
-// has been cloned, whether it is writable, and if not, the error
-// stopping it getting to the next state.
+// has been cloned and is writable, and if not, the error stopping it
+// getting to the next state.
 func (r *Repo) Status() (GitRepoStatus, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()


### PR DESCRIPTION
Setting up git can be quite fiddly. One thing that would make it easier to troubleshoot is if fluxd did a better job of logging why it hadn't cloned the git repo yet.

This commit introduces a struct for not-ready-errors, so they can include the underlying problem. Since we now _expect_ there to be an underlying reason, create errors for "just haven't tried yet", and enforce the invariant of `not ready -> has error`.

Fixes #1170.