### PR TITLE
prevent bogus manifest fetching success

### DIFF
--- a/registry/client.go
+++ b/registry/client.go
@@ -79,7 +79,7 @@ func (a *Remote) Manifest(ctx context.Context, ref string) (image.Info, error) {
 
 interpret:
 	if fetchErr != nil {
-		return image.Info{}, err
+		return image.Info{}, fetchErr
 	}
 
 	info := image.Info{ID: a.repo.ToRef(ref), Digest: manifestDigest.String()}


### PR DESCRIPTION
An error while fetching an image manifest would return a nil error (hence indicating success) with a unit value `image.Info{}` struct.

That is bad news for the caller in `Warmer.warm()`, which will map an image tag to that empty image.Info{}, polluting the cache entry for the image+tag and image in memcached.

When we subsequently use this info to determine the latest suitable tag, we encounter zero `CreatedAt` timestamps, which, prior to the changes in #1247, #1249 and #1250 would cause the wrong images to be released.

Fixes #1127.