### PR TITLE
Get image pull secrets via serviceAccounts

### DIFF
--- a/cluster/kubernetes/images.go
+++ b/cluster/kubernetes/images.go
@@ -19,7 +19,8 @@ func mergeCredentials(log func(...interface{}) error, client extendedClient, nam
 	if saName == "" {
 		saName = "default"
 	}
-	sa, err := client.ServiceAccounts(namespace).Get(saName, meta_v1.GetOptions{})
+
+	sa, err := client.CoreV1().ServiceAccounts(namespace).Get(saName, meta_v1.GetOptions{})
 	if err == nil {
 		for _, ips := range sa.ImagePullSecrets {
 			imagePullSecrets = append(imagePullSecrets, ips.Name)
@@ -36,7 +37,7 @@ func mergeCredentials(log func(...interface{}) error, client extendedClient, nam
 			continue
 		}
 
-		secret, err := client.Secrets(namespace).Get(name, meta_v1.GetOptions{})
+		secret, err := client.CoreV1().Secrets(namespace).Get(name, meta_v1.GetOptions{})
 		if err != nil {
 			log("err", errors.Wrapf(err, "getting secret %q from namespace %q", name, namespace))
 			seenCreds[name] = registry.NoCredentials()

--- a/cluster/kubernetes/images.go
+++ b/cluster/kubernetes/images.go
@@ -3,11 +3,13 @@ package kubernetes
 import (
 	"fmt"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	apiv1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry"
 )
@@ -114,7 +116,8 @@ func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 
 			imageCreds := make(registry.ImageCreds)
 			for _, podController := range podControllers {
-				mergeCredentials(c.logger.Log, c.client, ns.Name, podController.podTemplate, imageCreds, seenCreds)
+				logger := log.With(c.logger, "resource", flux.MakeResourceID(ns.Name, kind, podController.name))
+				mergeCredentials(logger.Log, c.client, ns.Name, podController.podTemplate, imageCreds, seenCreds)
 			}
 
 			// Merge creds

--- a/cluster/kubernetes/images.go
+++ b/cluster/kubernetes/images.go
@@ -1,0 +1,132 @@
+package kubernetes
+
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+	apiv1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/registry"
+)
+
+func mergeCredentials(log func(...interface{}) error, client extendedClient, namespace string, podTemplate apiv1.PodTemplateSpec, imageCreds registry.ImageCreds, seenCreds map[string]registry.Credentials) {
+	creds := registry.NoCredentials()
+	var imagePullSecrets []string
+	saName := podTemplate.Spec.ServiceAccountName
+	if saName == "" {
+		saName = "default"
+	}
+	sa, err := client.ServiceAccounts(namespace).Get(saName, meta_v1.GetOptions{})
+	if err == nil {
+		for _, ips := range sa.ImagePullSecrets {
+			imagePullSecrets = append(imagePullSecrets, ips.Name)
+		}
+	}
+
+	for _, imagePullSecret := range podTemplate.Spec.ImagePullSecrets {
+		imagePullSecrets = append(imagePullSecrets, imagePullSecret.Name)
+	}
+
+	for _, name := range imagePullSecrets {
+		if seen, ok := seenCreds[name]; ok {
+			creds.Merge(seen)
+			continue
+		}
+
+		secret, err := client.Secrets(namespace).Get(name, meta_v1.GetOptions{})
+		if err != nil {
+			log("err", errors.Wrapf(err, "getting secret %q from namespace %q", name, namespace))
+			seenCreds[name] = registry.NoCredentials()
+			continue
+		}
+
+		var decoded []byte
+		var ok bool
+		// These differ in format; but, ParseCredentials will
+		// handle either.
+		switch apiv1.SecretType(secret.Type) {
+		case apiv1.SecretTypeDockercfg:
+			decoded, ok = secret.Data[apiv1.DockerConfigKey]
+		case apiv1.SecretTypeDockerConfigJson:
+			decoded, ok = secret.Data[apiv1.DockerConfigJsonKey]
+		default:
+			log("skip", "unknown type", "secret", namespace+"/"+secret.Name, "type", secret.Type)
+			seenCreds[name] = registry.NoCredentials()
+			continue
+		}
+
+		if !ok {
+			log("err", errors.Wrapf(err, "retrieving pod secret %q", secret.Name))
+			seenCreds[name] = registry.NoCredentials()
+			continue
+		}
+
+		// Parse secret
+		crd, err := registry.ParseCredentials(fmt.Sprintf("%s:secret/%s", namespace, name), decoded)
+		if err != nil {
+			log("err", err.Error())
+			seenCreds[name] = registry.NoCredentials()
+			continue
+		}
+		seenCreds[name] = crd
+
+		// Merge into the credentials for this PodSpec
+		creds.Merge(crd)
+	}
+
+	// Now create the service and attach the credentials
+	for _, container := range podTemplate.Spec.Containers {
+		r, err := image.ParseRef(container.Image)
+		if err != nil {
+			log("err", err.Error())
+			continue
+		}
+		imageCreds[r.Name] = creds
+	}
+}
+
+// ImagesToFetch is a k8s specific method to get a list of images to update along with their credentials
+func (c *Cluster) ImagesToFetch() registry.ImageCreds {
+	allImageCreds := make(registry.ImageCreds)
+
+	namespaces, err := c.getAllowedNamespaces()
+	if err != nil {
+		c.logger.Log("err", errors.Wrap(err, "getting namespaces"))
+		return allImageCreds
+	}
+
+	for _, ns := range namespaces {
+		seenCreds := make(map[string]registry.Credentials)
+		for kind, resourceKind := range resourceKinds {
+			podControllers, err := resourceKind.getPodControllers(c, ns.Name)
+			if err != nil {
+				if se, ok := err.(*apierrors.StatusError); ok && se.ErrStatus.Reason == meta_v1.StatusReasonNotFound {
+					// Kind not supported by API server, skip
+				} else {
+					c.logger.Log("err", errors.Wrapf(err, "getting kind %s for namespace %s", kind, ns.Name))
+				}
+				continue
+			}
+
+			imageCreds := make(registry.ImageCreds)
+			for _, podController := range podControllers {
+				mergeCredentials(c.logger.Log, c.client, ns.Name, podController.podTemplate, imageCreds, seenCreds)
+			}
+
+			// Merge creds
+			for imageID, creds := range imageCreds {
+				existingCreds, ok := allImageCreds[imageID]
+				if ok {
+					existingCreds.Merge(creds)
+				} else {
+					allImageCreds[imageID] = creds
+				}
+			}
+		}
+	}
+
+	return allImageCreds
+}

--- a/cluster/kubernetes/images_test.go
+++ b/cluster/kubernetes/images_test.go
@@ -1,0 +1,76 @@
+package kubernetes
+
+import (
+	"encoding/base64"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	apiv1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes/fake"
+
+	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/registry"
+)
+
+func noopLog(...interface{}) error {
+	return nil
+}
+
+func makeImagePullSecret(ns, name, host string) *apiv1.Secret {
+	imagePullSecret := apiv1.Secret{Type: apiv1.SecretTypeDockerConfigJson}
+	imagePullSecret.Name = name
+	imagePullSecret.Namespace = ns
+	imagePullSecret.Data = map[string][]byte{
+		apiv1.DockerConfigJsonKey: []byte(`
+{
+  "auths": {
+    "` + host + `": {
+      "auth": "` + base64.StdEncoding.EncodeToString([]byte("user:passwd")) + `"
+      }
+    }
+}`),
+	}
+	return &imagePullSecret
+}
+
+func makeServiceAccount(ns, name string, imagePullSecretNames []string) *apiv1.ServiceAccount {
+	sa := apiv1.ServiceAccount{}
+	sa.Namespace = ns
+	sa.Name = name
+	for _, ips := range imagePullSecretNames {
+		sa.ImagePullSecrets = append(sa.ImagePullSecrets, apiv1.LocalObjectReference{Name: ips})
+	}
+	return &sa
+}
+
+func TestMergeCredentials(t *testing.T) {
+	ns, secretName1, secretName2 := "foo-ns", "secret-creds", "secret-sa-creds"
+	saName := "service-account"
+	ref, _ := image.ParseRef("foo/bar:tag")
+	spec := apiv1.PodTemplateSpec{
+		Spec: apiv1.PodSpec{
+			ServiceAccountName: saName,
+			ImagePullSecrets: []apiv1.LocalObjectReference{
+				{Name: secretName1},
+			},
+			Containers: []apiv1.Container{
+				{Name: "container1", Image: ref.String()},
+			},
+		},
+	}
+
+	clientset := fake.NewSimpleClientset(
+		makeServiceAccount(ns, saName, []string{secretName2}),
+		makeImagePullSecret(ns, secretName1, "docker.io"),
+		makeImagePullSecret(ns, secretName2, "quay.io"))
+	client := extendedClient{clientset, nil}
+
+	creds := registry.ImageCreds{}
+	mergeCredentials(noopLog, client, ns, spec, creds, make(map[string]registry.Credentials))
+
+	// check that we accumulated some credentials
+	assert.Contains(t, creds, ref.Name)
+	c := creds[ref.Name]
+	hosts := c.Hosts()
+	assert.ElementsMatch(t, []string{"docker.io", "quay.io"}, hosts)
+}

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -22,8 +22,6 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
-	"github.com/weaveworks/flux/image"
-	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/ssh"
 )
@@ -319,126 +317,6 @@ func (c *Cluster) PublicSSHKey(regenerate bool) (ssh.PublicKey, error) {
 	}
 	publicKey, _ := c.sshKeyRing.KeyPair()
 	return publicKey, nil
-}
-
-func mergeCredentials(c *Cluster, namespace string, podTemplate apiv1.PodTemplateSpec, imageCreds registry.ImageCreds, seenCreds map[string]registry.Credentials) {
-	creds := registry.NoCredentials()
-	var imagePullSecrets []string
-
-	saName := podTemplate.Spec.ServiceAccountName
-	if saName == "" {
-		saName = "default"
-	}
-	sa, err := c.client.ServiceAccounts(namespace).Get(saName, meta_v1.GetOptions{})
-	if err == nil {
-		for _, ips := range sa.ImagePullSecrets {
-			imagePullSecrets = append(imagePullSecrets, ips.Name)
-		}
-	}
-
-	for _, imagePullSecret := range podTemplate.Spec.ImagePullSecrets {
-		imagePullSecrets = append(imagePullSecrets, imagePullSecret.Name)
-	}
-
-	for _, name := range imagePullSecrets {
-		if seen, ok := seenCreds[name]; ok {
-			creds.Merge(seen)
-			continue
-		}
-
-		secret, err := c.client.Secrets(namespace).Get(name, meta_v1.GetOptions{})
-		if err != nil {
-			c.logger.Log("err", errors.Wrapf(err, "getting secret %q from namespace %q", name, namespace))
-			seenCreds[name] = registry.NoCredentials()
-			continue
-		}
-
-		var decoded []byte
-		var ok bool
-		// These differ in format; but, ParseCredentials will
-		// handle either.
-		switch apiv1.SecretType(secret.Type) {
-		case apiv1.SecretTypeDockercfg:
-			decoded, ok = secret.Data[apiv1.DockerConfigKey]
-		case apiv1.SecretTypeDockerConfigJson:
-			decoded, ok = secret.Data[apiv1.DockerConfigJsonKey]
-		default:
-			c.logger.Log("skip", "unknown type", "secret", namespace+"/"+secret.Name, "type", secret.Type)
-			seenCreds[name] = registry.NoCredentials()
-			continue
-		}
-
-		if !ok {
-			c.logger.Log("err", errors.Wrapf(err, "retrieving pod secret %q", secret.Name))
-			seenCreds[name] = registry.NoCredentials()
-			continue
-		}
-
-		// Parse secret
-		crd, err := registry.ParseCredentials(fmt.Sprintf("%s:secret/%s", namespace, name), decoded)
-		if err != nil {
-			c.logger.Log("err", err.Error())
-			seenCreds[name] = registry.NoCredentials()
-			continue
-		}
-		seenCreds[name] = crd
-
-		// Merge into the credentials for this PodSpec
-		creds.Merge(crd)
-	}
-
-	// Now create the service and attach the credentials
-	for _, container := range podTemplate.Spec.Containers {
-		r, err := image.ParseRef(container.Image)
-		if err != nil {
-			c.logger.Log("err", err.Error())
-			continue
-		}
-		imageCreds[r.Name] = creds
-	}
-}
-
-// ImagesToFetch is a k8s specific method to get a list of images to update along with their credentials
-func (c *Cluster) ImagesToFetch() registry.ImageCreds {
-	allImageCreds := make(registry.ImageCreds)
-
-	namespaces, err := c.getAllowedNamespaces()
-	if err != nil {
-		c.logger.Log("err", errors.Wrap(err, "getting namespaces"))
-		return allImageCreds
-	}
-
-	for _, ns := range namespaces {
-		seenCreds := make(map[string]registry.Credentials)
-		for kind, resourceKind := range resourceKinds {
-			podControllers, err := resourceKind.getPodControllers(c, ns.Name)
-			if err != nil {
-				if se, ok := err.(*apierrors.StatusError); ok && se.ErrStatus.Reason == meta_v1.StatusReasonNotFound {
-					// Kind not supported by API server, skip
-				} else {
-					c.logger.Log("err", errors.Wrapf(err, "getting kind %s for namespace %s", kind, ns.Name))
-				}
-				continue
-			}
-
-			imageCreds := make(registry.ImageCreds)
-			for _, podController := range podControllers {
-				mergeCredentials(c, ns.Name, podController.podTemplate, imageCreds, seenCreds)
-			}
-
-			// Merge creds
-			for imageID, creds := range imageCreds {
-				existingCreds, ok := allImageCreds[imageID]
-				if ok {
-					existingCreds.Merge(creds)
-				} else {
-					allImageCreds[imageID] = creds
-				}
-			}
-		}
-	}
-
-	return allImageCreds
 }
 
 // getAllowedNamespaces returns a list of namespaces that the Flux instance is expected


### PR DESCRIPTION
It is possible, and often more economical, to give ImagePullSecrets to
a service account (perhaps the default for the namespace), rather than
each workload individually.

So that flux will still find these secrets, look up the service
account, and its imagePullSecrets, if any. This involves one more RPC
to the API server (to get the service account), per workload.

Fixes #1043.