### PR TITLE
chart: fix known_hosts

### DIFF
--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -10,6 +10,6 @@ data:
           {{ print $value }}
         {{- end }}
       {{- else }}
-        {{- .Values.ssh.known_hosts }}
+        {{ .Values.ssh.known_hosts }}
       {{- end }}
     {{- end }}


### PR DESCRIPTION
If you use one host key for known_hosts file, it will dump value right after pipe and fails on syntax error.

```Error: YAML parse error on flux/templates/ssh.yaml: error converting YAML to JSON: yaml: line 5: did not find expected comment or line break```