### PR TITLE
Update pflag to avoid flag parsing gotchas

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -383,8 +383,8 @@
 [[projects]]
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "e57e3eeb33f795204c1ca35f56c44f83227c6e66"
-  version = "v1.0.0"
+  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
+  version = "v1.0.1"
 
 [[projects]]
   name = "github.com/src-d/gcfg"

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -116,14 +116,15 @@ func main() {
 		dockerConfig = fs.String("docker-config", "", "path to a docker config to use for image registry credentials")
 	)
 
-	if err := fs.Parse(os.Args[1:]); err != nil {
+	err := fs.Parse(os.Args[1:])
+	switch {
+	case err == pflag.ErrHelp:
+		os.Exit(0)
+	case err != nil:
 		fmt.Fprintf(os.Stderr, "Error: %s\n\n", err.Error())
-		fmt.Fprintf(os.Stderr, "Usage of %s:\n", os.Args[0])
-		fs.PrintDefaults()
+		fs.Usage()
 		os.Exit(2)
-	}
-
-	if *versionFlag {
+	case *versionFlag:
 		fmt.Println(version)
 		os.Exit(0)
 	}


### PR DESCRIPTION
github.com/spf13/pflag has moderately wacky error handling, which it
probably inherited from `flag` in stdlib.

You can either choose to let it handle flag parsing errors for you, by
printing the error and usage then exiting (`ExitOnError`); or, return
them to you so you can decide what to do (`ContinueOnError`).

The revision of pflag we were using (in the first mode) was silent in
the case that parsing a flag _value_ failed -- so we changed to use
the second mode, and handled errors by printing the usage
ourselves. However, it wasn't silent in other cases, meaning we would
output the usage twice (including if you used the `--help` flag).

The newer revision of pflag 1. doesn't output usage if you've told it
you'll handle errors, and 2. doesn't remain silent when it fails to
parse a value. So it would work for us in either mode; since we're
already using ContinueOnError, just tidy that up.

Fixes #1176.
