### PR TITLE
Support initContainers and {image, tag} and {image: {repository, tag}} Helm values

### DIFF
--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.4.0 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.4.1 "$@"

--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.3.3 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.4.0 "$@"

--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.4.1 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.4.2 "$@"

--- a/cluster/kubernetes/resource/fluxhelmrelease.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease.go
@@ -57,7 +57,6 @@ func FindFluxHelmReleaseContainers(values map[string]interface{}, visit func(str
 	// an image defined at the top-level is given a standard container name:
 	if image, setter, ok := interpretAsContainer(stringMap(values)); ok {
 		visit(ReleaseContainerName, image, setter)
-		return nil
 	}
 
 	// an image as part of a field is treated as a "container" spec

--- a/cluster/kubernetes/resource/fluxhelmrelease_test.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease_test.go
@@ -1,6 +1,7 @@
 package resource
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/weaveworks/flux/resource"
@@ -343,5 +344,78 @@ spec:
 	}
 	if containers[0].Name != expectedContainer {
 		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}
+
+func TestParseAllFormatsInOne(t *testing.T) {
+
+	type container struct {
+		name, image, tag string
+	}
+
+	// *NB* the containers will be calculated based on the order
+	//  1. the entry for 'image' if present
+	//  2. the order of the keys in `values`.
+	//
+	// To avoid having to mess around later, I have cooked the order
+	// of these so they can be compared directly to the return value.
+	expected := []container{
+		{ReleaseContainerName, "repo/imageOne", "tagOne"},
+		{"AAA", "repo/imageTwo", "tagTwo"},
+		{"ZZZ", "repo/imageThree", "tagThree"},
+	}
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: test
+  namespace: test
+spec:
+  chartGitPath: test
+  values:
+    # top-level image
+    image: ` + expected[0].image + ":" + expected[0].tag + `
+
+    # under .container, as image and tag entries
+    ` + expected[1].name + `:
+      image: ` + expected[1].image + `
+      tag: ` + expected[1].tag + `
+
+    # under .container.image, as repository and tag entries
+    ` + expected[2].name + `:
+      image:
+        repository: ` + expected[2].image + `
+        tag: ` + expected[2].tag + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["test:fluxhelmrelease/test"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != len(expected) {
+		t.Fatalf("expected %d containers, got %d", len(expected), len(containers))
+	}
+	for i, c0 := range expected {
+		c1 := containers[i]
+		if c1.Name != c0.name {
+			t.Errorf("names do not match %q != %q", c0, c1)
+		}
+		c0image := fmt.Sprintf("%s:%s", c0.image, c0.tag)
+		if c1.Image.String() != c0image {
+			t.Errorf("images do not match %q != %q", c0image, c1.Image.String())
+		}
 	}
 }

--- a/cluster/kubernetes/resource/fluxhelmrelease_test.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease_test.go
@@ -6,7 +6,7 @@ import (
 	"github.com/weaveworks/flux/resource"
 )
 
-func TestParseSimpleFormat(t *testing.T) {
+func TestParseImageOnlyFormat(t *testing.T) {
 	expectedImage := "bitnami/mariadb:10.1.30-r1"
 	doc := `---
 apiVersion: helm.integrations.flux.weave.works/v1alpha2
@@ -19,6 +19,7 @@ metadata:
 spec:
   chartGitPath: mariadb
   values:
+    first: post
     image: ` + expectedImage + `
     persistence:
       enabled: false
@@ -47,7 +48,53 @@ spec:
 	}
 }
 
