### PR TITLE
Record unusable image manifests, rather than fail

### DIFF
--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -47,17 +47,6 @@ type tagKey struct {
 	fullRepositoryPath string
 }
 
-func NewTagKey(id image.CanonicalName) Keyer {
-	return &tagKey{id.String()}
-}
-
-func (k *tagKey) Key() string {
-	return strings.Join([]string{
-		"registrytagsv3", // Just to version in case we need to change format later.
-		k.fullRepositoryPath,
-	}, "|")
-}
-
 type repoKey struct {
 	fullRepositoryPath string
 }

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -9,6 +9,7 @@ import (
 
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/registry"
 )
 
 var (
@@ -72,12 +73,15 @@ func (c *Cache) GetImage(id image.Ref) (image.Info, error) {
 	if err != nil {
 		return image.Info{}, err
 	}
-	var img image.Info
+	var img registry.ImageEntry
 	err = json.Unmarshal(val, &img)
 	if err != nil {
 		return image.Info{}, err
 	}
-	return img, nil
+	if img.ExcludedReason != "" {
+		return image.Info{}, errors.New(img.ExcludedReason)
+	}
+	return img.Info, nil
 }
 
 // ImageRepository holds the last good information on an image

--- a/registry/cache/warming_test.go
+++ b/registry/cache/warming_test.go
@@ -55,13 +55,15 @@ func TestWarm(t *testing.T) {
 		TagsFn: func() ([]string, error) {
 			return []string{"tag"}, nil
 		},
-		ManifestFn: func(tag string) (image.Info, error) {
+		ManifestFn: func(tag string) (registry.ImageEntry, error) {
 			if tag != "tag" {
 				t.Errorf("remote client was asked for %q instead of %q", tag, "tag")
 			}
-			return image.Info{
-				ID:        ref,
-				CreatedAt: time.Now(),
+			return registry.ImageEntry{
+				Info: image.Info{
+					ID:        ref,
+					CreatedAt: time.Now(),
+				},
 			}, nil
 		},
 	}

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -10,11 +10,11 @@ import (
 )
 
 type Client struct {
-	ManifestFn func(ref string) (image.Info, error)
+	ManifestFn func(ref string) (registry.ImageEntry, error)
 	TagsFn     func() ([]string, error)
 }
 
-func (m *Client) Manifest(ctx context.Context, tag string) (image.Info, error) {
+func (m *Client) Manifest(ctx context.Context, tag string) (registry.ImageEntry, error) {
 	return m.ManifestFn(tag)
 }
 

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -74,7 +74,7 @@ func NewInstrumentedClient(next Client) Client {
 	}
 }
 
-func (m *instrumentedClient) Manifest(ctx context.Context, ref string) (res image.Info, err error) {
+func (m *instrumentedClient) Manifest(ctx context.Context, ref string) (res ImageEntry, err error) {
 	start := time.Now()
 	res, err = m.next.Manifest(ctx, ref)
 	remoteDuration.With(


### PR DESCRIPTION
At present the registry client considers a non-Linux/AMD64 image an
error, which provokes the image "cache" warmer to fail for that entire
image repo. As more and more image repositories have Windows images,
this mean flux won't be able to automate or even report on many
workloads.

What we actually want to do is just exclude unusable images from the
result; and for bonus points, record the fact that it wasn't a usable
image. To this end, I've wrapped the cache entries in a struct that
also includes an "excluded reason". If that field is present, the
fetch is considered a success, but the image is not included in the
result for the repo.

The cache entry version doesn't need to be bumped, because old entries
can be parsed as new entries. Happily, no-one has to refresh their
image DB from scratch.

Fixes #741.