### PR TITLE
Add --k8s-namespace-whitelist setting that specifies namespaces to watch.

### DIFF
--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -175,7 +175,7 @@ func (c *Cluster) SomeControllers(ids []flux.ResourceID) (res []cluster.Controll
 // AllControllers returns all controllers matching the criteria; that is, in
 // the namespace (or any namespace if that argument is empty)
 func (c *Cluster) AllControllers(namespace string) (res []cluster.Controller, err error) {
-	namespaces, err := c.getNamespaces()
+	namespaces, err := c.getAllowedNamespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting namespaces")
 	}
@@ -261,7 +261,7 @@ func (c *Cluster) Ping() error {
 func (c *Cluster) Export() ([]byte, error) {
 	var config bytes.Buffer
 
-	namespaces, err := c.getNamespaces()
+	namespaces, err := c.getAllowedNamespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting namespaces")
 	}
@@ -375,7 +375,7 @@ func mergeCredentials(c *Cluster, namespace string, podTemplate apiv1.PodTemplat
 func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 	allImageCreds := make(registry.ImageCreds)
 
-	namespaces, err := c.getNamespaces()
+	namespaces, err := c.getAllowedNamespaces()
 	if err != nil {
 		c.logger.Log("err", errors.Wrap(err, "getting namespaces"))
 		return allImageCreds
@@ -413,12 +413,12 @@ func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 	return allImageCreds
 }
 
-// getNamespaces returns a list of namespaces that the Flux instance is expected
+// getAllowedNamespaces returns a list of namespaces that the Flux instance is expected
 // to have access to and can look for resources inside of.
 // It returns a list of all namespaces unless a namespace whitelist has been set on the Cluster
 // instance, in which case it returns a list containing the namespaces from the whitelist
 // that exist in the cluster.
-func (c *Cluster) getNamespaces() ([]apiv1.Namespace, error) {
+func (c *Cluster) getAllowedNamespaces() ([]apiv1.Namespace, error) {
 	nsList := []apiv1.Namespace{}
 
 	namespaces, err := c.client.Namespaces().List(meta_v1.ListOptions{})

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -170,13 +170,13 @@ func (c *Cluster) SomeControllers(ids []flux.ResourceID) (res []cluster.Controll
 // AllControllers returns all controllers matching the criteria; that is, in
 // the namespace (or any namespace if that argument is empty)
 func (c *Cluster) AllControllers(namespace string) (res []cluster.Controller, err error) {
-	namespaces, err := c.client.Namespaces().List(meta_v1.ListOptions{})
+	namespaces, err := c.getNamespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting namespaces")
 	}
 
 	var allControllers []cluster.Controller
-	for _, ns := range namespaces.Items {
+	for _, ns := range namespaces {
 		if namespace != "" && ns.Name != namespace {
 			continue
 		}

--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -1,0 +1,62 @@
+package kubernetes
+
+import (
+	apiv1 "k8s.io/api/core/v1"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakekubernetes "k8s.io/client-go/kubernetes/fake"
+	"testing"
+	"reflect"
+)
+
+func newNamespace(name string) *apiv1.Namespace {
+	return &apiv1.Namespace{
+		ObjectMeta: meta_v1.ObjectMeta{
+			Name: name,
+		},
+		TypeMeta: meta_v1.TypeMeta{
+			APIVersion: "v1",
+			Kind: "Namespace",
+		},
+	}
+}
+
+func testGetNamespaces(t *testing.T, namespace []string, expected []string) {
+	clientset := fakekubernetes.NewSimpleClientset(newNamespace("default"),
+		newNamespace("kube-system"))
+
+	c := NewCluster(clientset, nil, nil, nil, nil, namespace)
+
+	namespaces, err := c.getNamespaces()
+	if err != nil {
+		t.Errorf("The error should be nil, not: %s", err)
+	}
+
+	result := []string{}
+	for _, namespace := range namespaces {
+		result = append(result, namespace.ObjectMeta.Name)
+	}
+
+	if reflect.DeepEqual(result, expected) != true {
+		t.Errorf("Unexpected namespaces: %v != %v.", result, expected)
+	}
+}
+
+func TestGetNamespacesDefault(t *testing.T) {
+	testGetNamespaces(t, []string{}, []string{"default","kube-system",})
+}
+
+func TestGetNamespacesNamespacesIsNil(t *testing.T) {
+	testGetNamespaces(t, nil, []string{"default","kube-system",})
+}
+
+func TestGetNamespacesNamespacesSet(t *testing.T) {
+	testGetNamespaces(t, []string{"default"}, []string{"default",})
+}
+
+func TestGetNamespacesNamespacesSetDoesNotExist(t *testing.T) {
+	testGetNamespaces(t, []string{"hello"}, []string{})
+}
+
+func TestGetNamespacesNamespacesMultiple(t *testing.T) {
+	testGetNamespaces(t, []string{"default","hello","kube-system"}, []string{"default","kube-system"})
+}

--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -20,13 +20,13 @@ func newNamespace(name string) *apiv1.Namespace {
 	}
 }
 
-func testGetNamespaces(t *testing.T, namespace []string, expected []string) {
+func testGetAllowedNamespaces(t *testing.T, namespace []string, expected []string) {
 	clientset := fakekubernetes.NewSimpleClientset(newNamespace("default"),
 		newNamespace("kube-system"))
 
 	c := NewCluster(clientset, nil, nil, nil, nil, namespace)
 
-	namespaces, err := c.getNamespaces()
+	namespaces, err := c.getAllowedNamespaces()
 	if err != nil {
 		t.Errorf("The error should be nil, not: %s", err)
 	}
@@ -41,22 +41,22 @@ func testGetNamespaces(t *testing.T, namespace []string, expected []string) {
 	}
 }
 
-func TestGetNamespacesDefault(t *testing.T) {
-	testGetNamespaces(t, []string{}, []string{"default","kube-system",})
+func TestGetAllowedNamespacesDefault(t *testing.T) {
+	testGetAllowedNamespaces(t, []string{}, []string{"default","kube-system",})
 }
 
-func TestGetNamespacesNamespacesIsNil(t *testing.T) {
-	testGetNamespaces(t, nil, []string{"default","kube-system",})
+func TestGetAllowedNamespacesNamespacesIsNil(t *testing.T) {
+	testGetAllowedNamespaces(t, nil, []string{"default","kube-system",})
 }
 
-func TestGetNamespacesNamespacesSet(t *testing.T) {
-	testGetNamespaces(t, []string{"default"}, []string{"default",})
+func TestGetAllowedNamespacesNamespacesSet(t *testing.T) {
+	testGetAllowedNamespaces(t, []string{"default"}, []string{"default",})
 }
 
-func TestGetNamespacesNamespacesSetDoesNotExist(t *testing.T) {
-	testGetNamespaces(t, []string{"hello"}, []string{})
+func TestGetAllowedNamespacesNamespacesSetDoesNotExist(t *testing.T) {
+	testGetAllowedNamespaces(t, []string{"hello"}, []string{})
 }
 
-func TestGetNamespacesNamespacesMultiple(t *testing.T) {
-	testGetNamespaces(t, []string{"default","hello","kube-system"}, []string{"default","kube-system"})
+func TestGetAllowedNamespacesNamespacesMultiple(t *testing.T) {
+	testGetAllowedNamespaces(t, []string{"default","hello","kube-system"}, []string{"default","kube-system"})
 }

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -105,6 +105,7 @@ func main() {
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "Name of the k8s secret used to store the private SSH key")
 		k8sSecretVolumeMountPath = fs.String("k8s-secret-volume-mount-path", "/etc/fluxd/ssh", "Mount location of the k8s secret storing the private SSH key")
 		k8sSecretDataKey         = fs.String("k8s-secret-data-key", "identity", "Data key holding the private SSH key within the k8s secret")
+		k8sNamespaceWhitelist = fs.StringSlice("k8s-namespace-whitelist", []string{}, "Experimental, optional: restrict the view of the cluster to the namespaces listed. All namespaces are included if this is not set.")
 		// SSH key generation
 		sshKeyBits   = optionalVar(fs, &ssh.KeyBitsValue{}, "ssh-keygen-bits", "-b argument to ssh-keygen (default unspecified)")
 		sshKeyType   = optionalVar(fs, &ssh.KeyTypeValue{}, "ssh-keygen-type", "-t argument to ssh-keygen (default unspecified)")
@@ -114,7 +115,6 @@ func main() {
 		token       = fs.String("token", "", "Authentication token for upstream service")
 
 		dockerConfig = fs.String("docker-config", "", "path to a docker config to use for image registry credentials")
-		k8sNamespaceWhitelist = fs.StringSlice("k8s-namespace-whitelist", []string{}, "Optional, comma separated list of namespaces to monitor for workloads")
 	)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -114,6 +114,7 @@ func main() {
 		token       = fs.String("token", "", "Authentication token for upstream service")
 
 		dockerConfig = fs.String("docker-config", "", "path to a docker config to use for image registry credentials")
+		k8sNamespaceWhitelist = fs.StringSlice("k8s-namespace-whitelist", []string{}, "Optional, comma separated list of namespaces to monitor for workloads")
 	)
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -241,7 +242,7 @@ func main() {
 		logger.Log("kubectl", kubectl)
 
 		kubectlApplier := kubernetes.NewKubectl(kubectl, restClientConfig)
-		k8sInst := kubernetes.NewCluster(clientset, ifclientset, kubectlApplier, sshKeyRing, logger)
+		k8sInst := kubernetes.NewCluster(clientset, ifclientset, kubectlApplier, sshKeyRing, logger, *k8sNamespaceWhitelist)
 
 		if err := k8sInst.Ping(); err != nil {
 			logger.Log("ping", err)

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -70,6 +70,9 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--k8s-secret-name       | `flux-git-deploy`               | name of the k8s secret used to store the private SSH key|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|
 |--k8s-secret-data-key   | `identity`                      | data key holding the private SSH key within the k8s secret|
+|**k8s configuration**   |                            |  | |
+|--k8s-namespace-whitelist|                                | optional, comma separated list of namespaces to monitor for workloads (default: all namespaces)|
+|**upstream service**    |                            |  | |
 |--connect               |                               | connect to an upstream service e.g., Weave Cloud, at this base address|
 |--token                 |                               | authentication token for upstream service|
 |**SSH key generation**  |                               | |

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -71,7 +71,7 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|
 |--k8s-secret-data-key   | `identity`                      | data key holding the private SSH key within the k8s secret|
 |**k8s configuration**   |                            |  | |
-|--k8s-namespace-whitelist|                                | optional, comma separated list of namespaces to monitor for workloads (default: all namespaces)|
+|--k8s-namespace-whitelist|                                | Experimental, optional: restrict the view of the cluster to the namespaces listed. All namespaces are included if this is not set.|
 |**upstream service**    |                            |  | |
 |--connect               |                               | connect to an upstream service e.g., Weave Cloud, at this base address|
 |--token                 |                               | authentication token for upstream service|


### PR DESCRIPTION
Add --k8s-namespace-whitelist setting that specifies namespaces to watch.
    
Fixes #1181
    
Currently, Flux expects to have access to all namespaces, even if no manifests
in the repository reference another namespace, it will check all namespaces
for controllers to update.
    
This change adds a --k8s-namespace-whitelist setting which, if set, will restrict
Flux to only watch the specified namespaces and ignore all others.
    
Intended for clusters with large amounts of namespaces or restrictive RBAC
policies. If provided Flux will only monitor workloads in the given namespaces.
This significantly cuts the number of API calls made.
    
An empty list (i.e. not provided) yields the usual behaviour.