### PR TITLE
Avoid constant re-deployment of charts with multiple inline dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -762,6 +762,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "7f84e47c8d31056c53dd93d1ea0f705e5ce822eece988d8c5a1839365b33c59e"
+  inputs-digest = "2c24153e0bc861ad36def5316832ca62468561105ca3996b996e7cb7131cca4b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -165,6 +165,17 @@
   revision = "e89373fe6b4a7413d7acd6da1725b83ef713e6e4"
 
 [[projects]]
+  name = "github.com/google/go-cmp"
+  packages = [
+    "cmp",
+    "cmp/internal/diff",
+    "cmp/internal/function",
+    "cmp/internal/value"
+  ]
+  revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
+  version = "v0.2.0"
+
+[[projects]]
   branch = "master"
   name = "github.com/google/gofuzz"
   packages = ["."]
@@ -268,6 +279,12 @@
   packages = ["."]
   revision = "4b7aa43c6742a2c18fdef89dd197aaae7dac7ccd"
   version = "1.0.1"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/ncabatoff/go-seq"
+  packages = ["seq"]
+  revision = "b08ef85ed83364cba413c98a94bbd4169a0ce70b"
 
 [[projects]]
   name = "github.com/opencontainers/go-digest"
@@ -745,6 +762,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1d8f352c4b156819b80ca52ed9c1a80d8bfa4ebd1af4a1bc63a8a5f480282459"
+  inputs-digest = "7f84e47c8d31056c53dd93d1ea0f705e5ce822eece988d8c5a1839365b33c59e"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -113,6 +113,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator`
 | `helmOperator.tag` | Helm operator image tag | `0.1.0-alpha`
 | `helmOperator.pullPolicy` | Helm operator image pull policy | `IfNotPresent`
+| `helmOperator.logReleaseDiffs` | Helm operator should log the diff when a chart release diverges (possibly insecure) | `false`
 | `helmOperator.tillerNamespace` | Namespace in which the Tiller server can be found | `kube-system`
 | `helmOperator.tls.enable` | Enable TLS for communicating with Tiller | `false`
 | `helmOperator.tls.verify` | Verify the Tiller certificate, also enables TLS when set to true | `false`

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -70,6 +70,7 @@ spec:
         - --git-url={{ .Values.git.url }}
         - --git-branch={{ .Values.git.branch }}
         - --git-charts-path={{ .Values.git.chartsPath }}
+        - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
         {{- if .Values.helmOperator.tls.enable }}
         - --tiller-tls-enable={{ .Values.helmOperator.tls.enable }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -20,6 +20,7 @@ helmOperator:
   tag: 0.1.1-alpha
   pullPolicy: IfNotPresent
   tillerNamespace: kube-system
+  logReleaseDiffs: false
   tls:
     secretName: 'helm-client-certs'
     verify: false

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -382,7 +382,7 @@ func (chs *ChartChangeSync) shouldUpgrade(chartsRepo string, currRel *hapi_relea
 	// compare values && Chart
 	if diff := cmp.Diff(currVals, desVals); diff != "" {
 		if chs.logDiffs {
-			chs.logger.Log("error", fmt.Sprintf("Release %s: values have diverged due to manual Chart release, diff: %s", currRel.GetName(), diff))
+			chs.logger.Log("error", fmt.Sprintf("Release %s: values have diverged due to manual Chart release", currRel.GetName()), "diff", diff)
 		} else {
 			chs.logger.Log("error", fmt.Sprintf("Release %s: values have diverged due to manual Chart release", currRel.GetName()))
 		}
@@ -391,7 +391,7 @@ func (chs *ChartChangeSync) shouldUpgrade(chartsRepo string, currRel *hapi_relea
 
 	if diff := cmp.Diff(sortChartFields(currChart), sortChartFields(desChart)); diff != "" {
 		if chs.logDiffs {
-			chs.logger.Log("error", fmt.Sprintf("Release %s: Chart has diverged due to manual Chart release, diff: %s", currRel.GetName(), diff))
+			chs.logger.Log("error", fmt.Sprintf("Release %s: Chart has diverged due to manual Chart release", currRel.GetName()), "diff", diff)
 		} else {
 			chs.logger.Log("error", fmt.Sprintf("Release %s: Chart has diverged due to manual Chart release", currRel.GetName()))
 		}

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/golang/glog"
+	"github.com/google/go-cmp/cmp"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -327,9 +328,9 @@ func (c *Controller) enqueueUpateJob(old, new interface{}) {
 		return
 	}
 
-	if needsUpdate(oldFhr, newFhr) {
+	if diff := cmp.Diff(oldFhr.Spec, newFhr.Spec); diff != "" {
 		c.logger.Log("info", "UPGRADING release")
-		c.logger.Log("info", "Custom Resource driven release upgrade")
+		c.logger.Log("info", fmt.Sprintf("Custom Resource driven release upgrade, diff:\n%s", diff))
 		c.enqueueJob(new)
 	}
 }
@@ -343,31 +344,4 @@ func (c *Controller) deleteRelease(fhr ifv1.FluxHelmRelease) {
 		c.logger.Log("error", fmt.Sprintf("Chart release [%s] not deleted: %#v", name, err))
 	}
 	return
-}
-
-// needsUpdate compares two FluxHelmRelease and determines if any changes occurred
-func needsUpdate(old, new ifv1.FluxHelmRelease) bool {
-	oldValues, err := old.Spec.Values.YAML()
-	if err != nil {
-		return false
-	}
-
-	newValues, err := new.Spec.Values.YAML()
-	if err != nil {
-		return false
-	}
-
-	if oldValues != newValues {
-		return true
-	}
-
-	if old.Spec.ReleaseName != new.Spec.ReleaseName {
-		return true
-	}
-
-	if old.Spec.ChartGitPath != new.Spec.ChartGitPath {
-		return true
-	}
-
-	return false
 }

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -334,9 +334,9 @@ func (c *Controller) enqueueUpateJob(old, new interface{}) {
 	if diff := cmp.Diff(oldFhr.Spec, newFhr.Spec); diff != "" {
 		c.logger.Log("info", "UPGRADING release")
 		if c.logDiffs {
-			c.logger.Log("info", fmt.Sprintf("Custom Resource driven release upgrade, diff:\n%s", diff))
+			c.logger.Log("info", "Custom Resource driven release upgrade", "diff", diff)
 		} else {
-			c.logger.Log("info", fmt.Sprintf("Custom Resource driven release upgrade"))
+			c.logger.Log("info", "Custom Resource driven release upgrade")
 		}
 		c.enqueueJob(new)
 	}


### PR DESCRIPTION
Fix for #1235.  Sort slices in chart structures whose ordering is arbitrary, e.g. depended-upon charts, so that the charts can be properly compared.

Right now it logs the diff between values and the diff between charts when there are discrepancies.  If this PR is accepted we should probably add an option and make the logging behaviour opt-in: even though sensitive data should not be present in charts or values, it could be, and there's no reason to make a bad security situation worse.

The logging of diffs works great when processing a git-driven change.  When reverting a manual change made to a release's values it doesn't work so well: we get the entire before and after config yaml, making for a very large and hard to read diff if there are a lot of values.  It seems that the Helm API isn't populating Config.Values, only Config.Raw.  I haven't found a way around this yet.

I wrote some tests that demonstrated the problem that passed with this fix, but sadly the tests I was extending in integrations/helm/releasesync/releasesync_test.go seem to be gone on the master branch.  I'm not really sad, I'm happy with the new chartsync.go and the deleted tests don't make sense in the new context, but I'll have to see what I can do it in terms of automated tests for this area of the code.