### PR TITLE
Fix docs for standalone flux pod

### DIFF
--- a/site/helm/get-started.md
+++ b/site/helm/get-started.md
@@ -59,23 +59,33 @@ Add the Flux repository of Weaveworks:
 helm repo add weaveworks https://weaveworks.github.io/flux
 ```
 
-In this next step you install Weave Flux using `helm`. Simply:
+In this next step you install Weave Flux using `helm`. Simply
 
  1. Fork [flux-helm-test](https://github.com/weaveworks/flux-helm-test)
     on Github and
- 1. install Weave Flux and its Helm Operator by specifying your fork
+ 1. Install Weave Flux and its Helm Operator by specifying your fork
     URL:
 
-    *Just make sure you replace `YOURUSER` with your GitHub username
-    in the command below:*
-    ```sh
-    helm install --name flux \
-    --set helmOperator.create=true \
-    --set git.url=ssh://git@github.com/YOURUSER/flux-helm-test \
-    --set git.chartsPath=charts \
-    --namespace flux \
-    weaveworks/flux
-    ```
+      *Just make sure you replace `YOURUSER` with your GitHub username
+      in the command below:*
+      
+    - Using a public git server from `bitbucket.com`, `github.com` or `gitlab.com`:
+    
+      ```sh
+      helm install --name flux \
+      --set helmOperator.create=true \
+      --set git.url=ssh://git@github.com/YOURUSER/flux-helm-test \
+      --set git.chartsPath=charts \
+      --namespace flux \
+      weaveworks/flux
+      ```
+      
+    - Using a private git server:
+       
+      When deploying from a private repo, the known_hosts of the git server needs 
+      to be configured into a kubernetes configmap so that `StrictHostKeyChecking` is respected.
+      See [chart/flux/README.md](https://github.com/weaveworks/flux/blob/master/chart/flux/README.md#to-install-flux-with-the-helm-operator-and-a-private-git-repository)
+      for further installation instructions in this case.
 
 Allow some time for all containers to get up and running. If you're
 impatient, run the following command and see the pod creation

--- a/site/standalone/setup.md
+++ b/site/standalone/setup.md
@@ -136,21 +136,3 @@ manifest.
 You will need to explicitly tell fluxd to use that service account by
 uncommenting and possible adapting the line `# serviceAccountName:
 flux` in the file `fluxd-deployment.yaml` before applying it.
-
-It is also possible to create the known_hosts keys at the same time 
-as doing a `helm install` of `flux` and the `flux-helm-operator`. Line
-breaks can be used to separate one key from the next. See example below:
-
-```bash
-KNOWN_HOSTS='domain ssh-rsa line1
-domain ecdsa-sha2-line2
-domain ssh-ed25519 line3'
-
-helm install \
---name flux \
---set helmOperator.create=true \
---set git.url="ssh://git@github.com:weaveworks/flux-helm-test.git" \
---set-string ssh.known_hosts="${KNOWN_HOSTS}" \
---namespace flux \
-chart/flux
-```


### PR DESCRIPTION
What does this MR do?

- Minor doc fix where if the doc is for standalone, then
the helm operator should not be started

Why is this MR needed?

- To avoid confusion