-func TestParseLessSimpleFormat(t *testing.T) {
+func TestParseImageTagFormat(t *testing.T) {
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    first: post
+    image: ` + expectedImageName + `
+    tag: ` + expectedImageTag + `
+    persistence:
+      enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+}
+
+func TestParseNamedImageFormat(t *testing.T) {
 	expectedContainer := "db"
 	expectedImage := "bitnami/mariadb:10.1.30-r1"
 	doc := `---
@@ -62,7 +109,78 @@ spec:
   chartGitPath: mariadb
   values:
     ` + expectedContainer + `:
+      first: post
       image: ` + expectedImage + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+
+	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
+		t.Error(err)
+	}
+
+	containers = fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image = containers[0].Image.String()
+	if image != newImage.String() {
+		t.Errorf("expected container image %q, got %q", newImage.String(), image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}
+
+func TestParseNamedImageTagFormat(t *testing.T) {
+	expectedContainer := "db"
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    other:
+      not: "containing image"
+    ` + expectedContainer + `:
+      first: post
+      image: ` + expectedImageName + `
+      tag: ` + expectedImageTag + `
       persistence:
         enabled: false
 `

--- a/cluster/kubernetes/resource/fluxhelmrelease_test.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease_test.go
@@ -227,3 +227,121 @@ spec:
 		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
 	}
 }
+
+func TestParseImageObjectFormat(t *testing.T) {
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    first: post
+    image:
+      repository: ` + expectedImageName + `
+      tag: ` + expectedImageTag + `
+    persistence:
+      enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+}
+
+func TestParseNamedImageObjectFormat(t *testing.T) {
+	expectedContainer := "db"
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    other:
+      not: "containing image"
+    ` + expectedContainer + `:
+      first: post
+      image:
+        repository: ` + expectedImageName + `
+        tag: ` + expectedImageTag + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+
+	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
+		t.Error(err)
+	}
+
+	containers = fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image = containers[0].Image.String()
+	if image != newImage.String() {
+		t.Errorf("expected container image %q, got %q", newImage.String(), image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}

--- a/cluster/kubernetes/resource/spec.go
+++ b/cluster/kubernetes/resource/spec.go
@@ -22,13 +22,12 @@ type PodTemplate struct {
 
 func (t PodTemplate) Containers() []resource.Container {
 	var result []resource.Container
+	// FIXME(https://github.com/weaveworks/flux/issues/1269): account for possible errors (x2)
 	for _, c := range t.Spec.Containers {
-		// FIXME(michael): account for possible errors here
 		im, _ := image.ParseRef(c.Image)
 		result = append(result, resource.Container{Name: c.Name, Image: im})
 	}
 	for _, c := range t.Spec.InitContainers {
-		// FIXME(michael): account for possible errors here
 		im, _ := image.ParseRef(c.Image)
 		result = append(result, resource.Container{Name: c.Name, Image: im})
 	}

--- a/cluster/kubernetes/resource/spec.go
+++ b/cluster/kubernetes/resource/spec.go
@@ -27,11 +27,22 @@ func (t PodTemplate) Containers() []resource.Container {
 		im, _ := image.ParseRef(c.Image)
 		result = append(result, resource.Container{Name: c.Name, Image: im})
 	}
+	for _, c := range t.Spec.InitContainers {
+		// FIXME(michael): account for possible errors here
+		im, _ := image.ParseRef(c.Image)
+		result = append(result, resource.Container{Name: c.Name, Image: im})
+	}
 	return result
 }
 
 func (t PodTemplate) SetContainerImage(container string, ref image.Ref) error {
 	for i, c := range t.Spec.Containers {
+		if c.Name == container {
+			t.Spec.Containers[i].Image = ref.String()
+			return nil
+		}
+	}
+	for i, c := range t.Spec.InitContainers {
 		if c.Name == container {
 			t.Spec.Containers[i].Image = ref.String()
 			return nil
@@ -44,6 +55,7 @@ type PodSpec struct {
 	ImagePullSecrets []struct{ Name string }
 	Volumes          []Volume
 	Containers       []ContainerSpec
+	InitContainers   []ContainerSpec `yaml:"initContainers"`
 }
 
 type Volume struct {

--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -66,7 +66,7 @@ func (pc podController) toClusterController(resourceID flux.ResourceID) cluster.
 		}
 		clusterContainers = append(clusterContainers, resource.Container{Name: container.Name, Image: ref})
 	}
-	for _, container := range pc.podTemplate.Spec.Containers {
+	for _, container := range pc.podTemplate.Spec.InitContainers {
 		ref, err := image.ParseRef(container.Image)
 		if err != nil {
 			clusterContainers = nil

--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -66,6 +66,15 @@ func (pc podController) toClusterController(resourceID flux.ResourceID) cluster.
 		}
 		clusterContainers = append(clusterContainers, resource.Container{Name: container.Name, Image: ref})
 	}
+	for _, container := range pc.podTemplate.Spec.Containers {
+		ref, err := image.ParseRef(container.Image)
+		if err != nil {
+			clusterContainers = nil
+			excuse = err.Error()
+			break
+		}
+		clusterContainers = append(clusterContainers, resource.Container{Name: container.Name, Image: ref})
+	}
 
 	var antecedent flux.ResourceID
 	if ante, ok := pc.GetAnnotations()[AntecedentAnnotation]; ok {

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -29,7 +29,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.4.0 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.4.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 COPY ./kubeconfig /root/.kube/config

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -29,7 +29,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.4.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.4.2 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 COPY ./kubeconfig /root/.kube/config

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -29,7 +29,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.3.3 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.4.0 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 COPY ./kubeconfig /root/.kube/config


### PR DESCRIPTION
1. Support initContainers in deployments, daemonsets etc., via

 - read and write to initContainers as well as containers in
   manifests, so we can update them;
 - report on the initContainers of Kubernetes resources

2. Many charts use an encoding for images of

```
    image: image/name
    tag: tag
```

rather than putting the whole image ref in one field. Support that
(after kubeyaml) by interpreting the values fields, or its values,
depending on whether a "tag" entry is present.

3. Still more charts use

```
    image:
      repository: org/name
      tag: v1
```

including those generated by `helm create` (and not substantially altered afterwards). Support that too.

Fixes #1226.