### PR TITLE
Remove spurious ServicesWithPolicies

### DIFF
--- a/cluster/kubernetes/policies.go
+++ b/cluster/kubernetes/policies.go
@@ -81,15 +81,3 @@ func extractContainers(def []byte, id flux.ResourceID) ([]resource.Container, er
 	}
 	return workload.Containers(), nil
 }
-
-func (m *Manifests) ServicesWithPolicies(root string) (policy.ResourceMap, error) {
-	resources, err := m.LoadManifests(root, root)
-	if err != nil {
-		return nil, err
-	}
-	result := policy.ResourceMap{}
-	for _, res := range resources {
-		result[res.ResourceID()] = res.Policy()
-	}
-	return result, nil
-}

--- a/cluster/manifests.go
+++ b/cluster/manifests.go
@@ -35,8 +35,6 @@ type Manifests interface {
 	ParseManifests([]byte) (map[string]resource.Resource, error)
 	// UpdatePolicies modifies a manifest to apply the policy update specified
 	UpdatePolicies([]byte, flux.ResourceID, policy.Update) ([]byte, error)
-	// ServicesWithPolicies returns all services with their associated policies
-	ServicesWithPolicies(path string) (policy.ResourceMap, error)
 }
 
 // UpdateManifest looks for the manifest for the identified resource,

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -10,18 +10,17 @@ import (
 
 // Doubles as a cluster.Cluster and cluster.Manifests implementation
 type Mock struct {
-	AllServicesFunc          func(maybeNamespace string) ([]Controller, error)
-	SomeServicesFunc         func([]flux.ResourceID) ([]Controller, error)
-	PingFunc                 func() error
-	ExportFunc               func() ([]byte, error)
-	SyncFunc                 func(SyncDef) error
-	PublicSSHKeyFunc         func(regenerate bool) (ssh.PublicKey, error)
-	UpdateImageFunc          func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
-	LoadManifestsFunc        func(base, first string, rest ...string) (map[string]resource.Resource, error)
-	ParseManifestsFunc       func([]byte) (map[string]resource.Resource, error)
-	UpdateManifestFunc       func(path, resourceID string, f func(def []byte) ([]byte, error)) error
-	UpdatePoliciesFunc       func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
-	ServicesWithPoliciesFunc func(path string) (policy.ResourceMap, error)
+	AllServicesFunc    func(maybeNamespace string) ([]Controller, error)
+	SomeServicesFunc   func([]flux.ResourceID) ([]Controller, error)
+	PingFunc           func() error
+	ExportFunc         func() ([]byte, error)
+	SyncFunc           func(SyncDef) error
+	PublicSSHKeyFunc   func(regenerate bool) (ssh.PublicKey, error)
+	UpdateImageFunc    func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
+	LoadManifestsFunc  func(base, first string, rest ...string) (map[string]resource.Resource, error)
+	ParseManifestsFunc func([]byte) (map[string]resource.Resource, error)
+	UpdateManifestFunc func(path, resourceID string, f func(def []byte) ([]byte, error)) error
+	UpdatePoliciesFunc func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
 }
 
 func (m *Mock) AllControllers(maybeNamespace string) ([]Controller, error) {
@@ -66,8 +65,4 @@ func (m *Mock) UpdateManifest(path string, resourceID string, f func(def []byte)
 
 func (m *Mock) UpdatePolicies(def []byte, id flux.ResourceID, p policy.Update) ([]byte, error) {
 	return m.UpdatePoliciesFunc(def, id, p)
-}
-
-func (m *Mock) ServicesWithPolicies(path string) (policy.ResourceMap, error) {
-	return m.ServicesWithPoliciesFunc(path)
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -604,7 +604,6 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 			return kresource.ParseMultidoc(allDefs, "test")
 		}
 		k8s.PingFunc = func() error { return nil }
-		k8s.ServicesWithPoliciesFunc = (&kubernetes.Manifests{}).ServicesWithPolicies
 		k8s.SomeServicesFunc = func([]flux.ResourceID) ([]cluster.Controller, error) {
 			return []cluster.Controller{
 				singleService,

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -7,8 +7,9 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 
-	"github.com/weaveworks/flux/git"
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/policy"
+	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/update"
 )
 
@@ -17,17 +18,17 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 
 	ctx := context.Background()
 
-	candidateServicesPolicyMap, err := d.getUnlockedAutomatedServicesPolicyMap(ctx)
+	candidateServices, err := d.getUnlockedAutomatedResources(ctx)
 	if err != nil {
-		logger.Log("error", errors.Wrap(err, "getting unlocked automated services"))
+		logger.Log("error", errors.Wrap(err, "getting unlocked automated resources"))
 		return
 	}
-	if len(candidateServicesPolicyMap) == 0 {
+	if len(candidateServices) == 0 {
 		logger.Log("msg", "no automated services")
 		return
 	}
 	// Find images to check
-	services, err := d.Cluster.SomeControllers(candidateServicesPolicyMap.ToSlice())
+	services, err := d.Cluster.SomeControllers(candidateServices.IDs())
 	if err != nil {
 		logger.Log("error", errors.Wrap(err, "checking services for new images"))
 		return
@@ -41,10 +42,14 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 
 	changes := &update.Automated{}
 	for _, service := range services {
+		var p policy.Set
+		if resource, ok := candidateServices[service.ID]; ok {
+			p = resource.Policy()
+		}
 	containers:
 		for _, container := range service.ContainersOrNil() {
 			currentImageID := container.Image
-			pattern := policy.GetTagPattern(candidateServicesPolicyMap, service.ID, container.Name)
+			pattern := policy.GetTagPattern(p, container.Name)
 			repo := currentImageID.Name
 			logger := log.With(logger, "service", service.ID, "container", container.Name, "repo", repo, "pattern", pattern, "current", currentImageID)
 
@@ -81,18 +86,28 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 	}
 }
 
-// getUnlockedAutomatedServicesPolicyMap returns a resource policy map for all unlocked automated services
-func (d *Daemon) getUnlockedAutomatedServicesPolicyMap(ctx context.Context) (policy.ResourceMap, error) {
-	var services policy.ResourceMap
-	err := d.WithClone(ctx, func(checkout *git.Checkout) error {
-		var err error
-		services, err = d.Manifests.ServicesWithPolicies(checkout.ManifestDir())
-		return err
-	})
+type resources map[flux.ResourceID]resource.Resource
+
+func (r resources) IDs() (ids []flux.ResourceID) {
+	for k, _ := range r {
+		ids = append(ids, k)
+	}
+	return ids
+}
+
+// getUnlockedAutomatedServices returns all the resources that are
+func (d *Daemon) getUnlockedAutomatedResources(ctx context.Context) (resources, error) {
+	resources, _, err := d.getResources(ctx)
 	if err != nil {
 		return nil, err
 	}
-	automatedServices := services.OnlyWithPolicy(policy.Automated)
-	lockedServices := services.OnlyWithPolicy(policy.Locked)
-	return automatedServices.Without(lockedServices), nil
+
+	result := map[flux.ResourceID]resource.Resource{}
+	for _, resource := range resources {
+		policies := resource.Policy()
+		if policies.Has(policy.Automated) && !policies.Has(policy.Locked) {
+			result[resource.ResourceID()] = resource
+		}
+	}
+	return result, nil
 }

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
-	"github.com/weaveworks/flux/cluster/kubernetes"
 	kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 	"github.com/weaveworks/flux/event"
@@ -48,7 +47,6 @@ func daemon(t *testing.T) (*Daemon, func()) {
 		return kresource.ParseMultidoc(allDefs, "exported")
 	}
 	k8s.ExportFunc = func() ([]byte, error) { return nil, nil }
-	k8s.ServicesWithPoliciesFunc = (&kubernetes.Manifests{}).ServicesWithPolicies
 
 	events = &mockEventWriter{}
 

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -36,12 +36,8 @@ func Tag(policy Policy) bool {
 	return strings.HasPrefix(string(policy), "tag.")
 }
 
-func GetTagPattern(services ResourceMap, service flux.ResourceID, container string) Pattern {
-	if services == nil {
-		return PatternAll
-	}
-	policies, ok := services[service]
-	if !ok {
+func GetTagPattern(policies Set, container string) Pattern {
+	if policies == nil {
 		return PatternAll
 	}
 	pattern, ok := policies.Get(TagPrefix(container))
@@ -140,39 +136,4 @@ func (s Set) ToStringMap() map[string]string {
 		m[string(p)] = v
 	}
 	return m
-}
-
-type ResourceMap map[flux.ResourceID]Set
-
-func (s ResourceMap) ToSlice() []flux.ResourceID {
-	slice := []flux.ResourceID{}
-	for service, _ := range s {
-		slice = append(slice, service)
-	}
-	return slice
-}
-
-func (s ResourceMap) Contains(id flux.ResourceID) bool {
-	_, ok := s[id]
-	return ok
-}
-
-func (s ResourceMap) Without(other ResourceMap) ResourceMap {
-	newMap := ResourceMap{}
-	for k, v := range s {
-		if !other.Contains(k) {
-			newMap[k] = v
-		}
-	}
-	return newMap
-}
-
-func (s ResourceMap) OnlyWithPolicy(p Policy) ResourceMap {
-	newMap := ResourceMap{}
-	for k, v := range s {
-		if v.Has(p) {
-			newMap[k] = v
-		}
-	}
-	return newMap
 }

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/weaveworks/flux"
 )
 
 func TestJSON(t *testing.T) {
@@ -51,13 +50,10 @@ func TestJSON(t *testing.T) {
 }
 
 func Test_GetTagPattern(t *testing.T) {
-	resourceID, err := flux.ParseResourceID("default:deployment/helloworld")
-	assert.NoError(t, err)
 	container := "helloContainer"
 
 	type args struct {
-		services  ResourceMap
-		service   flux.ResourceID
+		policies  Set
 		container string
 	}
 	tests := []struct {
@@ -67,23 +63,20 @@ func Test_GetTagPattern(t *testing.T) {
 	}{
 		{
 			name: "Nil policies",
-			args: args{services: nil},
+			args: args{policies: nil},
 			want: PatternAll,
 		},
 		{
 			name: "No match",
-			args: args{services: ResourceMap{}},
+			args: args{policies: Set{}},
 			want: PatternAll,
 		},
 		{
 			name: "Match",
 			args: args{
-				services: ResourceMap{
-					resourceID: Set{
-						Policy(fmt.Sprintf("tag.%s", container)): "glob:master-*",
-					},
+				policies: Set{
+					Policy(fmt.Sprintf("tag.%s", container)): "glob:master-*",
 				},
-				service:   resourceID,
 				container: container,
 			},
 			want: NewPattern("master-*"),
@@ -91,10 +84,7 @@ func Test_GetTagPattern(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := GetTagPattern(tt.args.services, tt.args.service, tt.args.container); got != tt.want {
-				t.Errorf("GetTagPattern() = %v, want %v", got, tt.want)
-
-			}
+			assert.Equal(t, tt.want, GetTagPattern(tt.args.policies, tt.args.container))
 		})
 	}
 }

--- a/release/context.go
+++ b/release/context.go
@@ -9,7 +9,6 @@ import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/git"
-	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/update"
@@ -144,9 +143,4 @@ func (rc *ReleaseContext) WorkloadsForUpdate() (map[flux.ResourceID]*update.Cont
 		}
 	}
 	return defined, nil
-}
-
-// Shortcut for this
-func (rc *ReleaseContext) ServicesWithPolicies() (policy.ResourceMap, error) {
-	return rc.manifests.ServicesWithPolicies(rc.repo.ManifestDir())
 }

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -6,12 +6,12 @@ import (
 	"net/rpc"
 	"net/rpc/jsonrpc"
 
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/api/v10"
-	"github.com/weaveworks/flux/policy"
-
 	"github.com/weaveworks/flux/api/v6"
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/job"
+	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/update"
 )
@@ -131,44 +131,47 @@ type listImagesWithOptionsClient interface {
 // interface to dispatch .ListImages() and .ListServices() to the correct
 // API version.
 func listImagesWithOptions(ctx context.Context, client listImagesWithOptionsClient, opts v10.ListImagesOptions) ([]v6.ImageStatus, error) {
-	images, err := client.ListImages(ctx, opts.Spec)
+	statuses, err := client.ListImages(ctx, opts.Spec)
 	if err != nil {
-		return images, err
+		return statuses, err
 	}
 
 	var ns string
 	if opts.Spec != update.ResourceSpecAll {
 		resourceID, err := opts.Spec.AsID()
 		if err != nil {
-			return images, err
+			return statuses, err
 		}
 		ns, _, _ = resourceID.Components()
 	}
 	services, err := client.ListServices(ctx, ns)
 
-	policyMap := make(policy.ResourceMap)
+	policyMap := map[flux.ResourceID]map[string]string{}
 	for _, service := range services {
-		s := policy.Set{}
-		for k, v := range service.Policies {
-			s[policy.Policy(k)] = v
-		}
-		policyMap[service.ID] = s
+		policyMap[service.ID] = service.Policies
 	}
 
 	// Polyfill container fields from v10
-	for i, image := range images {
-		for j, container := range image.Containers {
-			tagPattern := policy.GetTagPattern(policyMap, image.ID, container.Name)
+	for i, status := range statuses {
+		for j, container := range status.Containers {
+			var p policy.Set
+			if policies, ok := policyMap[status.ID]; ok {
+				p = policy.Set{}
+				for k, v := range policies {
+					p[policy.Policy(k)] = v
+				}
+			}
+			tagPattern := policy.GetTagPattern(p, container.Name)
 			// Create a new container using the same function used in v10
 			newContainer, err := v6.NewContainer(container.Name, update.ImageInfos(container.Available), container.Current, tagPattern, opts.OverrideContainerFields)
 			if err != nil {
-				return images, err
+				return statuses, err
 			}
-			images[i].Containers[j] = newContainer
+			statuses[i].Containers[j] = newContainer
 		}
 	}
 
-	return images, nil
+	return statuses, nil
 }
 
 func (p *RPCClientV6) UpdateManifests(ctx context.Context, u update.Spec) (job.ID, error) {

--- a/update/filter.go
+++ b/update/filter.go
@@ -3,6 +3,7 @@ package update
 import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/policy"
 )
 
 const (
@@ -77,16 +78,13 @@ func (f *IncludeFilter) Filter(u ControllerUpdate) ControllerResult {
 }
 
 type LockedFilter struct {
-	IDs []flux.ResourceID
 }
 
 func (f *LockedFilter) Filter(u ControllerUpdate) ControllerResult {
-	for _, id := range f.IDs {
-		if u.ResourceID == id {
-			return ControllerResult{
-				Status: ReleaseStatusSkipped,
-				Error:  Locked,
-			}
+	if u.Resource.Policy().Has(policy.Locked) {
+		return ControllerResult{
+			Status: ReleaseStatusSkipped,
+			Error:  Locked,
 		}
 	}
 	return ControllerResult{}

--- a/update/release.go
+++ b/update/release.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
-	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/registry"
@@ -47,9 +46,7 @@ const UserAutomated = "<automated>"
 
 type ReleaseContext interface {
 	SelectServices(Result, []ControllerFilter, []ControllerFilter) ([]*ControllerUpdate, error)
-	ServicesWithPolicies() (policy.ResourceMap, error)
 	Registry() registry.Registry
-	Manifests() cluster.Manifests
 }
 
 // NB: these get sent from fluxctl, so we have to maintain the json format of
@@ -154,13 +151,7 @@ func (s ReleaseSpec) filters(rc ReleaseContext) ([]ControllerFilter, []Controlle
 
 	// Filter out locked controllers unless given a specific controller(s) and forced
 	if !(len(ids) > 0 && s.Force) {
-		// Locked filter
-		services, err := rc.ServicesWithPolicies()
-		if err != nil {
-			return nil, nil, err
-		}
-		lockedSet := services.OnlyWithPolicy(policy.Locked)
-		postfilters = append(postfilters, &LockedFilter{lockedSet.ToSlice()})
+		postfilters = append(postfilters, &LockedFilter{})
 	}
 
 	return prefilters, postfilters, nil


### PR DESCRIPTION
The method `ServicesWithPolicies` and its associated type,
`policy.ResourceMap` aren't needed. At best, the required value is
easily calculated at the call site, and at worst, the invocation
repeats a lot of work for a value (e.g., a resource's policy set) that
is already available in scope.