### PR TITLE
Correctly store Excluded manifests

### DIFF
--- a/registry/imageentry_test.go
+++ b/registry/imageentry_test.go
@@ -1,0 +1,60 @@
+package registry
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaveworks/flux/image"
+)
+
+// Check that the ImageEntry type can be round-tripped via JSON.
+func TestImageEntryRoundtrip(t *testing.T) {
+
+	test := func(t *testing.T, entry ImageEntry) {
+		bytes, err := json.Marshal(entry)
+		assert.NoError(t, err)
+
+		var entry2 ImageEntry
+		assert.NoError(t, json.Unmarshal(bytes, &entry2))
+		assert.Equal(t, entry, entry2)
+	}
+
+	ref, err := image.ParseRef("quay.io/weaveworks/flux:1.0.0")
+	assert.NoError(t, err)
+
+	info := image.Info{
+		ID:        ref,
+		CreatedAt: time.Now().UTC(), // to UTC since we unmarshal times in UTC
+	}
+
+	entry := ImageEntry{
+		Info: info,
+	}
+	t.Run("With an info", func(t *testing.T) { test(t, entry) })
+	t.Run("With an excluded reason", func(t *testing.T) {
+		entry.Info = image.Info{}
+		entry.ExcludedReason = "just because"
+		test(t, entry)
+	})
+}
+
+// Check that existing entries, which are image.Info, will parse into
+// the ImageEntry struct.
+func TestImageInfoParsesAsEntry(t *testing.T) {
+	ref, err := image.ParseRef("quay.io/weaveworks/flux:1.0.0")
+	assert.NoError(t, err)
+	info := image.Info{
+		ID:        ref,
+		CreatedAt: time.Now().UTC(), // to UTC since we unmarshal times in UTC
+	}
+
+	bytes, err := json.Marshal(info)
+	assert.NoError(t, err)
+
+	var entry2 ImageEntry
+	assert.NoError(t, json.Unmarshal(bytes, &entry2))
+	assert.Equal(t, info, entry2.Info)
+}


### PR DESCRIPTION
I noticed that fluxd was continually fetching image manifests that
were "excluded", that is, had the wrong arch or otherwise weren't
suitable.

The design in #1265 was to mark those manifests as excluded, but count
them as successful fetches; and, to save the fact in memcached. The
implementation failed on three counts:

 - it would unconditionally use a cached result, even if excluded;

 - it was using the ID from excluded results (which have no ID value)
   as a key, so they got effectively thrown away anyway;

 - the encoding of results to JSON omitted the ExcludedReason field,
   because they embed the image.Info struct and thus inherit its JSON
   encoding methods.

This commit corrects those problems.