### PR TITLE
helm-op: Add support for connecting to tiller using tls

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -104,6 +104,13 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator` 
 | `helmOperator.tag` | Helm operator image tag | `0.1.0-alpha` 
 | `helmOperator.pullPolicy` | Helm operator image pull policy | `IfNotPresent` 
+| `helmOperator.tillerNamespace` | Namespace in which the Tiller server can be found | `kube-system`
+| `helmOperator.tls.enable` | Enable TLS for communicating with Tiller | `false`
+| `helmOperator.tls.verify` | Verify the Tiller certificate, also enables TLS when set to true | `false`
+| `helmOperator.tls.secretName` | Name of the secret containing the TLS client certificates for communicating with Tiller | `helm-client-certs`
+| `helmOperator.tls.keyFile` | Name of the key file within the k8s secret | `tls.key`
+| `helmOperator.tls.certFile` | Name of the certificate file within the k8s secret | `tls.crt`
+| `helmOperator.tls.caContent` | Certificate Authority content used to validate the Tiller server certificate | None
 | `token` | Weave Cloud service token | None 
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -133,5 +133,189 @@ helm upgrade --reuse-values flux \
 weaveworks/flux
 ```
 
+## Installing Weave Flux helm-operator and Helm with TLS enabled
+
+### Installing Helm / Tiller
+
+Generate certificates for Tiller and Flux. This will provide a CA, server certs for tiller and client certs for helm / weave flux. 
+
+The following script can be used for that (requires [cfssl](https://github.com/cloudflare/cfssl)):
+
+```bash
+export TILLER_HOSTNAME=tiller-server
+export TILLER_SERVER=server
+export USER_NAME=flux-helm-operator
+
+mkdir tls
+cd ./tls
+
+# Prep the configuration
+echo '{"CN":"CA","key":{"algo":"rsa","size":4096}}' | cfssl gencert -initca - | cfssljson -bare ca -
+echo '{"signing":{"default":{"expiry":"43800h","usages":["signing","key encipherment","server auth","client auth"]}}}' > ca-config.json
+
+# Create the tiller certificate
+echo '{"CN":"'$TILLER_SERVER'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert \
+  -config=ca-config.json -ca=ca.pem \
+  -ca-key=ca-key.pem \
+  -hostname="$TILLER_HOSTNAME" - | cfssljson -bare $TILLER_SERVER
+
+# Create a client certificate
+echo '{"CN":"'$USER_NAME'","hosts":[""],"key":{"algo":"rsa","size":4096}}' | cfssl gencert \
+  -config=ca-config.json -ca=ca.pem -ca-key=ca-key.pem \
+  -hostname="$TILLER_HOSTNAME" - | cfssljson -bare $USER_NAME
+```
+
+Alternatively, you can follow the [Helm documentation for configuring TLS](https://docs.helm.sh/using_helm/#using-ssl-between-helm-and-tiller).
 
 
+Next deploy Helm with TLS and RBAC enabled; 
+
+Create a file called `helm-rbac.yaml`. This contains all the RBAC configuration for Tiller:
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: tiller
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: tiller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: tiller
+    namespace: kube-system
+
+---
+# Helm client serviceaccount
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: helm
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: tiller-user
+  namespace: kube-system
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods/portforward
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: tiller-user-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: tiller-user
+subjects:
+- kind: ServiceAccount
+  name: helm
+  namespace: kube-system
+```
+
+Deploy Tiller:
+
+```bash
+kubectl apply -f helm-rbac.yaml
+
+# Deploy helm with mutual TLS enabled
+helm init --upgrade --service-account tiller \
+    --override 'spec.template.spec.containers[0].command'='{/tiller,--storage=secret}' \
+    --tiller-tls \
+    --tiller-tls-cert ./tls/server.pem \
+    --tiller-tls-key ./tls/server-key.pem \
+    --tiller-tls-verify \
+    --tls-ca-cert ./tls/ca.pem
+```
+
+To check if Tiller installed succesfully with TLS enabled, try `helm ls`. This should give an error:
+
+```bash
+# Should give an error
+$ helm ls
+Error: transport is closing
+```
+
+When providing the certificates, it should work correctly:
+
+```bash
+helm --tls \
+  --tls-ca-cert ./tls/ca.pem \
+  --tls-cert ./tls/flux-helm-operator.pem \
+  --tls-key ././tls/flux-helm-operator-key.pem \
+  ls
+```
+
+## deploy weave flux helm-operator
+
+First create a new Kubernetes TLS secret for the client certs;
+
+```bash
+kubectl create secret tls helm-client --cert=tls/flux-helm-operator.pem --key=./tls/flux-helm-operator-key.pem
+```
+
+> note; this has to be in the same namespace as the helm-operator is deployed in.
+
+Deploy flux with Helm;
+
+```bash
+helm repo add weaveworks https://weaveworks.github.io/flux
+
+helm upgrade --install \
+    --set helmOperator.create=true \
+    --set git.url=$YOUR_GIT_REPO \
+    --set helmOperator.tls.enable=true \
+    --set helmOperator.tls.verify=true \    
+    --set helmOperator.tls.secretName=helm-client \
+    --set helmOperator.tls.caContent="$(cat ./tls/ca.pem)" \
+    flux \
+    weaveworks/flux
+```
+
+### Check if it worked
+
+Use `kubectl logs` on the helm-operator and observe the helm client being created.
+
+### Debugging
+
+#### Error creating helm client: failed to append certificates from file: /etc/fluxd/helm-ca/ca.crt
+
+Your CA certificate content is not set correctly, check if your configMap contains the correct values. Example:
+
+```bash
+$ kubectl get configmaps flux-helm-tls-ca-config -o yaml
+apiVersion: v1
+data:
+  ca.crt: |
+    -----BEGIN CERTIFICATE-----
+    ....
+    -----END CERTIFICATE-----
+kind: ConfigMap
+metadata:
+  creationTimestamp: 2018-07-04T15:27:25Z
+  name: flux-helm-tls-ca-config
+  namespace: helm-system
+  resourceVersion: "1267257"
+  selfLink: /api/v1/namespaces/helm-system/configmaps/flux-helm-tls-ca-config
+  uid: c106f866-7f9e-11e8-904a-025000000001
+```

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -32,6 +32,18 @@ spec:
         secret:
           secretName: {{ template "flux.fullname" . }}-git-deploy
           defaultMode: 0400
+      {{- if .Values.helmOperator.tls.enable }}
+      - name: helm-tls-certs
+        secret:
+          secretName: {{ .Values.helmOperator.tls.secretName }}
+          defaultMode: 0400
+      {{- if .Values.helmOperator.tls.verify }}
+      - name: helm-tls-ca
+        configMap:
+          name: {{ template "flux.fullname" . }}-helm-tls-ca-config
+          defaultMode: 0600
+      {{- end }}
+      {{- end }}
       containers:
       - name: flux-helm-operator
         image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
@@ -44,8 +56,28 @@ spec:
         - name: git-key
           mountPath: /etc/fluxd/ssh
           readOnly: true
+        {{- if .Values.helmOperator.tls.enable }}
+        - name: helm-tls-certs
+          mountPath: /etc/fluxd/helm
+          readOnly: true
+        {{- if .Values.helmOperator.tls.verify }}
+        - name: helm-tls-ca
+          mountPath: /etc/fluxd/helm-ca
+          readOnly: true
+        {{- end }}
+        {{- end }}
         args:
         - --git-url={{ .Values.git.url }}
         - --git-branch={{ .Values.git.branch }}
         - --git-charts-path={{ .Values.git.chartsPath }}
+        - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
+        {{- if .Values.helmOperator.tls.enable }}
+        - --tiller-tls-enable={{ .Values.helmOperator.tls.enable }}
+        - --tiller-tls-key-path={{ .Values.helmOperator.tls.keyPath }}
+        - --tiller-tls-cert-path={{ .Values.helmOperator.tls.certPath }}
+        {{- if .Values.helmOperator.tls.verify }}
+        - --tiller-tls-verify={{ .Values.helmOperator.tls.verify }}
+        - --tiller-tls-ca-cert-path=/etc/fluxd/helm-ca/ca.crt
+        {{- end }}
+        {{- end }}
 {{- end -}}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -73,8 +73,8 @@ spec:
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
         {{- if .Values.helmOperator.tls.enable }}
         - --tiller-tls-enable={{ .Values.helmOperator.tls.enable }}
-        - --tiller-tls-key-path={{ .Values.helmOperator.tls.keyPath }}
-        - --tiller-tls-cert-path={{ .Values.helmOperator.tls.certPath }}
+        - --tiller-tls-key-path=/etc/fluxd/helm/{{ .Values.helmOperator.tls.keyFile }}
+        - --tiller-tls-cert-path=/etc/fluxd/helm/{{ .Values.helmOperator.tls.certFile }}
         {{- if .Values.helmOperator.tls.verify }}
         - --tiller-tls-verify={{ .Values.helmOperator.tls.verify }}
         - --tiller-tls-ca-cert-path=/etc/fluxd/helm-ca/ca.crt

--- a/chart/flux/templates/helm-tls.yaml
+++ b/chart/flux/templates/helm-tls.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.helmOperator.tls.enable -}}
+{{- if .Values.helmOperator.tls.verify -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "flux.fullname" . }}-helm-tls-ca-config
+data:
+  ca.crt: {{ .Values.helmOperator.tls.caContent }}
+{{- end -}}
+{{- end -}}

--- a/chart/flux/templates/helm-tls.yaml
+++ b/chart/flux/templates/helm-tls.yaml
@@ -5,6 +5,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "flux.fullname" . }}-helm-tls-ca-config
 data:
-  ca.crt: {{ .Values.helmOperator.tls.caContent }}
+  ca.crt: |
+    {{ .Values.helmOperator.tls.caContent | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -19,6 +19,14 @@ helmOperator:
   repository: quay.io/weaveworks/helm-operator
   tag: 0.1.0-alpha
   pullPolicy: IfNotPresent
+  tillerNamespace: kube-system
+  tls:
+    secretName: 'helm-client-certs'
+    verify: false
+    enable: false
+    keyPath: '/etc/fluxd/helm/tls.key'
+    certPath: '/etc/fluxd/helm/tls.crt'
+    caContent: ''
 
 rbac:
   # Specifies whether RBAC resources should be created

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -24,8 +24,8 @@ helmOperator:
     secretName: 'helm-client-certs'
     verify: false
     enable: false
-    keyPath: '/etc/fluxd/helm/tls.key'
-    certPath: '/etc/fluxd/helm/tls.crt'
+    keyFile: 'tls.key'
+    certFile: 'tls.crt'
     caContent: ''
 
 rbac:

--- a/site/helm/helm-integration.md
+++ b/site/helm/helm-integration.md
@@ -65,24 +65,29 @@ helm-operator requires setup and offers customization though a multitude of flag
 
 |flag                    | default                       | purpose |
 |------------------------|-------------------------------|---------|
-|--kubernetes-kubectl    |                               | Optional, explicit path to kubectl tool.|
-|--kubeconfig            |                               | Path to a kubeconfig. Only required if out-of-cluster.|
-|--master                |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.|
-|                        |                               | **Tiller options**|
-|--tillerIP              |                               | Tiller IP address. Only required if out-of-cluster.|
-|--tillerPort            |                               | Tiller port.|
-|--tillerNamespace       |                               | Tiller namespace. If not provided, the default is kube-system.|
-|                        |                               | **Git repo & key etc.**|
-|--git-url               |                               | URL of git repo with Helm Charts; e.g., `ssh://git@github.com/weaveworks/flux-example`|
-|--git-branch            | `master`                      | Branch of git repo to use for Kubernetes manifests|
-|--git-charts-path       | `charts`                      | Path within git repo to locate Kubernetes Charts (relative path)|
-|                        |                               | **repo chart changes** (none of these need overriding, usually) |
-|--git-poll-interval     | `5 minutes`                   | period at which to poll git repo for new commits|
-|--chartsSyncInterval    | 3*time.Minute                 | Interval at which to check for changed charts.|
-|--chartsSyncTimeout     | 1*time.Minute                 | Timeout when checking for changed charts.|
-|                        |                               | **k8s-secret backed ssh keyring configuration**|
+|--kubernetes-kubectl          |                               | Optional, explicit path to kubectl tool.|
+|--kubeconfig                  |                               | Path to a kubeconfig. Only required if out-of-cluster.|
+|--master                      |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.|
+|                              |                               | **Tiller options**|
+|--tillerIP                    |                               | Tiller IP address. Only required if out-of-cluster.|
+|--tillerPort                  |                               | Tiller port.|
+|--tillerNamespace             |                               | Tiller namespace. If not provided, the default is kube-system.| |
+|--tiller-tls-enable           |`false`                        | Enable TLS communication with Tiller. If provided, requires TLSKey and TLSCert to be provided as well. |
+|--tiller-tls-verify           |`false`                        | Verify TLS certificate from Tiller. Will enable TLS communication when provided. |
+|--tiller-tls-tls-key-path     |`/etc/fluxd/helm/tls.key`      | Path to private key file used to communicate with the Tiller server. |
+|--tiller-tls-tls-cert-path    |`/etc/fluxd/helm/tls.crt`      | Path to certificate file used to communicate with the Tiller server. |
+|--tiller-tls-tls-ca-cert-path |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled. |
+|                              |                               | **Git repo & key etc.**|
+|--git-url                     |                               | URL of git repo with Helm Charts; e.g., `ssh://git@github.com/weaveworks/flux-example`|
+|--git-branch                  | `master`                      | Branch of git repo to use for Kubernetes manifests|
+|--git-charts-path             | `charts`                      | Path within git repo to locate Kubernetes Charts (relative path)|
+|                              |                               | **repo chart changes** (none of these need overriding, usually) |
+|--git-poll-interval           | `5 minutes`                   | period at which to poll git repo for new commits|
+|--chartsSyncInterval          | 3*time.Minute                 | Interval at which to check for changed charts.|
+|--chartsSyncTimeout           | 1*time.Minute                 | Timeout when checking for changed charts.|
+|                              |                               | **k8s-secret backed ssh keyring configuration**|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`       | Mount location of the k8s secret storing the private SSH key|
-|--k8s-secret-data-key   | `identity`                    | Data key holding the private SSH key within the k8s secret|
-|--queueWorkerCount      |  2                            | Number of workers to process queue with Chart release jobs.|
+|--k8s-secret-data-key         | `identity`                    | Data key holding the private SSH key within the k8s secret|
+|--queueWorkerCount            |  2                            | Number of workers to process queue with Chart release jobs.|
 
 [Requirements](./helm-integration-requirements.md)


### PR DESCRIPTION
- Add support for connecting to tiller using TLS authentication.
   It is based on the way the helm client itself configures the TLS authentication and behaves the same way. The default is TLS disabled.
- Updates the helm chart to support the TLS options. Expects the helm client certificates to be stored in a k8s secret in the same namespace as the helm-operator is deployed. The secretName can be passed along using the helm-deployment. When configuring TLS Verify, a CA certificate has to be passed and this will be created as a ConfigMap during the deployment.

Closes #1198