### PR TITLE
Documentation updates.

### DIFF
--- a/site/standalone/installing.md
+++ b/site/standalone/installing.md
@@ -133,6 +133,15 @@ export FLUX_URL="http://$(minikube ip):$fluxport/api/flux"
 fluxctl list-controllers --all-namespaces
 ```
 
+### Remote endpoint
+
+```
+export POD_NAME=$(kubectl get pods --namespace default -l "name=flux" -o jsonpath="{.items[0].metadata.name}")
+kubectl port-forward $POD_NAME 3030:3030
+export FLUX_URL="http://127.0.0.1:3030/api/flux"
+fluxctl list-controllers --all-namespaces
+```
+
 ## fluxctl
 
 This allows you to control Flux from the command line, and if you're

--- a/site/standalone/setup.md
+++ b/site/standalone/setup.md
@@ -39,8 +39,12 @@ manifest.
 
 ## Add an SSH deploy key to the repository
 
-Flux connects to the repository using an SSH key. You have two
-options:
+Flux connects to the repository using an SSH key.
+
+***The SSH key must be configured to have R/W access to the repository*** because flux writes tags to the repository on
+sync.
+ 
+You have two options:
 
 ### 1. Allow flux to generate a key for you.
 

--- a/site/standalone/setup.md
+++ b/site/standalone/setup.md
@@ -41,8 +41,7 @@ manifest.
 
 Flux connects to the repository using an SSH key.
 
-***The SSH key must be configured to have R/W access to the repository*** because flux writes tags to the repository on
-sync.
+***The SSH key must be configured to have R/W access to the repository***.
  
 You have two options:
 


### PR DESCRIPTION
- Make it clear that SSH key should have R/W access.
- Add snippet to show how to use fluxctl on your remote cluster.