### PR TITLE
helm-op: Add git hosts to known hosts in /etc/ssh/ssh_known_hosts

### DIFF
--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -19,14 +19,11 @@ ENTRYPOINT [ "/sbin/tini", "--", "helm-operator" ]
 
 RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
-# Add git hosts to known hosts file so when git ssh's using the deploy
-# key we don't get an unknown host warning.
-RUN mkdir ~/.ssh && touch ~/.ssh/known_hosts && \
-    ssh-keyscan github.com gitlab.com bitbucket.org >> ~/.ssh/known_hosts && \
-    chmod 600 ~/.ssh/known_hosts
+# Add git hosts to known hosts file so we can use
+# StrickHostKeyChecking with git+ssh
+RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
 # Add default SSH config, which points at the private key we'll mount
-COPY ./ssh_config /root/.ssh/config
-RUN chmod 600 /root/.ssh/config
+COPY ./ssh_config /etc/ssh/ssh_config
 
 COPY ./kubectl /usr/local/bin/
 COPY ./helm-operator /usr/local/bin/


### PR DESCRIPTION
Port the know hosts changes from Flux to Flux Helm Operator ref #1154