### PR TITLE
Helm: support FHRs that mention more than one image

### DIFF
--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.3.1 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.3.2 "$@"

--- a/cluster/kubernetes/resource/fluxhelmrelease_test.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease_test.go
@@ -1,0 +1,111 @@
+package resource
+
+import (
+	"testing"
+
+	"github.com/weaveworks/flux/resource"
+)
+
+func TestParseSimpleFormat(t *testing.T) {
+	expectedImage := "bitnami/mariadb:10.1.30-r1"
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    image: ` + expectedImage + `
+    persistence:
+      enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+}
+
+func TestParseLessSimpleFormat(t *testing.T) {
+	expectedContainer := "db"
+	expectedImage := "bitnami/mariadb:10.1.30-r1"
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    ` + expectedContainer + `:
+      image: ` + expectedImage + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+
+	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
+		t.Error(err)
+	}
+
+	containers = fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image = containers[0].Image.String()
+	if image != newImage.String() {
+		t.Errorf("expected container image %q, got %q", newImage.String(), image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}

--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -333,13 +333,13 @@ func makeFluxHelmReleasePodController(fluxHelmRelease *fhr_v1alpha2.FluxHelmRele
 // interpreting the FluxHelmRelease resource. The interpretation is
 // analogous to that in cluster/kubernetes/resource/fluxhelmrelease.go
 func createK8sFHRContainers(spec fhr_v1alpha2.FluxHelmReleaseSpec) []apiv1.Container {
-	values := spec.Values
-	if imgInfo, ok := values["image"]; ok {
-		if imgInfoStr, ok := imgInfo.(string); ok {
-			return []apiv1.Container{
-				{Name: kresource.ReleaseContainerName, Image: imgInfoStr},
-			}
-		}
-	}
-	return nil
+	var containers []apiv1.Container
+	_ = kresource.FindFluxHelmReleaseContainers(spec.Values, func(name string, image image.Ref, _ kresource.ImageSetter) error {
+		containers = append(containers, apiv1.Container{
+			Name:  kresource.ReleaseContainerName,
+			Image: image.String(),
+		})
+		return nil
+	})
+	return containers
 }

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -50,6 +50,7 @@ func TestUpdates(t *testing.T) {
 		{"in multidoc", case9resource, case9containers, case9image, case9, case9out},
 		{"in kubernetes List resource", case10resource, case10containers, case10image, case10, case10out},
 		{"FluxHelmRelease (simple image encoding)", case11resource, case11containers, case11image, case11, case11out},
+		{"FluxHelmRelease (multi image encoding)", case12resource, case12containers, case12image, case12, case12out},
 	} {
 		t.Run(c.name, func(t *testing.T) {
 			testUpdate(t, c)
@@ -821,4 +822,47 @@ spec:
     image: bitnami/mariadb:10.1.33
     persistence:
       enabled: false
+`
+
+const case12 = `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    mariadb:
+      image: bitnami/mariadb:10.1.30-r1
+      persistence:
+        enabled: false
+    sidecar:
+      image: sidecar:v1
+`
+
+const case12resource = "maria:fluxhelmrelease/mariadb"
+const case12image = "bitnami/mariadb:10.1.33"
+
+var case12containers = []string{"mariadb"}
+
+const case12out = `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    mariadb:
+      image: bitnami/mariadb:10.1.33
+      persistence:
+        enabled: false
+    sidecar:
+      image: sidecar:v1
 `

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -19,7 +19,7 @@ ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.3.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.3.2 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 # Add git hosts to known hosts file so we can use


### PR DESCRIPTION
kubeyaml 0.3.2 supports updating the images in a FluxHelmRelease when they are given in the format:

```
spec:
  values:
    somename:
      image: repo/image:tag
    othername:
      image: repo/image:tag
```

This PR bumps the version of kubeyaml in the two places it's mentioned -- the docker file, and the shim script -- and adds a test that the update code, invoking kubeyaml actually does update an FHR given in that format.

It also adapts kubernetes/resource and kubernetes/ so that the internal model of resources in the repo and in the cluster understand how to interpret FHRs in the same way as kubeyaml does.

Fixes #1175.