### PR TITLE
Process known_hosts from string literals with newline separation per key

### DIFF
--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -3,4 +3,13 @@ kind: ConfigMap
 metadata:
   name: {{ template "flux.fullname" . }}-ssh-config
 data:
-  known_hosts: {{ .Values.ssh.known_hosts }}
+  known_hosts: |
+    {{- if .Values.ssh.known_hosts }}
+      {{- if contains "\n" .Values.ssh.known_hosts }}
+        {{- range $value := .Values.ssh.known_hosts | splitList "\n" }}
+          {{ print $value }}
+        {{- end }}
+      {{- else }}
+        {{- .Values.ssh.known_hosts }}
+      {{- end }}
+    {{- end }}

--- a/site/standalone/setup.md
+++ b/site/standalone/setup.md
@@ -136,3 +136,21 @@ manifest.
 You will need to explicitly tell fluxd to use that service account by
 uncommenting and possible adapting the line `# serviceAccountName:
 flux` in the file `fluxd-deployment.yaml` before applying it.
+
+It is also possible to create the known_hosts keys at the same time 
+as doing a `helm install` of `flux` and the `flux-helm-operator`. Line
+breaks can be used to separate one key from the next. See example below:
+
+```bash
+KNOWN_HOSTS='domain ssh-rsa line1
+domain ecdsa-sha2-line2
+domain ssh-ed25519 line3'
+
+helm install \
+--name flux \
+--set helmOperator.create=true \
+--set git.url="ssh://git@github.com:weaveworks/flux-helm-test.git" \
+--set-string ssh.known_hosts="${KNOWN_HOSTS}" \
+--namespace flux \
+chart/flux
+```


### PR DESCRIPTION
What does this MR do?

- Splits newline separated known_host keys into multiple lines

Why is this MR needed?

- To allow a creation of multiline known_hosts when creating from `helm install` rather
than `kubectl create configmap ...`.
- Less manual intervention