### PR TITLE
Fix ResourceIDRegexp to allow dots in resource names

### DIFF
--- a/flux.go
+++ b/flux.go
@@ -14,8 +14,8 @@ var (
 	ErrInvalidServiceID = errors.New("invalid service ID")
 
 	LegacyServiceIDRegexp       = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
+	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9._-]+)$")
+	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9._-]+)$")
 )
 
 // ResourceID is an opaque type which uniquely identifies a resource in an

--- a/flux_test.go
+++ b/flux_test.go
@@ -1,0 +1,38 @@
+package flux
+
+import (
+    "testing"
+)
+
+func TestParseResourceID(t *testing.T) {
+    resourceId, err := ParseResourceID("default:customresourcedefinition/my.resource.com")
+    if err != nil {
+        t.Error("Got unexpected error", err)
+    }
+
+    if resourceId.String() != "default:customresourcedefinition/my.resource.com" {
+        t.Error("Got unexpected resourceId", resourceId)
+    }
+}
+
+func TestParseResourceIDOptionalNamespace(t *testing.T) {
+    resourceId, err := ParseResourceIDOptionalNamespace("default", "test:customresourcedefinition/my.resource.com")
+    if err != nil {
+        t.Error("Got unexpected error", err)
+    }
+
+    if resourceId.String() != "test:customresourcedefinition/my.resource.com" {
+        t.Error("Got unexpected resourceId", resourceId)
+    }
+}
+
+func TestParseResourceIDOptionalNamespaceNotSet(t *testing.T) {
+    resourceId, err := ParseResourceIDOptionalNamespace("default", "customresourcedefinition/my.resource.com")
+    if err != nil {
+        t.Error("Got unexpected error", err)
+    }
+
+    if resourceId.String() != "default:customresourcedefinition/my.resource.com" {
+        t.Error("Got unexpected resourceId", resourceId)
+    }
+}


### PR DESCRIPTION
Some resources (particularly CustomResourceDefinitions) have dots in their names, these
are currently considered invalid by ResourceIDRegexp.

I do not know if this causes an issue inside of Flux, but I import it for fluxcloud and
it breaks unmarshalling events:

```
error decoding: parsing default:customresourcedefinition/clustersecrets.clustersecret.codesink.net: invalid service ID
```