### PR TITLE
Verify known_host ssh keys during image build

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -7,6 +7,11 @@ RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
 RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
+
+# Verify newly added known_hosts (man-in-middle mitigation)
+ADD ./verify_known_hosts /home/flux/verify_known_hosts
+RUN sh /home/flux/verify_known_hosts /etc/ssh/ssh_known_hosts && rm /home/flux/verify_known_hosts
+
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config
 

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -10,6 +10,10 @@ RUN ssh-keyscan github.com gitlab.com bitbucket.org >> /etc/ssh/ssh_known_hosts
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config
 
+# Verify newly added known_hosts (man-in-middle mitigation)
+ADD ./verify_known_hosts /home/flux/verify_known_hosts
+RUN sh /home/flux/verify_known_hosts /etc/ssh/ssh_known_hosts && rm /home/flux/verify_known_hosts
+
 COPY ./kubectl /usr/local/bin/
 
 # These are pretty static

--- a/docker/verify_known_hosts
+++ b/docker/verify_known_hosts
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+set -e
+
+known_hosts_file=${1}
+known_hosts_file=${known_hosts_file:-/etc/ssh/ssh_known_hosts}
+
+# Verify github ssh keys
+github_rsa_fingerprint=$(sed "1q;d" < "${known_hosts_file}" | ssh-keygen -l -f -| cut -d " " -f 2)
+
+if [[ "${github_rsa_fingerprint}" != "SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8" ]]; then
+  echo "The github ssh key fingerprint ${github_rsa_fingerprint} does not match expectations" && \
+  echo "Aborting build" && \
+  exit 1;
+fi
+
+# Verify gitlab ssh keys
+gitlab_rsa_fingerprint=$(sed "2q;d" < "${known_hosts_file}" | ssh-keygen -l -f -| cut -d " " -f 2) && \
+gitlab_ecdsa_fingerprint=$(sed "3q;d" < "${known_hosts_file}" | ssh-keygen -l -f -| cut -d " " -f 2) && \
+gitlab_ed25519_fingerprint=$(sed "4q;d" < "${known_hosts_file}" | ssh-keygen -l -f -| cut -d " " -f 2)
+
+if [[ "${gitlab_rsa_fingerprint}" != "SHA256:ROQFvPThGrW4RuWLoL9tq9I9zJ42fK4XywyRtbOz/EQ" ]]; then
+  echo "The gitlab ssh key fingerprint ${gitlab_rsa_fingerprint} does not match expectations" && \
+  echo "Aborting build" && \
+  exit 1;
+fi
+
+if [[ "${gitlab_ecdsa_fingerprint}" != "SHA256:HbW3g8zUjNSksFbqTiUWPWg2Bq1x8xdGUrliXFzSnUw" ]]; then
+  echo "The gitlab ssh key fingerprint ${gitlab_ecdsa_fingerprint} does not match expectations" && \
+  echo "Aborting build" && \
+  exit 1;
+fi
+
+if [[ "${gitlab_ed25519_fingerprint}" != "SHA256:eUXGGm1YGsMAS7vkcx6JOJdOGHPem5gQp4taiCfCLB8" ]]; then
+  echo "The gitlab ssh key fingerprint ${gitlab_ed25519_fingerprint} does not match expectations" && \
+  echo "Aborting build" && \
+  exit 1;
+fi
+
+# Verify bitbucket ssh keys
+bitbucket_rsa_fingerprint=$(sed "5q;d" < "${known_hosts_file}" | ssh-keygen -l -f -| cut -d " " -f 2)
+
+if [[ "${bitbucket_rsa_fingerprint}" != "SHA256:zzXQOXSRBEiUtuE8AikJYKwbHaxvSc0ojez9YXaGp1A" ]]; then
+  echo "The bitbucket ssh key fingerprint ${bitbucket_rsa_fingerprint} does not match expectations" && \
+  echo "Aborting build" && \
+  exit 1;
+fi


### PR DESCRIPTION
What does this commit/MR do?

- Verifies the known_hosts match expectations after running a
ssh-keyscan on the git hosts

Why is this commit/MR needed?

- To mitigate (albeit unlikely) man-in-middle attacks