### PR TITLE
Image filtering and ordering with semver

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -745,6 +745,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "39117abf5941771d8502f737e9680717e0d6659d66b5f3da5ec48a142cdc986a"
+  inputs-digest = "1d8f352c4b156819b80ca52ed9c1a80d8bfa4ebd1af4a1bc63a8a5f480282459"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -49,3 +49,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 [[constraint]]
   branch = "master"
   name = "github.com/pkg/term"
+
+[[constraint]]
+  name = "github.com/Masterminds/semver"
+  version = "1.4.0"

--- a/api/v6/container.go
+++ b/api/v6/container.go
@@ -3,6 +3,7 @@ package v6
 import (
 	"github.com/pkg/errors"
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/update"
 )
@@ -26,7 +27,9 @@ type Container struct {
 }
 
 // NewContainer creates a Container given a list of images and the current image
-func NewContainer(name string, images update.ImageInfos, currentImage image.Info, tagPattern string, fields []string) (Container, error) {
+func NewContainer(name string, images update.ImageInfos, currentImage image.Info, tagPattern policy.Pattern, fields []string) (Container, error) {
+	images.Sort(tagPattern)
+
 	// All images
 	imagesCount := len(images)
 	imagesErr := ""
@@ -35,7 +38,7 @@ func NewContainer(name string, images update.ImageInfos, currentImage image.Info
 	}
 	var newImages []image.Info
 	for _, img := range images {
-		if img.CreatedAt.After(currentImage.CreatedAt) {
+		if tagPattern.Newer(&img, &currentImage) {
 			newImages = append(newImages, img)
 		}
 	}
@@ -46,7 +49,7 @@ func NewContainer(name string, images update.ImageInfos, currentImage image.Info
 	filteredImagesCount := len(filteredImages)
 	var newFilteredImages []image.Info
 	for _, img := range filteredImages {
-		if img.CreatedAt.After(currentImage.CreatedAt) {
+		if tagPattern.Newer(&img, &currentImage) {
 			newFilteredImages = append(newFilteredImages, img)
 		}
 	}

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -52,6 +52,7 @@ var ResourceMap = map[flux.ResourceID]string{
 	flux.MustParseResourceID("default:service/multi-service"):     "multi.yaml",
 	flux.MustParseResourceID("default:deployment/list-deploy"):    "list.yaml",
 	flux.MustParseResourceID("default:service/list-service"):      "list.yaml",
+	flux.MustParseResourceID("default:deployment/semver"):         "semver-deploy.yaml",
 }
 
 // ServiceMap ... given a base path, construct the map representing
@@ -64,6 +65,7 @@ func ServiceMap(dir string) map[flux.ResourceID][]string {
 		flux.MustParseResourceID("default:deployment/test-service"):   []string{filepath.Join(dir, "test/test-service-deploy.yaml")},
 		flux.MustParseResourceID("default:deployment/multi-deploy"):   []string{filepath.Join(dir, "multi.yaml")},
 		flux.MustParseResourceID("default:deployment/list-deploy"):    []string{filepath.Join(dir, "list.yaml")},
+		flux.MustParseResourceID("default:deployment/semver"):         []string{filepath.Join(dir, "semver-deploy.yaml")},
 	}
 }
 
@@ -96,6 +98,31 @@ spec:
         - -addr=:8080
         ports:
         - containerPort: 8080
+`,
+	// Automated deployment with semver enabled
+	"semver-deploy.yaml": `---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: semver
+  annotations:
+    flux.weave.works/automated: "true"
+    flux.weave.works/tag.greeter: semver:*
+spec:
+  minReadySeconds: 1
+  replicas: 5
+  template:
+    metadata:
+      labels:
+        name: semver
+    spec:
+      containers:
+      - name: greeter
+        image: quay.io/weaveworks/helloworld:master-a000001
+        args:
+        - -msg=Ahoy
+        ports:
+        - containerPort: 80
 `,
 	"locked-service-deploy.yaml": `apiVersion: extensions/v1beta1
 kind: Deployment

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -142,7 +142,7 @@ func calculatePolicyChanges(opts *controllerPolicyOpts) (policy.Update, error) {
 			Add(policy.LockedUser)
 	}
 	if opts.tagAll != "" {
-		add = add.Set(policy.TagAll, "glob:"+opts.tagAll)
+		add = add.Set(policy.TagAll, policy.NewPattern(opts.tagAll).String())
 	}
 
 	for _, tagPair := range opts.tags {
@@ -153,7 +153,7 @@ func calculatePolicyChanges(opts *controllerPolicyOpts) (policy.Update, error) {
 
 		container, tag := parts[0], parts[1]
 		if tag != "*" {
-			add = add.Set(policy.TagPrefix(container), "glob:"+tag)
+			add = add.Set(policy.TagPrefix(container), policy.NewPattern(tag).String())
 		} else {
 			remove = remove.Add(policy.TagPrefix(container))
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -163,14 +163,14 @@ func (d *Daemon) ListImagesWithOptions(ctx context.Context, opts v10.ListImagesO
 		services, err = d.Cluster.SomeControllers([]flux.ResourceID{id})
 	}
 
-	imageRepos, err := update.FetchImageRepos(d.Registry, clusterContainers(services), d.Logger)
-	if err != nil {
-		return nil, errors.Wrap(err, "getting images for services")
-	}
-
 	policyResourceMap, _, err := d.getPolicyResourceMap(ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	imageRepos, err := update.FetchImageRepos(d.Registry, clusterContainers(services), d.Logger)
+	if err != nil {
+		return nil, errors.Wrap(err, "getting images for services")
 	}
 
 	var res []v6.ImageStatus

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -38,6 +38,7 @@ const (
 	svc               = "default:deployment/helloworld"
 	container         = "greeter"
 	ns                = "default"
+	oldHelloImage     = "quay.io/weaveworks/helloworld:3" // older in time but newer version!
 	newHelloImage     = "quay.io/weaveworks/helloworld:2"
 	currentHelloImage = "quay.io/weaveworks/helloworld:master-a000001"
 
@@ -151,6 +152,8 @@ func TestDaemon_ListImagesWithOptions(t *testing.T) {
 	assert.NoError(t, err)
 	newImageRef, err := image.ParseRef(newHelloImage)
 	assert.NoError(t, err)
+	oldImageRef, err := image.ParseRef(oldHelloImage)
+	assert.NoError(t, err)
 
 	// Service 2
 	anotherSvcID, err := flux.ParseResourceID(anotherSvc)
@@ -180,10 +183,11 @@ func TestDaemon_ListImagesWithOptions(t *testing.T) {
 							Available: []image.Info{
 								{ID: newImageRef},
 								{ID: currentImageRef},
+								{ID: oldImageRef},
 							},
-							AvailableImagesCount:    2,
+							AvailableImagesCount:    3,
 							NewAvailableImagesCount: 1,
-							FilteredImagesCount:     2,
+							FilteredImagesCount:     3,
 							NewFilteredImagesCount:  1,
 						},
 					},
@@ -222,10 +226,11 @@ func TestDaemon_ListImagesWithOptions(t *testing.T) {
 							Available: []image.Info{
 								{ID: newImageRef},
 								{ID: currentImageRef},
+								{ID: oldImageRef},
 							},
-							AvailableImagesCount:    2,
+							AvailableImagesCount:    3,
 							NewAvailableImagesCount: 1,
-							FilteredImagesCount:     2,
+							FilteredImagesCount:     3,
 							NewFilteredImagesCount:  1,
 						},
 					},
@@ -478,6 +483,57 @@ func TestDaemon_JobStatusWithNoCache(t *testing.T) {
 	w.ForJobSucceeded(d, id)
 }
 
+func TestDaemon_Automated(t *testing.T) {
+	d, start, clean, k8s, _ := mockDaemon(t)
+	start()
+	defer clean()
+	w := newWait(t)
+
+	service := cluster.Controller{
+		ID: flux.MakeResourceID(ns, "deployment", "helloworld"),
+		Containers: cluster.ContainersOrExcuse{
+			Containers: []resource.Container{
+				{
+					Name:  container,
+					Image: mustParseImageRef(currentHelloImage),
+				},
+			},
+		},
+	}
+	k8s.SomeServicesFunc = func([]flux.ResourceID) ([]cluster.Controller, error) {
+		return []cluster.Controller{service}, nil
+	}
+
+	// updates from helloworld:master-xxx to helloworld:2
+	w.ForImageTag(t, d, svc, container, "2")
+}
+
+func TestDaemon_Automated_semver(t *testing.T) {
+	d, start, clean, k8s, _ := mockDaemon(t)
+	start()
+	defer clean()
+	w := newWait(t)
+
+	resid := flux.MustParseResourceID("default:deployment/semver")
+	service := cluster.Controller{
+		ID: resid,
+		Containers: cluster.ContainersOrExcuse{
+			Containers: []resource.Container{
+				{
+					Name:  container,
+					Image: mustParseImageRef(currentHelloImage),
+				},
+			},
+		},
+	}
+	k8s.SomeServicesFunc = func([]flux.ResourceID) ([]cluster.Controller, error) {
+		return []cluster.Controller{service}, nil
+	}
+
+	// helloworld:3 is older than helloworld:2 but semver orders by version
+	w.ForImageTag(t, d, resid.String(), container, "3")
+}
+
 func makeImageInfo(ref string, t time.Time) image.Info {
 	return image.Info{ID: mustParseImageRef(ref), CreatedAt: t}
 }
@@ -506,13 +562,13 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 	}
 	multiService := []cluster.Controller{
 		singleService,
-		cluster.Controller{
+		{
 			ID: flux.MakeResourceID("another", "deployment", "service"),
 			Containers: cluster.ContainersOrExcuse{
 				Containers: []resource.Container{
 					{
-						Name:  "it-doesn't-matter",
-						Image: mustParseImageRef("another/service:latest"),
+						Name:  anotherContainer,
+						Image: mustParseImageRef(anotherImage),
 					},
 				},
 			},
@@ -560,6 +616,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 
 	var imageRegistry registry.Registry
 	{
+		img0 := makeImageInfo(oldHelloImage, time.Now().Add(-1*time.Second))
 		img1 := makeImageInfo(currentHelloImage, time.Now())
 		img2 := makeImageInfo(newHelloImage, time.Now().Add(1*time.Second))
 		img3 := makeImageInfo("another/service:latest", time.Now().Add(1*time.Second))
@@ -568,6 +625,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 				img1,
 				img2,
 				img3,
+				img0,
 			},
 		}
 	}
@@ -696,6 +754,32 @@ func (w *wait) ForSyncStatus(d *Daemon, rev string, expectedNumCommits int) []st
 		return err == nil && len(revs) == expectedNumCommits
 	}, fmt.Sprintf("Waiting for sync status to have %d commits", expectedNumCommits))
 	return revs
+}
+
+func (w *wait) ForImageTag(t *testing.T, d *Daemon, service, container, tag string) {
+	w.Eventually(func() bool {
+		co, err := d.Repo.Clone(context.TODO(), d.GitConfig)
+		if err != nil {
+			return false
+		}
+		defer co.Clean()
+
+		m, err := d.Manifests.LoadManifests(co.Dir(), co.ManifestDir())
+		assert.NoError(t, err)
+
+		resources, err := d.Manifests.ParseManifests(m[service].Bytes())
+		assert.NoError(t, err)
+
+		workload, ok := resources[service].(resource.Workload)
+		assert.True(t, ok)
+		for _, c := range workload.Containers() {
+			if c.Name == container && c.Image.Tag == tag {
+				return true
+			}
+		}
+		return false
+	}, fmt.Sprintf("Waiting for image tag: %q", tag))
+
 }
 
 func updateImage(ctx context.Context, d *Daemon, t *testing.T) job.ID {

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -48,7 +48,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 			repo := currentImageID.Name
 			logger := log.With(logger, "service", service.ID, "container", container.Name, "repo", repo, "pattern", pattern, "current", currentImageID)
 
-			filteredImages := imageRepos.GetRepoImages(repo).Filter(pattern)
+			filteredImages := imageRepos.GetRepoImages(repo).FilterAndSort(pattern)
 
 			if latest, ok := filteredImages.Latest(); ok && latest.ID != currentImageID {
 				if latest.ID.Tag == "" {

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -1,16 +1,14 @@
 package daemon
 
 import (
+	"context"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
-
-	"sync"
-
-	"context"
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"

--- a/policy/pattern.go
+++ b/policy/pattern.go
@@ -1,0 +1,93 @@
+package policy
+
+import (
+	"github.com/Masterminds/semver"
+	"github.com/ryanuber/go-glob"
+	"github.com/weaveworks/flux/image"
+	"strings"
+)
+
+const (
+	globPrefix   = "glob:"
+	semverPrefix = "semver:"
+)
+
+var (
+	// PatternAll matches everything.
+	PatternAll    = NewPattern(globPrefix + "*")
+	PatternLatest = NewPattern(globPrefix + "latest")
+)
+
+// Pattern provides an interface to match image tags.
+type Pattern interface {
+	// Matches returns true if the given image tag matches the pattern.
+	Matches(tag string) bool
+	// String returns the prefixed string representation.
+	String() string
+	// Newer returns true if image `a` is newer than image `b`.
+	Newer(a, b *image.Info) bool
+	// Valid returns true if the pattern is considered valid.
+	Valid() bool
+}
+
+type GlobPattern string
+
+// SemverPattern matches by semantic versioning.
+// See https://semver.org/
+type SemverPattern struct {
+	pattern     string // pattern without prefix
+	constraints *semver.Constraints
+}
+
+// NewPattern instantiates a Pattern according to the prefix
+// it finds. The prefix can be either `glob:` (default if omitted)
+// or `semver:`.
+
+func NewPattern(pattern string) Pattern {
+	if strings.HasPrefix(pattern, semverPrefix) {
+		pattern = strings.TrimPrefix(pattern, semverPrefix)
+		c, _ := semver.NewConstraint(pattern)
+		return SemverPattern{pattern, c}
+	}
+	return GlobPattern(strings.TrimPrefix(pattern, globPrefix))
+}
+
+func (g GlobPattern) Matches(tag string) bool {
+	return glob.Glob(string(g), tag)
+}
+
+func (g GlobPattern) String() string {
+	return globPrefix + string(g)
+}
+
+func (g GlobPattern) Newer(a, b *image.Info) bool {
+	return image.NewerByCreated(a, b)
+}
+
+func (g GlobPattern) Valid() bool {
+	return true
+}
+
+func (s SemverPattern) Matches(tag string) bool {
+	v, err := semver.NewVersion(tag)
+	if err != nil {
+		return false
+	}
+	if s.constraints == nil {
+		// Invalid constraints match anything
+		return true
+	}
+	return s.constraints.Check(v)
+}
+
+func (s SemverPattern) String() string {
+	return semverPrefix + s.pattern
+}
+
+func (s SemverPattern) Newer(a, b *image.Info) bool {
+	return image.NewerBySemver(a, b)
+}
+
+func (s SemverPattern) Valid() bool {
+	return s.constraints != nil
+}

--- a/policy/pattern_test.go
+++ b/policy/pattern_test.go
@@ -1,0 +1,88 @@
+package policy
+
+import (
+	"testing"
+
+	"fmt"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGlobPattern_Matches(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		pattern string
+		true    []string
+		false   []string
+	}{
+		{
+			name:    "all",
+			pattern: "*",
+			true:    []string{"", "1", "foo"},
+			false:   nil,
+		},
+		{
+			name:    "all prefixed",
+			pattern: "glob:*",
+			true:    []string{"", "1", "foo"},
+			false:   nil,
+		},
+		{
+			name:    "prefix",
+			pattern: "master-*",
+			true:    []string{"master-", "master-foo"},
+			false:   []string{"", "foo-master"},
+		},
+	} {
+		pattern := NewPattern(tt.pattern)
+		assert.IsType(t, GlobPattern(""), pattern)
+		t.Run(tt.name, func(t *testing.T) {
+			for _, tag := range tt.true {
+				assert.True(t, pattern.Matches(tag))
+			}
+			for _, tag := range tt.false {
+				assert.False(t, pattern.Matches(tag))
+			}
+		})
+	}
+}
+
+func TestSemverPattern_Matches(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		pattern string
+		true    []string
+		false   []string
+	}{
+		{
+			name:    "all",
+			pattern: "semver:*",
+			true:    []string{"1", "1.0", "v1.0.3"},
+			false:   []string{"", "latest", "2.0.1-alpha.1"},
+		},
+		{
+			name:    "semver",
+			pattern: "semver:~1",
+			true:    []string{"v1", "1", "1.2", "1.2.3"},
+			false:   []string{"", "latest", "2.0.0"},
+		},
+		{
+			name:    "semver pre-release",
+			pattern: "semver:2.0.1-alpha.1",
+			true:    []string{"2.0.1-alpha.1"},
+			false:   []string{"2.0.1"},
+		},
+	} {
+		pattern := NewPattern(tt.pattern)
+		assert.IsType(t, SemverPattern{}, pattern)
+		for _, tag := range tt.true {
+			t.Run(fmt.Sprintf("%s[%q]", tt.name, tag), func(t *testing.T) {
+				assert.True(t, pattern.Matches(tag))
+			})
+		}
+		for _, tag := range tt.false {
+			t.Run(fmt.Sprintf("%s[%q]", tt.name, tag), func(t *testing.T) {
+				assert.False(t, pattern.Matches(tag))
+			})
+		}
+	}
+}

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -36,15 +36,19 @@ func Tag(policy Policy) bool {
 	return strings.HasPrefix(string(policy), "tag.")
 }
 
-func GetTagPattern(services ResourceMap, service flux.ResourceID, container string) string {
+func GetTagPattern(services ResourceMap, service flux.ResourceID, container string) Pattern {
 	if services == nil {
-		return "*"
+		return PatternAll
 	}
-	policies := services[service]
-	if pattern, ok := policies.Get(TagPrefix(container)); ok {
-		return strings.TrimPrefix(pattern, "glob:")
+	policies, ok := services[service]
+	if !ok {
+		return PatternAll
 	}
-	return "*"
+	pattern, ok := policies.Get(TagPrefix(container))
+	if !ok {
+		return PatternAll
+	}
+	return NewPattern(pattern)
 }
 
 type Updates map[flux.ResourceID]Update

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -63,17 +63,17 @@ func Test_GetTagPattern(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want string
+		want Pattern
 	}{
 		{
 			name: "Nil policies",
 			args: args{services: nil},
-			want: "*",
+			want: PatternAll,
 		},
 		{
 			name: "No match",
 			args: args{services: ResourceMap{}},
-			want: "*",
+			want: PatternAll,
 		},
 		{
 			name: "Match",
@@ -86,13 +86,14 @@ func Test_GetTagPattern(t *testing.T) {
 				service:   resourceID,
 				container: container,
 			},
-			want: "master-*",
+			want: NewPattern("master-*"),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := GetTagPattern(tt.args.services, tt.args.service, tt.args.container); got != tt.want {
 				t.Errorf("GetTagPattern() = %v, want %v", got, tt.want)
+
 			}
 		})
 	}

--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -66,14 +66,14 @@ Loop:
 		case <-timeout.C:
 			t.Fatal("Cache timeout")
 		case <-tick.C:
-			_, err := r.GetSortedRepositoryImages(id.Name)
+			_, err := r.GetRepositoryImages(id.Name)
 			if err == nil {
 				break Loop
 			}
 		}
 	}
 
-	img, err := r.GetSortedRepositoryImages(id.Name)
+	img, err := r.GetRepositoryImages(id.Name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"encoding/json"
-	"sort"
 	"time"
 
 	"github.com/pkg/errors"
@@ -31,9 +30,9 @@ type Cache struct {
 	Reader Reader
 }
 
-// GetSortedRepositoryImages returns the list of image manifests in an image
+// GetRepositoryImages returns the list of image manifests in an image
 // repository (e.g,. at "quay.io/weaveworks/flux")
-func (c *Cache) GetSortedRepositoryImages(id image.Name) ([]image.Info, error) {
+func (c *Cache) GetRepositoryImages(id image.Name) ([]image.Info, error) {
 	repoKey := NewRepositoryKey(id.CanonicalName())
 	bytes, _, err := c.Reader.GetKey(repoKey)
 	if err != nil {
@@ -59,7 +58,6 @@ func (c *Cache) GetSortedRepositoryImages(id image.Name) ([]image.Info, error) {
 		images[i] = im
 		i++
 	}
-	sort.Sort(image.ByCreatedDesc(images))
 	return images, nil
 }
 

--- a/registry/cache/warming_test.go
+++ b/registry/cache/warming_test.go
@@ -71,7 +71,7 @@ func TestWarm(t *testing.T) {
 	warmer.warm(context.TODO(), logger, repo, registry.NoCredentials())
 
 	registry := &Cache{Reader: c}
-	repoInfo, err := registry.GetSortedRepositoryImages(ref.Name)
+	repoInfo, err := registry.GetRepositoryImages(ref.Name)
 	if err != nil {
 		t.Error(err)
 	}

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -2,8 +2,6 @@ package mock
 
 import (
 	"context"
-	"sort"
-
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux/image"
@@ -41,7 +39,7 @@ type Registry struct {
 	Err    error
 }
 
-func (m *Registry) GetSortedRepositoryImages(id image.Name) ([]image.Info, error) {
+func (m *Registry) GetRepositoryImages(id image.Name) ([]image.Info, error) {
 	var imgs []image.Info
 	for _, i := range m.Images {
 		// include only if it's the same repository in the same place
@@ -49,7 +47,6 @@ func (m *Registry) GetSortedRepositoryImages(id image.Name) ([]image.Info, error
 			imgs = append(imgs, i)
 		}
 	}
-	sort.Sort(image.ByCreatedDesc(imgs))
 	return imgs, m.Err
 }
 

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -46,9 +46,9 @@ func NewInstrumentedRegistry(next Registry) Registry {
 	}
 }
 
-func (m *instrumentedRegistry) GetSortedRepositoryImages(id image.Name) (res []image.Info, err error) {
+func (m *instrumentedRegistry) GetRepositoryImages(id image.Name) (res []image.Info, err error) {
 	start := time.Now()
-	res, err = m.next.GetSortedRepositoryImages(id)
+	res, err = m.next.GetRepositoryImages(id)
 	registryDuration.With(
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -12,7 +12,7 @@ var (
 
 // Registry is a store of image metadata.
 type Registry interface {
-	GetSortedRepositoryImages(image.Name) ([]image.Info, error)
+	GetRepositoryImages(image.Name) ([]image.Info, error)
 	GetImage(image.Ref) (image.Info, error)
 }
 

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -1,7 +1,6 @@
 package release
 
 import (
-	"encoding/json"
 	"fmt"
 	"reflect"
 	"testing"
@@ -203,6 +202,7 @@ func Test_FilterLogic(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
 			},
 		}, {
 			Name: "exclude specific service",
@@ -235,6 +235,7 @@ func Test_FilterLogic(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
 			},
 		}, {
 			Name: "update specific image",
@@ -262,6 +263,7 @@ func Test_FilterLogic(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
 			},
 		},
 		// skipped if: not ignored AND (locked or not found in cluster)
@@ -297,6 +299,7 @@ func Test_FilterLogic(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
 			},
 		},
 		{
@@ -330,6 +333,7 @@ func Test_FilterLogic(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
 				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
+				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
 			},
 		},
 		{
@@ -346,6 +350,7 @@ func Test_FilterLogic(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
 				flux.MustParseResourceID(notInRepoService):                    skippedNotInRepo,
 			},
 		},
@@ -397,6 +402,7 @@ func Test_ImageStatus(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
 					Status: update.ReleaseStatusIgnored,
 					Error:  update.DoesNotUseImage,
@@ -419,6 +425,7 @@ func Test_ImageStatus(t *testing.T) {
 				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
 				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
+				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
 			},
 		},
 	} {
@@ -686,14 +693,8 @@ func Test_UpdateContainers(t *testing.T) {
 
 func testRelease(t *testing.T, ctx *ReleaseContext, spec update.ReleaseSpec, expected update.Result) {
 	results, err := Release(ctx, spec, log.NewNopLogger())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(expected, results) {
-		exp, _ := json.Marshal(expected)
-		got, _ := json.Marshal(results)
-		t.Errorf("--- expected ---\n%s\n--- got ---\n%s\n", string(exp), string(got))
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, expected, results)
 }
 
 // --- test verification

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -160,7 +160,7 @@ func listImagesWithOptions(ctx context.Context, client listImagesWithOptionsClie
 		for j, container := range image.Containers {
 			tagPattern := policy.GetTagPattern(policyMap, image.ID, container.Name)
 			// Create a new container using the same function used in v10
-			newContainer, err := v6.NewContainer(container.Name, container.Available, container.Current, tagPattern, opts.OverrideContainerFields)
+			newContainer, err := v6.NewContainer(container.Name, update.ImageInfos(container.Available), container.Current, tagPattern, opts.OverrideContainerFields)
 			if err != nil {
 				return images, err
 			}

--- a/site/using.md
+++ b/site/using.md
@@ -389,6 +389,20 @@ individually:
 fluxctl policy --controller=default:deployment/helloworld --tag='helloworld=prod-*' --tag='sidecar=prod-*'
 ``` 
 
+If your images use [semantic versioning](https://semver.org) you can filter by image tags
+that adhere to certain constraints:
+```
+fluxctl policy --controller=default:deployment/helloworld --tag-all='semver:~1'
+```
+
+or only release images that have a stable semantic version tag (X.Y.Z):
+```
+fluxctl policy --controller=default:deployment/helloworld --tag-all='semver:*'
+```
+
+This will also affect the way flux determines the newest image tag
+by looking at the newest version instead of image creation date.
+
 ## Actions triggered through `fluxctl`
 
 `fluxctl` provides the following flags for the message and author customization:

--- a/site/using.md
+++ b/site/using.md
@@ -400,8 +400,8 @@ or only release images that have a stable semantic version tag (X.Y.Z):
 fluxctl policy --controller=default:deployment/helloworld --tag-all='semver:*'
 ```
 
-This will also affect the way flux determines the newest image tag
-by looking at the newest version instead of image creation date.
+Using a semver filter will also affect how flux sorts images, so
+that the higher versions will be considered newer.
 
 ## Actions triggered through `fluxctl`
 

--- a/site/using.md
+++ b/site/using.md
@@ -366,17 +366,24 @@ When building images it is often useful to tag build images by the branch that t
 quay.io/weaveworks/helloworld:master-9a16ff945b9e
 ```
 
-Indicates that the "helloworld" image was built against master commit "9a16ff945b9e". 
+Indicates that the "helloworld" image was built against master
+commit "9a16ff945b9e".
 
-When automation is turned on flux will, by default, use whatever is the latest image on a given repository. If you want to only auto-update your image against a certain subset of tags then you can do that using tag filtering.
+When automation is turned on flux will, by default, use whatever
+is the latest image on a given repository. If you want to only
+auto-update your image against a certain subset of tags then you
+can do that using tag filtering.
 
-So for example, if you want to only update the "helloworld" image to tags that were built against the "prod" branch then you could do the following:
+So for example, if you want to only update the "helloworld" image
+to tags that were built against the "prod" branch then you could
+do the following:
 
 ```
 fluxctl policy --controller=default:deployment/helloworld --tag-all='prod-*'
 ```
 
-If your pod contains multiple containers then you tag each container individually:
+If your pod contains multiple containers then you tag each container
+individually:
 
 ```
 fluxctl policy --controller=default:deployment/helloworld --tag='helloworld=prod-*' --tag='sidecar=prod-*'

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -27,7 +27,7 @@ func TestDecanon(t *testing.T) {
 		name: infos,
 	}}
 
-	filteredImages := m.GetRepoImages(mustParseName("weaveworks/helloworld")).Filter(policy.PatternAll)
+	filteredImages := m.GetRepoImages(mustParseName("weaveworks/helloworld")).FilterAndSort(policy.PatternAll)
 	latest, ok := filteredImages.Latest()
 	if !ok {
 		t.Error("did not find latest image")
@@ -35,7 +35,7 @@ func TestDecanon(t *testing.T) {
 		t.Error("name did not match what was asked")
 	}
 
-	filteredImages = m.GetRepoImages(mustParseName("index.docker.io/weaveworks/helloworld")).Filter(policy.PatternAll)
+	filteredImages = m.GetRepoImages(mustParseName("index.docker.io/weaveworks/helloworld")).FilterAndSort(policy.PatternAll)
 	latest, ok = filteredImages.Latest()
 	if !ok {
 		t.Error("did not find latest image")
@@ -62,10 +62,10 @@ func TestImageInfos_Filter_latest(t *testing.T) {
 		ID: image.Ref{Name: image.Name{Image: "moon"}, Tag: "v0"},
 	}
 	ii := ImageInfos{latest, other}
-	assert.Equal(t, ImageInfos{latest}, ii.Filter(policy.PatternLatest))
-	assert.Equal(t, ImageInfos{latest}, ii.Filter(policy.NewPattern("latest")))
-	assert.Equal(t, ImageInfos{other}, ii.Filter(policy.PatternAll))
-	assert.Equal(t, ImageInfos{other}, ii.Filter(policy.NewPattern("*")))
+	assert.Equal(t, SortedImageInfos{latest}, ii.FilterAndSort(policy.PatternLatest))
+	assert.Equal(t, SortedImageInfos{latest}, ii.FilterAndSort(policy.NewPattern("latest")))
+	assert.Equal(t, SortedImageInfos{other}, ii.FilterAndSort(policy.PatternAll))
+	assert.Equal(t, SortedImageInfos{other}, ii.FilterAndSort(policy.NewPattern("*")))
 }
 
 func TestImageInfos_Filter_semver(t *testing.T) {
@@ -74,8 +74,8 @@ func TestImageInfos_Filter_semver(t *testing.T) {
 	semver1 := image.Info{ID: image.Ref{Name: image.Name{Image: "earth"}, Tag: "1.0.0"}}
 
 	ii := ImageInfos{latest, semver0, semver1}
-	assert.Equal(t, ImageInfos{semver1, semver0}, ii.Filter(policy.NewPattern("semver:*")))
-	assert.Equal(t, ImageInfos{semver1}, ii.Filter(policy.NewPattern("semver:~1")))
+	assert.Equal(t, SortedImageInfos{semver1, semver0}, ii.FilterAndSort(policy.NewPattern("semver:*")))
+	assert.Equal(t, SortedImageInfos{semver1}, ii.FilterAndSort(policy.NewPattern("semver:~1")))
 }
 
 func TestAvail(t *testing.T) {

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -4,7 +4,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/policy"
 )
 
 var (
@@ -24,7 +27,7 @@ func TestDecanon(t *testing.T) {
 		name: infos,
 	}}
 
-	filteredImages := m.GetRepoImages(mustParseName("weaveworks/helloworld")).Filter("*")
+	filteredImages := m.GetRepoImages(mustParseName("weaveworks/helloworld")).Filter(policy.PatternAll)
 	latest, ok := filteredImages.Latest()
 	if !ok {
 		t.Error("did not find latest image")
@@ -32,7 +35,7 @@ func TestDecanon(t *testing.T) {
 		t.Error("name did not match what was asked")
 	}
 
-	filteredImages = m.GetRepoImages(mustParseName("index.docker.io/weaveworks/helloworld")).Filter("*")
+	filteredImages = m.GetRepoImages(mustParseName("index.docker.io/weaveworks/helloworld")).Filter(policy.PatternAll)
 	latest, ok = filteredImages.Latest()
 	if !ok {
 		t.Error("did not find latest image")
@@ -49,6 +52,30 @@ func TestDecanon(t *testing.T) {
 			t.Errorf("got image with name %q", im.ID.String())
 		}
 	}
+}
+
+func TestImageInfos_Filter_latest(t *testing.T) {
+	latest := image.Info{
+		ID: image.Ref{Name: image.Name{Image: "flux"}, Tag: "latest"},
+	}
+	other := image.Info{
+		ID: image.Ref{Name: image.Name{Image: "moon"}, Tag: "v0"},
+	}
+	ii := ImageInfos{latest, other}
+	assert.Equal(t, ImageInfos{latest}, ii.Filter(policy.PatternLatest))
+	assert.Equal(t, ImageInfos{latest}, ii.Filter(policy.NewPattern("latest")))
+	assert.Equal(t, ImageInfos{other}, ii.Filter(policy.PatternAll))
+	assert.Equal(t, ImageInfos{other}, ii.Filter(policy.NewPattern("*")))
+}
+
+func TestImageInfos_Filter_semver(t *testing.T) {
+	latest := image.Info{ID: image.Ref{Name: image.Name{Image: "flux"}, Tag: "latest"}}
+	semver0 := image.Info{ID: image.Ref{Name: image.Name{Image: "moon"}, Tag: "v0.0.1"}}
+	semver1 := image.Info{ID: image.Ref{Name: image.Name{Image: "earth"}, Tag: "1.0.0"}}
+
+	ii := ImageInfos{latest, semver0, semver1}
+	assert.Equal(t, ImageInfos{semver1, semver0}, ii.Filter(policy.NewPattern("semver:*")))
+	assert.Equal(t, ImageInfos{semver1}, ii.Filter(policy.NewPattern("semver:~1")))
 }
 
 func TestAvail(t *testing.T) {

--- a/update/release.go
+++ b/update/release.go
@@ -231,7 +231,7 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		for _, container := range containers {
 			currentImageID := container.Image
 
-			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).Filter("*")
+			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).Filter(policy.PatternAll)
 			latestImage, ok := filteredImages.Latest()
 			if !ok {
 				if currentImageID.CanonicalName() != singleRepo {

--- a/update/release.go
+++ b/update/release.go
@@ -231,7 +231,7 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		for _, container := range containers {
 			currentImageID := container.Image
 
-			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).Filter(policy.PatternAll)
+			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).FilterAndSort(policy.PatternAll)
 			latestImage, ok := filteredImages.Latest()
 			if !ok {
 				if currentImageID.CanonicalName() != singleRepo {


### PR DESCRIPTION
Currently, containers can be tagged in manifests to filter what image
tags are considered when doing automated releases. Filtering is done by
specifying a wildcard glob. An optional prefix `glob:` can be used.

This PR adds support for tag filters based on [semantic versioning][0]
by using the prefix `semver:` instead. Version constraints can be
specified that filter images. Since versions have an implicit ordering
this also changes the way images are sorted when trying to determine the
newest image. For glob filtering this falls back to image creation date.

[0]: https://semver.org

Closes #706 