### PR TITLE
Update kubeyaml to get .spec.values handling fix

### DIFF
--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.3.2 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.3.3 "$@"

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -839,6 +839,7 @@ spec:
       image: bitnami/mariadb:10.1.30-r1
       persistence:
         enabled: false
+    workProperly: true
     sidecar:
       image: sidecar:v1
 `
@@ -863,6 +864,7 @@ spec:
       image: bitnami/mariadb:10.1.33
       persistence:
         enabled: false
+    workProperly: true
     sidecar:
       image: sidecar:v1
 `

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -29,7 +29,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.3.2 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.3.3 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 COPY ./kubeconfig /root/.kube/config


### PR DESCRIPTION
kubeyaml used to assume that every entry in the values map of a
FluxHelmRelease was itself a map. This meant that having an values
like

```
values:
  mariadb:
    image: mariadb:v1.50
  someFlag: true
```

would break it, and you couldn't update those YAMLs.

0.3.3 no longer assumes this.

We also need to stabilise the order of containers got from FluxHelmReleases, so they don't 1. jump around in API results, and 2. look different after updates, and fail the release verification as a result.