### PR TITLE
Switch to busybox for integration test

### DIFF
--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -30,7 +30,7 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 		Logger:         log.With(log.NewLogfmtLogger(os.Stderr), "component", "memcached"),
 	}, strings.Fields(*memcachedIPs)...)
 
-	id, _ := image.ParseRef("alpine")
+	id, _ := image.ParseRef("busybox")
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 


### PR DESCRIPTION
Alpine just released a multi-arch image, and this breaks any integration test, which tries to download the alpine image metadata (and fails because of #741).

A temporary fix is to use busybox for the test instead. Longer term, we should fix #741 of course.