### PR TITLE
Fix problem with multiple image support in FluxHelmReleases

### DIFF
--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -336,7 +336,7 @@ func createK8sFHRContainers(spec fhr_v1alpha2.FluxHelmReleaseSpec) []apiv1.Conta
 	var containers []apiv1.Container
 	_ = kresource.FindFluxHelmReleaseContainers(spec.Values, func(name string, image image.Ref, _ kresource.ImageSetter) error {
 		containers = append(containers, apiv1.Container{
-			Name:  kresource.ReleaseContainerName,
+			Name:  name,
 			Image: image.String(),
 		})
 		return nil


### PR DESCRIPTION
#1175 didn't quite do the job.

When FluxHelmRelease resources are obtained via the Kubernetes API,
maps in the free-form `.spec.values` field are typed
`map[string]interface{}` since it is deserialised from JSON.

So, we have to account for this case as well as the
`map[interface{}]interface{}` that comes from YAML (i.e., manifest
files), if we want to factor the interpretation of `.spec.values` into
a single procedure.