### PR TITLE
Optimize Docker cache usage for flux and helm-operator docker images.

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,5 +1,17 @@
 FROM alpine:3.6
 
+WORKDIR /home/flux
+
+RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
+
+# Add git hosts to known hosts file so we can use
+# StrickHostKeyChecking with git+ssh
+RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
+# Add default SSH config, which points at the private key we'll mount
+COPY ./ssh_config /etc/ssh/ssh_config
+
+COPY ./kubectl /usr/local/bin/
+
 # These are pretty static
 LABEL maintainer="Weaveworks <help@weave.works>" \
       org.opencontainers.image.title="flux" \
@@ -14,22 +26,13 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
       org.label-schema.vcs-url="git@github.com:weaveworks/flux" \
       org.label-schema.vendor="Weaveworks"
 
-WORKDIR /home/flux
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
 # Get the kubeyaml binary (files) and put them on the path
 COPY --from=quay.io/squaremo/kubeyaml:0.3.2 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
-# Add git hosts to known hosts file so we can use
-# StrickHostKeyChecking with git+ssh
-RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
-# Add default SSH config, which points at the private key we'll mount
-COPY ./ssh_config /etc/ssh/ssh_config
-
 COPY ./kubeconfig /root/.kube/config
-COPY ./kubectl /usr/local/bin/
 COPY ./fluxd /usr/local/bin/
 
 ARG BUILD_DATE

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -1,5 +1,17 @@
 FROM alpine:3.6
 
+WORKDIR /home/flux
+
+RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
+
+# Add git hosts to known hosts file so we can use
+# StrickHostKeyChecking with git+ssh
+RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
+# Add default SSH config, which points at the private key we'll mount
+COPY ./ssh_config /etc/ssh/ssh_config
+
+COPY ./kubectl /usr/local/bin/
+
 # These are pretty static
 LABEL maintainer="Weaveworks <help@weave.works>" \
       org.opencontainers.image.title="flux-helm-operator" \
@@ -14,18 +26,8 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
       org.label-schema.vcs-url="git@github.com:weaveworks/flux" \
       org.label-schema.vendor="Weaveworks"
 
-WORKDIR /home/flux
 ENTRYPOINT [ "/sbin/tini", "--", "helm-operator" ]
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
-
-# Add git hosts to known hosts file so we can use
-# StrickHostKeyChecking with git+ssh
-RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
-# Add default SSH config, which points at the private key we'll mount
-COPY ./ssh_config /etc/ssh/ssh_config
-
-COPY ./kubectl /usr/local/bin/
 COPY ./helm-operator /usr/local/bin/
 
 ARG BUILD_DATE


### PR DESCRIPTION
Moves the common parts of the Dockerfiles to be in the same order so that the first seven steps are cached.

This is to be just slightly kinder to the networking on my CI system which pulls both images.