### PR TITLE
Check if boolean policies equal true

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -124,9 +124,9 @@ func (d *Daemon) ListServices(ctx context.Context, namespace string) ([]v6.Contr
 			Status:     service.Status,
 			Antecedent: service.Antecedent,
 			Labels:     service.Labels,
-			Automated:  policies.Contains(policy.Automated),
-			Locked:     policies.Contains(policy.Locked),
-			Ignore:     policies.Contains(policy.Ignore),
+			Automated:  policies.Has(policy.Automated),
+			Locked:     policies.Has(policy.Locked),
+			Ignore:     policies.Has(policy.Ignore),
 			Policies:   policies.ToStringMap(),
 		})
 	}
@@ -342,7 +342,7 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) updateFu
 		var anythingAutomated bool
 
 		for serviceID, u := range updates {
-			if policy.Set(u.Add).Contains(policy.Automated) {
+			if policy.Set(u.Add).Has(policy.Automated) {
 				anythingAutomated = true
 			}
 			// find the service manifest

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -101,10 +101,14 @@ func clone(s Set) Set {
 	return newMap
 }
 
-// Contains method determines if a resource has a particular policy present
-func (s Set) Contains(needle Policy) bool {
-	for p := range s {
+// Has returns true if a resource has a particular policy present, and
+// for boolean policies, if it is set to true.
+func (s Set) Has(needle Policy) bool {
+	for p, v := range s {
 		if p == needle {
+			if Boolean(needle) {
+				return v == "true"
+			}
 			return true
 		}
 	}
@@ -162,7 +166,7 @@ func (s ResourceMap) Without(other ResourceMap) ResourceMap {
 func (s ResourceMap) OnlyWithPolicy(p Policy) ResourceMap {
 	newMap := ResourceMap{}
 	for k, v := range s {
-		if _, ok := v[p]; ok {
+		if v.Has(p) {
 			newMap[k] = v
 		}
 	}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -16,7 +16,7 @@ func TestJSON(t *testing.T) {
 	boolPolicy = boolPolicy.Add(Locked)
 	policy := boolPolicy.Set(LockedUser, "user@example.com")
 
-	if !(policy.Contains(Ignore) && policy.Contains(Locked)) {
+	if !(policy.Has(Ignore) && policy.Has(Locked)) {
 		t.Errorf("Policy did not include those added")
 	}
 	if val, ok := policy.Get(LockedUser); !ok || val != "user@example.com" {

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -49,29 +49,29 @@ func prepareSyncDelete(logger log.Logger, repoResources map[string]resource.Reso
 	if len(repoResources) == 0 {
 		return
 	}
-	if res.Policy().Contains(policy.Ignore) {
+	if res.Policy().Has(policy.Ignore) {
 		logger.Log("resource", res.ResourceID(), "ignore", "delete")
 		return
 	}
 	if _, ok := repoResources[id]; !ok {
 		sync.Actions = append(sync.Actions, cluster.SyncAction{
-			Delete:     res,
+			Delete: res,
 		})
 	}
 }
 
 func prepareSyncApply(logger log.Logger, clusterResources map[string]resource.Resource, id string, res resource.Resource, sync *cluster.SyncDef) {
-	if res.Policy().Contains(policy.Ignore) {
+	if res.Policy().Has(policy.Ignore) {
 		logger.Log("resource", res.ResourceID(), "ignore", "apply")
 		return
 	}
 	if cres, ok := clusterResources[id]; ok {
-		if cres.Policy().Contains(policy.Ignore) {
+		if cres.Policy().Has(policy.Ignore) {
 			logger.Log("resource", res.ResourceID(), "ignore", "apply")
 			return
 		}
 	}
 	sync.Actions = append(sync.Actions, cluster.SyncAction{
-		Apply:      res,
+		Apply: res,
 	})
 }


### PR DESCRIPTION
It should be possible to set the annotation, e.g.,

    flux.weave.works/automated: 'false'

and expect automation to be off for that resource. However, since we
were checking only for the presence of the automation policy, and not
its value, any value was interpreted as on.

I've changed the name of the method used, so that it's a break from
the previous use (and to flush out where it was used).

Fixes #1256.