### PR TITLE
Manual releases comply with container image tag filters; and --force

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -171,7 +171,7 @@ func promptSpec(out io.Writer, result job.Result, verbosity int) (update.Contain
 	menu := update.NewMenu(out, result.Result, verbosity)
 	containerSpecs, err := menu.Run()
 	return update.ContainerSpecs{
-		Kind: update.ReleaseKindExecute,
+		Kind:           update.ReleaseKindExecute,
 		ContainerSpecs: containerSpecs,
 		SkipMismatches: false,
 	}, err

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -22,6 +22,7 @@ type controllerReleaseOpts struct {
 	exclude        []string
 	dryRun         bool
 	interactive    bool
+	force          bool
 	outputOpts
 	cause update.Cause
 
@@ -55,6 +56,7 @@ func (opts *controllerReleaseOpts) Command() *cobra.Command {
 	cmd.Flags().StringSliceVar(&opts.exclude, "exclude", []string{}, "List of controllers to exclude")
 	cmd.Flags().BoolVar(&opts.dryRun, "dry-run", false, "Do not release anything; just report back what would have been done")
 	cmd.Flags().BoolVar(&opts.interactive, "interactive", false, "Select interactively which containers to update")
+	cmd.Flags().BoolVarP(&opts.force, "force", "f", false, "Disregard locks and container image filters (has no effect when used with --all or --update-all-images)")
 
 	// Deprecated
 	cmd.Flags().StringSliceVarP(&opts.services, "service", "s", []string{}, "Service to release")
@@ -76,8 +78,16 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-	if len(opts.controllers) <= 0 && !opts.allControllers {
+
+	switch {
+	case len(opts.controllers) <= 0 && !opts.allControllers:
 		return newUsageError("please supply either --all, or at least one --controller=<controller>")
+	case opts.force && opts.allControllers && opts.allImages:
+		return newUsageError("--force has no effect when used with --all and --update-all-images")
+	case opts.force && opts.allControllers:
+		fmt.Fprintf(cmd.OutOrStderr(), "Warning: --force will not ignore locked controllers when used with --all\n")
+	case opts.force && opts.allImages:
+		fmt.Fprintf(cmd.OutOrStderr(), "Warning: --force will not ignore container image tags when used with --update-all-images\n")
 	}
 
 	var controllers []update.ResourceSpec
@@ -133,6 +143,7 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		ImageSpec:    image,
 		Kind:         kind,
 		Excludes:     excludes,
+		Force:        opts.force,
 	}
 	jobID, err := opts.API.UpdateManifests(ctx, update.Spec{
 		Type:  update.Images,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -340,16 +340,15 @@ func TestDaemon_NotifyChange(t *testing.T) {
 	}
 
 	// Check that history was written to
-	var e []event.Event
 	w.Eventually(func() bool {
-		e, _ = events.AllEvents(time.Time{}, -1, time.Time{})
-		return len(e) > 0
-	}, "Waiting for new events")
-	if 1 != len(e) {
-		t.Fatal("Expected one log event from the sync, but got", len(e))
-	} else if event.EventSync != e[0].Type {
-		t.Fatalf("Expected event with type %s but got %s", event.EventSync, e[0].Type)
-	}
+		es, _ := events.AllEvents(time.Time{}, -1, time.Time{})
+		for _, e := range es {
+			if e.Type == event.EventSync {
+				return true
+			}
+		}
+		return false
+	}, "Waiting for new sync events")
 }
 
 // When I perform a release, it should add a job to update git to the queue

--- a/update/release.go
+++ b/update/release.go
@@ -231,7 +231,12 @@ func (s ReleaseSpec) calculateImageUpdates(rc ReleaseContext, candidates []*Cont
 		for _, container := range containers {
 			currentImageID := container.Image
 
-			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).FilterAndSort(policy.PatternAll)
+			tagPattern := policy.PatternAll
+			if pattern, ok := u.Resource.Policy().Get(policy.TagPrefix(container.Name)); ok {
+				tagPattern = policy.NewPattern(pattern)
+			}
+
+			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).FilterAndSort(tagPattern)
 			latestImage, ok := filteredImages.Latest()
 			if !ok {
 				if currentImageID.CanonicalName() != singleRepo {

--- a/update/release.go
+++ b/update/release.go
@@ -122,13 +122,13 @@ func (s ReleaseSpec) filters(rc ReleaseContext) ([]ControllerFilter, []Controlle
 	var prefilters, postfilters []ControllerFilter
 
 	ids := []flux.ResourceID{}
-	for _, s := range s.ServiceSpecs {
-		if s == ResourceSpecAll {
+	for _, ss := range s.ServiceSpecs {
+		if ss == ResourceSpecAll {
 			// "<all>" Overrides any other filters
 			ids = []flux.ResourceID{}
 			break
 		}
-		id, err := flux.ParseResourceID(string(s))
+		id, err := flux.ParseResourceID(string(ss))
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
This PR makes manual releases to comply with container image tag filters (previously only automated releases did so), and adds the option to `force` a release outside of these constraints. `force` also ignores locked controllers when targeted at specific controllers.

Please have a lock at individual commit messages for further details. 

Closes #941 
Closes #1054