### PR TITLE
Fluxctl should search for pod labels added by helm chart

### DIFF
--- a/cmd/fluxctl/portforward.go
+++ b/cmd/fluxctl/portforward.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/justinbarrick/go-k8s-portforward"
+	"github.com/pkg/errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Attempt to create PortForwards to fluxes that match the label selectors until a Flux
+// is found or an error is returned.
+func tryPortforwards(ns string, selectors ...metav1.LabelSelector) (p *portforward.PortForward, err error) {
+	message := fmt.Sprintf("Flux pod not found for labels in namespace %s:", ns)
+
+	for _, selector := range selectors {
+		p, err = tryPortforward(ns, selector)
+		if err == nil {
+			return
+		}
+
+		if ! strings.Contains(err.Error(), "Could not find pod for selector") {
+			return
+		} else {
+			message = fmt.Sprintf("%s\n  %s", message, metav1.FormatLabelSelector(&selector))
+		}
+	}
+
+	if err != nil {
+		err = errors.New(message)
+	}
+
+	return
+}
+
+// Attempt to create a portforward in the namespace for the provided LabelSelector
+func tryPortforward(ns string, selector metav1.LabelSelector) (*portforward.PortForward, error) {
+	portforwarder, err := portforward.NewPortForwarder(ns, selector, 3030)
+	if err != nil {
+		return portforwarder, err
+	}
+
+	err = portforwarder.Start()
+	if err != nil {
+		return portforwarder, err
+	}
+
+	return portforwarder, nil
+}


### PR DESCRIPTION
The Flux Helm chart does not have a name label on it, but we still want the flux instance
to be discoverable by fluxctl.

This change makes it so that if fluxctl does not find a pod by the labels
`name in (flux,fluxd,weave-flux-agent)`, it searches for `app=flux`.

If it does not find either label, it returns a nice message:

```
$ ./fluxctl --k8s-fwd-ns lol list-controllers
Error: Flux pod not found for labels in namespace lol:
  name in (flux,fluxd,weave-flux-agent)
  app=flux
Run 'fluxctl list-controllers --help' for usage.
$
```

Fixes #1242