### PR TITLE
Bump helm-operator version in example YAML

### DIFF
--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         # There are no ":latest" images for helm-operator. Find the most recent
         # release or image version at https://quay.io/weaveworks/helm-operator
         # and replace the tag here.
-        image: quay.io/weaveworks/helm-operator:0.1.0-alpha
+        image: quay.io/weaveworks/helm-operator:0.1.1-alpha
         imagePullPolicy: IfNotPresent
         volumeMounts:
         # Include this if you need to mount a customised known_hosts


### PR DESCRIPTION
This brings the example YAML up to date with the most recent release, as well as the docs in master.