### PR TITLE
Adds --k8s-namespace-whitelist cli option

### DIFF
--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -1,0 +1,79 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/go-kit/kit/log"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func kubeTestSetup(t *testing.T, nsWhitelist []string) (*Cluster, apiv1.NamespaceList) {
+	kube := &Cluster{
+		applier: nil,
+		logger:  log.NewNopLogger(),
+		nsWhitelist: nsWhitelist,
+	}
+
+	// Create a new API object from scratch each time
+	namespaces := []apiv1.Namespace{}
+	for _, nsName := range testNamespaces {
+		namespaces = append(namespaces, apiv1.Namespace{
+			TypeMeta: v1.TypeMeta{
+				Kind: "Namespace",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name: nsName,
+			},
+		})
+	}
+	namespaceList :=  apiv1.NamespaceList{Items: namespaces}
+	return kube, namespaceList
+}
+
+func TestFilterNamespacesEmptyFilter(t *testing.T) {
+	kube, namespaces := kubeTestSetup(t, []string{})
+
+	kube.filterNamespaces(&namespaces)
+	for i, _ := range testNamespaces {
+		filteredName := namespaces.Items[i].Name
+		unfilteredName := testNamespaces[i]
+		if filteredName != unfilteredName {
+			t.Errorf("expected namespace '%s' but found '%s'", unfilteredName, filteredName)
+		}
+	}
+}
+
+func TestFilterNamespacesOneNamespace(t *testing.T) {
+	kube, namespaces := kubeTestSetup(t, []string{"namespace2"})
+
+	kube.filterNamespaces(&namespaces)
+
+	if len(namespaces.Items) != 1 {
+		t.Errorf("expected 1 namespace but got %d - %#v", len(namespaces.Items), namespaces.Items)
+	}
+	if namespaces.Items[0].Name != "namespace2" {
+		t.Errorf("expected namespace 'namespace2' but was '%s'", namespaces.Items[0].Name)
+	}
+}
+
+func TestFilterNamespacesTwoNamespaces(t *testing.T) {
+	kube, namespaces := kubeTestSetup(t, []string{"namespace2", "namespace1"})
+
+	kube.filterNamespaces(&namespaces)
+
+	if len(namespaces.Items) != 2 {
+		t.Errorf("expected 2 namespaces but got %d - %#v", len(namespaces.Items), namespaces.Items)
+	}
+	for i, expected := range []string{"namespace1", "namespace2"} {
+		if namespaces.Items[i].Name != expected {
+			t.Errorf("expected list element %d to be '%s' but was '%s'", i, expected, namespaces.Items[0].Name)
+		}
+	}
+}
+
+var testNamespaces = [...]string{
+	"namespace1",
+	"namespace2",
+	"namespace3",
+}

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -105,6 +105,8 @@ func main() {
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "Name of the k8s secret used to store the private SSH key")
 		k8sSecretVolumeMountPath = fs.String("k8s-secret-volume-mount-path", "/etc/fluxd/ssh", "Mount location of the k8s secret storing the private SSH key")
 		k8sSecretDataKey         = fs.String("k8s-secret-data-key", "identity", "Data key holding the private SSH key within the k8s secret")
+		// k8s namespace whitelist for clusters with large amounts of namespaces
+		k8sNamespaceWhitelist    = fs.StringSlice("k8s-namespace-whitelist", []string{}, "Optional, comma separated list of namespaces to monitor for workloads")
 		// SSH key generation
 		sshKeyBits   = optionalVar(fs, &ssh.KeyBitsValue{}, "ssh-keygen-bits", "-b argument to ssh-keygen (default unspecified)")
 		sshKeyType   = optionalVar(fs, &ssh.KeyTypeValue{}, "ssh-keygen-type", "-t argument to ssh-keygen (default unspecified)")
@@ -241,7 +243,7 @@ func main() {
 		logger.Log("kubectl", kubectl)
 
 		kubectlApplier := kubernetes.NewKubectl(kubectl, restClientConfig)
-		k8sInst := kubernetes.NewCluster(clientset, ifclientset, kubectlApplier, sshKeyRing, logger)
+		k8sInst := kubernetes.NewCluster(clientset, ifclientset, kubectlApplier, sshKeyRing, logger, *k8sNamespaceWhitelist)
 
 		if err := k8sInst.Ping(); err != nil {
 			logger.Log("ping", err)

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -70,6 +70,9 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--k8s-secret-name       | `flux-git-deploy`               | name of the k8s secret used to store the private SSH key|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|
 |--k8s-secret-data-key   | `identity`                      | data key holding the private SSH key within the k8s secret|
+|**k8s configuration**   |                            |  | |
+|--k8s-namespace-whitelist|                                | optional, comma separated list of namespaces to monitor for workloads (default: all namespaces)|
+|**upstream service**    |                            |  | |
 |--connect               |                               | connect to an upstream service e.g., Weave Cloud, at this base address|
 |--token                 |                               | authentication token for upstream service|
 |**SSH key generation**  |                               | |


### PR DESCRIPTION
Fixes #1181 

Intended for clusters with large amounts of namespaces. If provided Flux
will only monitor workloads in the given namespaces. This significantly
cuts the number of API calls made.

An empty list (i.e. not provided) yields the usual behaviour.