### PR TITLE
fix git-url to use proper ssh:// url, reindent helm/installing.md

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -26,7 +26,7 @@ To install the chart with the release name `flux`:
 
 ```console
 $ helm install --name flux \
---set git.url=git@github.com:weaveworks/flux-example \
+--set git.url=ssh://git@github.com/weaveworks/flux-example \
 --namespace flux \
 weaveworks/flux
 ```
@@ -44,7 +44,7 @@ To install Flux with the Helm operator (alpha version):
 
 ```console
 $ helm install --name flux \
---set git.url=git@github.com:weaveworks/flux-helm-test \
+--set git.url=ssh://git@github.com/weaveworks/flux-helm-test \
 --set helmOperator.create=true \
 --namespace flux \
 weaveworks/flux
@@ -110,7 +110,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 
 ```console
 $ helm upgrade --install --wait flux \
---set git.url=git@github.com:stefanprodan/podinfo \
+--set git.url=ssh://git@github.com/stefanprodan/podinfo \
 --set git.path=deploy/auto-scaling \
 --namespace flux \
 weaveworks/flux

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -48,7 +48,7 @@ tolerations: []
 affinity: {}
 
 git:
-  # URL of git repo with Kubernetes manifests; e.g. git@github.com:weaveworks/flux-example
+  # URL of git repo with Kubernetes manifests; e.g. git.url=ssh://git@github.com/weaveworks/flux-example
   url: ""
   # Branch of git repo to use for Kubernetes manifests
   branch: "master"

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -45,6 +45,6 @@ spec:
           readOnly: true # this will be the case perforce in K8s >=1.10
         args:
         # replace (at least) the following URL
-        - --git-url=git@github.com:weaveworks/flux-helm-test
+        - --git-url=ssh://git@github.com/weaveworks/flux-helm-test
         - --git-branch=master
         - --git-charts-path=charts

--- a/site/helm/helm-integration.md
+++ b/site/helm/helm-integration.md
@@ -73,7 +73,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--tillerPort            |                               | Tiller port.|
 |--tillerNamespace       |                               | Tiller namespace. If not provided, the default is kube-system.|
 |                        |                               | **Git repo & key etc.**|
-|--git-url               |                               | URL of git repo with Helm Charts; e.g., `git@github.com:weaveworks/flux-example`|
+|--git-url               |                               | URL of git repo with Helm Charts; e.g., `ssh://git@github.com/weaveworks/flux-example`|
 |--git-branch            | `master`                      | Branch of git repo to use for Kubernetes manifests|
 |--git-charts-path       | `charts`                      | Path within git repo to locate Kubernetes Charts (relative path)|
 |                        |                               | **repo chart changes** (none of these need overriding, usually) |

--- a/site/helm/installing.md
+++ b/site/helm/installing.md
@@ -27,8 +27,9 @@ Download Helm:
   ```
 
 - On Linux:
-  - Download the [latest release](https://github.com/kubernetes/helm/releases/latest), unpack the
-    tarball and put the binary in your `$PATH`.
+  - Download the [latest
+    release](https://github.com/kubernetes/helm/releases/latest),
+    unpack the tarball and put the binary in your `$PATH`.
 
 Now create a service account and a cluster role binding for Tiller:
 
@@ -59,19 +60,18 @@ In this next step you install Weave Flux using `helm`. Simply:
  1. Fork [flux-helm-test](https://github.com/weaveworks/flux-helm-test)
     on Github and
  1. install Weave Flux and its Helm Operator by specifying your fork
-    URL.
+    URL:
 
-*Just make sure you replace `YOURUSER` with your GitHub username in
-the command below:*
-
-```sh
-helm install --name flux \
---set helmOperator.create=true \
---set git.url=git@github.com:YOURUSER/flux-helm-test \
---set git.chartsPath=charts \
---namespace flux \
-weaveworks/flux
-```
+    *Just make sure you replace `YOURUSER` with your GitHub username
+    in the command below:*
+    ```sh
+    helm install --name flux \
+    --set helmOperator.create=true \
+    --set git.url=ssh://git@github.com/YOURUSER/flux-helm-test \
+    --set git.chartsPath=charts \
+    --namespace flux \
+    weaveworks/flux
+    ```
 
 Allow some time for all containers to get up and running. If you're
 impatient, run the following command and see the pod creation


### PR DESCRIPTION
This is fixing the docs section wrt #1132 (and fixes the indentation of one doc).