### PR TITLE
change sshdir mount path to /etc/ssh/ssh_known_hosts

### DIFF
--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -38,8 +38,8 @@ spec:
         imagePullPolicy: {{ .Values.helmOperator.pullPolicy }}
         volumeMounts:
         - name: sshdir
-          mountPath: /root/.ssh/known_hosts
-          subPath: known_hosts
+          mountPath: /etc/ssh/ssh_known_hosts
+          subPath: ssh_known_hosts
           readOnly: true
         - name: git-key
           mountPath: /etc/fluxd/ssh

--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -3,4 +3,4 @@ kind: ConfigMap
 metadata:
   name: {{ template "flux.fullname" . }}-ssh-config
 data:
-  known_hosts: {{ .Values.ssh.known_hosts }}
+  ssh_known_hosts: {{ .Values.ssh.known_hosts }}

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -37,8 +37,8 @@ spec:
         # Include this if you need to mount a customised known_hosts
         # file; you'll also need the volume declared above.
         # - name: sshdir
-        # mountPath: /root/.ssh/known_hosts
-        # subPath: known_hosts
+        # mountPath: /etc/ssh/ssh_known_hosts
+        # subPath: ssh_known_hosts
         # readOnly: true
         - name: git-key
           mountPath: /etc/fluxd/ssh


### PR DESCRIPTION
What does this PR do?

- Changes the mount path for known_hosts

Why is this PR needed?

- To bring the helm templates inline with the changes to the Dockerfile
in PR #1188.