### PR TITLE
Read default image creds for each request

### DIFF
--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -98,15 +98,21 @@ func ParseCredentials(from string, b []byte) (Credentials, error) {
 }
 
 func ImageCredsWithDefaults(lookup func() ImageCreds, configPath string) (func() ImageCreds, error) {
-	var defaults Credentials
+	// pre-flight check
 	bs, err := ioutil.ReadFile(configPath)
 	if err == nil {
-		defaults, err = ParseCredentials(configPath, bs)
+		_, err = ParseCredentials(configPath, bs)
 	}
 	if err != nil {
 		return nil, err
 	}
+
 	return func() ImageCreds {
+		var defaults Credentials
+		bs, err := ioutil.ReadFile(configPath)
+		if err == nil {
+			defaults, _ = ParseCredentials(configPath, bs)
+		}
 		imageCreds := lookup()
 		for k, v := range imageCreds {
 			newCreds := NoCredentials()


### PR DESCRIPTION
Part of the point of being able to provide a docker config is to be
able to mount it from a volume, and thereby be able to update it on
the fly (e.g., with a sidecar).

But this won't work if it's read only at startup. So, just check it's
OK when we start, and otherwise read it every time we are asked for
credentials.