### PR TITLE
Make a separate changelog for the Helm operator

### DIFF
--- a/CHANGELOG-helmop.md
+++ b/CHANGELOG-helmop.md
@@ -1,0 +1,12 @@
+## 0.1.0-alpha (2018-05-01)
+
+First versioned release of the Flux Helm operator. The target features are:
+
+ - release Helm charts as specified in FluxHelmRelease resources
+   - these refer to charts in a single git repo, readable by the operator
+   - update releases when either the FluxHelmRelease resource or the
+     chart (in git) changes
+
+See
+https://github.com/weaveworks/flux/blob/helm-0.1.0-alpha/site/helm/
+for more detailed explanations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+This is the changelog for the Flux daemon; the changelog for the Helm
+operator is in [./CHANGELOG-helmop.md](./CHANGELOG-helmop.md).
+
 ## 1.4.1 (2018-06-21)
 
 This release fixes some wrinkles in the new YAML updating code, so
@@ -120,7 +123,9 @@ reindent blocks the first time it changes a file.
 
 ### Experimental
 
-- Alpha release of [helm-operator](https://github.com/weaveworks/flux/blob/master/site/helm/helm-integration.md)
+- Alpha release of
+  [helm-operator](https://github.com/weaveworks/flux/blob/master/site/helm/helm-integration.md). See
+  [./CHANGELOG-helmop.md](./CHANGELOG-helmop.md) for future releases.
 
 ## 1.2.3 (2018-02-07)
 


### PR DESCRIPTION
We have separate releases for the Helm operator, so we should have a separate changelog (which are really release notes).