### PR TITLE
git repo improvements for helm operator

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -597,9 +597,9 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 	}
 
 	start := func() {
-		wg.Add(1)
-		go repo.Start(shutdown, wg)
-		gittest.WaitForRepoReady(repo, t)
+		if err := repo.Ready(context.Background()); err != nil {
+			t.Fatal(err)
+		}
 
 		wg.Add(1)
 		go d.Loop(shutdown, wg, logger)

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -55,9 +55,9 @@ func daemon(t *testing.T) (*Daemon, func()) {
 	wg := &sync.WaitGroup{}
 	shutdown := make(chan struct{})
 
-	wg.Add(1)
-	go repo.Start(shutdown, wg)
-	gittest.WaitForRepoReady(repo, t)
+	if err := repo.Ready(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 
 	gitConfig := git.Config{
 		Branch:    "master",

--- a/git/export.go
+++ b/git/export.go
@@ -1,0 +1,29 @@
+package git
+
+import (
+	"context"
+	"os"
+)
+
+type Export struct {
+	dir string
+}
+
+func (e *Export) Dir() string {
+	return e.dir
+}
+
+func (e *Export) Clean() {
+	if e.dir != "" {
+		os.RemoveAll(e.dir)
+	}
+}
+
+// Export creates a minimal clone of the repo, at the ref given.
+func (r *Repo) Export(ctx context.Context, ref string) (*Export, error) {
+	dir, err := r.workingClone(ctx, ref)
+	if err != nil {
+		return nil, err
+	}
+	return &Export{dir}, nil
+}

--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -4,9 +4,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
-	"sync"
 	"testing"
-	"time"
 
 	"context"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
@@ -67,19 +65,17 @@ func Repo(t *testing.T) (*git.Repo, func()) {
 // the clone, the original repo, and a cleanup function.
 func CheckoutWithConfig(t *testing.T, config git.Config) (*git.Checkout, *git.Repo, func()) {
 	repo, cleanup := Repo(t)
-	shutdown, wg := make(chan struct{}), &sync.WaitGroup{}
-	wg.Add(1)
-	go repo.Start(shutdown, wg)
-	WaitForRepoReady(repo, t)
+	if err := repo.Ready(context.Background()); err != nil {
+		cleanup()
+		t.Fatal(err)
+	}
 
 	co, err := repo.Clone(context.Background(), config)
 	if err != nil {
-		close(shutdown)
 		cleanup()
 		t.Fatal(err)
 	}
 	return co, repo, func() {
-		close(shutdown)
 		co.Clean()
 		cleanup()
 	}
@@ -105,20 +101,4 @@ func execCommand(cmd string, args ...string) error {
 	c.Stderr = ioutil.Discard
 	c.Stdout = ioutil.Discard
 	return c.Run()
-}
-
-func WaitForRepoReady(r *git.Repo, t *testing.T) {
-	retries := 30
-	for {
-		s, _ := r.Status()
-		if s == git.RepoReady {
-			return
-		}
-		if retries == 0 {
-			t.Fatalf("repo was not ready after 3 seconds")
-			return
-		}
-		retries--
-		time.Sleep(100 * time.Millisecond)
-	}
 }

--- a/git/gittest/repo_test.go
+++ b/git/gittest/repo_test.go
@@ -71,9 +71,9 @@ func TestCheckout(t *testing.T) {
 
 	sd, sg := make(chan struct{}), &sync.WaitGroup{}
 
-	sg.Add(1)
-	go repo.Start(sd, sg)
-	WaitForRepoReady(repo, t)
+	if err := repo.Ready(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 
 	ctx := context.Background()
 

--- a/git/operations.go
+++ b/git/operations.go
@@ -246,7 +246,12 @@ func changedFiles(ctx context.Context, path, subPath, ref string) ([]string, err
 	// This uses --diff-filter to only look at changes for file _in
 	// the working dir_; i.e, we do not report on things that no
 	// longer appear.
-	if err := execGitCmd(ctx, path, out, "diff", "--name-only", "--diff-filter=ACMRT", ref, "--", subPath); err != nil {
+	args := []string{"diff", "--name-only", "--diff-filter=ACMRT", ref}
+	if subPath != "" {
+		args = append(args, "--", subPath)
+	}
+
+	if err := execGitCmd(ctx, path, out, args...); err != nil {
 		return nil, err
 	}
 	return splitList(out.String()), nil

--- a/git/repo.go
+++ b/git/repo.go
@@ -216,75 +216,105 @@ func (r *Repo) CommitsBetween(ctx context.Context, ref1, ref2, path string) ([]C
 	return onelinelog(ctx, r.dir, ref1+".."+ref2, path)
 }
 
+// step attempts to advance the repo state machine, and returns `true`
+// if it has made progress, `false` otherwise.
+func (r *Repo) step(bg context.Context) bool {
+	r.mu.RLock()
+	url := r.origin.URL
+	dir := r.dir
+	status := r.status
+	r.mu.RUnlock()
+
+	switch status {
+
+	case RepoNoConfig:
+		// this is not going to change in the lifetime of this
+		// process, so just exit.
+		return false
+
+	case RepoNew:
+		rootdir, err := ioutil.TempDir(os.TempDir(), "flux-gitclone")
+		if err != nil {
+			panic(err)
+		}
+
+		ctx, cancel := context.WithTimeout(bg, opTimeout)
+		dir, err = mirror(ctx, rootdir, url)
+		cancel()
+		if err == nil {
+			r.mu.Lock()
+			r.dir = dir
+			ctx, cancel := context.WithTimeout(bg, opTimeout)
+			err = r.fetch(ctx)
+			cancel()
+			r.mu.Unlock()
+		}
+		if err == nil {
+			r.setUnready(RepoCloned, ErrClonedOnly)
+			return true
+		}
+		dir = ""
+		os.RemoveAll(rootdir)
+		r.setUnready(RepoNew, err)
+		return false
+
+	case RepoCloned:
+		if !r.readonly {
+			ctx, cancel := context.WithTimeout(bg, opTimeout)
+			err := checkPush(ctx, dir, url)
+			cancel()
+			if err != nil {
+				r.setUnready(RepoCloned, err)
+				return false
+			}
+		}
+
+		r.setReady()
+		// Treat every transition to ready as a refresh, so
+		// that any listeners can respond in the same way.
+		r.refreshed()
+		return true
+
+	case RepoReady:
+		return false
+	}
+
+	return false
+}
+
+// Ready tries to advance the cloning process along as far as
+// possible, and returns an error if it is not able to get to a ready
+// state.
+func (r *Repo) Ready(ctx context.Context) error {
+	for r.step(ctx) {
+		// keep going!
+	}
+	_, err := r.Status()
+	return err
+}
+
 // Start begins synchronising the repo by cloning it, then fetching
 // the required tags and so on.
 func (r *Repo) Start(shutdown <-chan struct{}, done *sync.WaitGroup) error {
 	defer done.Done()
 
 	for {
+		ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+		advanced := r.step(ctx)
+		cancel()
 
-		r.mu.RLock()
-		url := r.origin.URL
-		dir := r.dir
-		status := r.status
-		r.mu.RUnlock()
+		if advanced {
+			continue
+		}
 
-		bg := context.Background()
-
-		switch status {
-
-		case RepoNoConfig:
-			// this is not going to change in the lifetime of this
-			// process, so just exit.
-			return nil
-		case RepoNew:
-
-			rootdir, err := ioutil.TempDir(os.TempDir(), "flux-gitclone")
-			if err != nil {
-				return err
-			}
-
-			ctx, cancel := context.WithTimeout(bg, opTimeout)
-			dir, err = mirror(ctx, rootdir, url)
-			cancel()
-			if err == nil {
-				r.mu.Lock()
-				r.dir = dir
-				ctx, cancel := context.WithTimeout(bg, opTimeout)
-				err = r.fetch(ctx)
-				cancel()
-				r.mu.Unlock()
-			}
-			if err == nil {
-				r.setUnready(RepoCloned, ErrClonedOnly)
-				continue // with new status, skipping timer
-			}
-			dir = ""
-			os.RemoveAll(rootdir)
-			r.setUnready(RepoNew, err)
-
-		case RepoCloned:
-			if !r.readonly {
-				ctx, cancel := context.WithTimeout(bg, opTimeout)
-				err := checkPush(ctx, dir, url)
-				cancel()
-				if err != nil {
-					r.setUnready(RepoCloned, err)
-					break
-				}
-			}
-
-			r.setReady()
-			// Treat every transition to ready as a refresh, so
-			// that any listeners can respond in the same way.
-			r.refreshed()
-			continue // with new status, skipping timer
-
-		case RepoReady:
+		status, _ := r.Status()
+		if status == RepoReady {
 			if err := r.refreshLoop(shutdown); err != nil {
 				r.setUnready(RepoNew, err)
 				continue // with new status, skipping timer
 			}
+		} else if status == RepoNoConfig {
+			return nil
 		}
 
 		tryAgain := time.NewTimer(10 * time.Second)
@@ -298,6 +328,7 @@ func (r *Repo) Start(shutdown <-chan struct{}, done *sync.WaitGroup) error {
 			continue
 		}
 	}
+	return nil
 }
 
 func (r *Repo) Refresh(ctx context.Context) error {

--- a/git/working.go
+++ b/git/working.go
@@ -2,8 +2,13 @@ package git
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
+)
+
+var (
+	ErrReadOnly = errors.New("cannot make a working clone of a read-only git repo")
 )
 
 // Config holds some values we use when working in the working clone of
@@ -43,6 +48,10 @@ type CommitAction struct {
 // Clone returns a local working clone of the sync'ed `*Repo`, using
 // the config given.
 func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
+	if r.readonly {
+		return nil, ErrReadOnly
+	}
+
 	upstream := r.Origin()
 	repoDir, err := r.workingClone(ctx, conf.Branch)
 	if err != nil {


### PR DESCRIPTION
Here are some improvements to the git mirroring, so that it's usable for the Helm operator.

 - allow a git repo be read-only, so that you can give the helm-op a read-only SSH key (as we do in local env)
 - add a "files only" clone, `git.Export`, so the helm operator can get at a working tree without all the config baggage that fluxd uses in its working directories
