### PR TITLE
Allow dots in resource names

### DIFF
--- a/flux.go
+++ b/flux.go
@@ -14,8 +14,8 @@ var (
 	ErrInvalidServiceID = errors.New("invalid service ID")
 
 	LegacyServiceIDRegexp       = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
+	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)$")
+	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.-]+)$")
 )
 
 // ResourceID is an opaque type which uniquely identifies a resource in an


### PR DESCRIPTION
Kubernetes resource names are DNS_SUBDOMAINs, which are basically
DNS_LABELs joined together with dots. It's perfectly reasonable to
have a name `foo.bar.baz`, for example.

Fixes #1195.