### PR TITLE
 Exclude locked workloads for container type release

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -78,7 +78,6 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 		return err
 	}
 
-
 	switch {
 	case len(opts.controllers) <= 0 && !opts.allControllers:
 		return newUsageError("please supply either --all, or at least one --controller=<controller>")
@@ -160,7 +159,7 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 			return err
 		}
 
-		spec, err := promptSpec(cmd.OutOrStdout(), result, opts.verbosity)
+		spec, err := promptSpec(cmd.OutOrStdout(), result, opts.verbosity, opts.force)
 		if err != nil {
 			fmt.Fprintln(cmd.OutOrStderr(), err.Error())
 			return nil
@@ -178,12 +177,13 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbosity)
 }
 
-func promptSpec(out io.Writer, result job.Result, verbosity int) (update.ContainerSpecs, error) {
+func promptSpec(out io.Writer, result job.Result, verbosity int, force bool) (update.ContainerSpecs, error) {
 	menu := update.NewMenu(out, result.Result, verbosity)
 	containerSpecs, err := menu.Run()
 	return update.ContainerSpecs{
 		Kind:           update.ReleaseKindExecute,
 		ContainerSpecs: containerSpecs,
 		SkipMismatches: false,
+		Force:          force,
 	}, err
 }

--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -159,7 +159,8 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 			return err
 		}
 
-		spec, err := promptSpec(cmd.OutOrStdout(), result, opts.verbosity, opts.force)
+		spec, err := promptSpec(cmd.OutOrStdout(), result, opts.verbosity)
+		spec.Force = opts.force
 		if err != nil {
 			fmt.Fprintln(cmd.OutOrStderr(), err.Error())
 			return nil
@@ -177,13 +178,12 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbosity)
 }
 
-func promptSpec(out io.Writer, result job.Result, verbosity int, force bool) (update.ContainerSpecs, error) {
+func promptSpec(out io.Writer, result job.Result, verbosity int) (update.ContainerSpecs, error) {
 	menu := update.NewMenu(out, result.Result, verbosity)
 	containerSpecs, err := menu.Run()
 	return update.ContainerSpecs{
 		Kind:           update.ReleaseKindExecute,
 		ContainerSpecs: containerSpecs,
 		SkipMismatches: false,
-		Force:          force,
 	}, err
 }

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -34,24 +34,24 @@ func Release(rc *ReleaseContext, changes Changes, logger log.Logger) (results up
 	before, err := rc.LoadManifests()
 	updates, results, err := changes.CalculateRelease(rc, logger)
 	if err != nil {
-		return results, err
+		return nil, err
 	}
 
 	err = ApplyChanges(rc, updates, logger)
 	if err != nil {
-		return results, MakeReleaseError(errors.Wrap(err, "applying changes"))
+		return nil, MakeReleaseError(errors.Wrap(err, "applying changes"))
 	}
 
 	after, err := rc.LoadManifests()
 	if err != nil {
-		return results, MakeReleaseError(errors.Wrap(err, "loading resources after updates"))
+		return nil, MakeReleaseError(errors.Wrap(err, "loading resources after updates"))
 	}
 
 	err = VerifyChanges(before, updates, after)
 	if err != nil {
-		return results, MakeReleaseError(errors.Wrap(err, "verifying changes"))
+		return nil, MakeReleaseError(errors.Wrap(err, "verifying changes"))
 	}
-	return results, err
+	return results, nil
 }
 
 func ApplyChanges(rc *ReleaseContext, updates []*update.ControllerUpdate, logger log.Logger) error {

--- a/release/releaser.go
+++ b/release/releaser.go
@@ -34,7 +34,7 @@ func Release(rc *ReleaseContext, changes Changes, logger log.Logger) (results up
 	before, err := rc.LoadManifests()
 	updates, results, err := changes.CalculateRelease(rc, logger)
 	if err != nil {
-		return nil, err
+		return results, err
 	}
 
 	err = ApplyChanges(rc, updates, logger)

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -987,17 +987,18 @@ func Test_UpdateContainers(t *testing.T) {
 			if ignoreMismatches {
 				name += " (SkipMismatches)"
 			}
-			specs.SkipMismatches = ignoreMismatches
-			specs.Force = tst.Force
+			t.Run(name, func(t *testing.T) {
+				specs.SkipMismatches = ignoreMismatches
+				specs.Force = tst.Force
 
-			results, err := Release(ctx, specs, log.NewNopLogger())
+				results, err := Release(ctx, specs, log.NewNopLogger())
 
-			if expected.Err != nil {
-				assert.Equal(t, expected.Err, err, name)
-			} else {
-				assert.Equal(t, expected.Result, results[tst.WorkloadID], name)
-				assert.Equal(t, expected.Commit, specs.CommitMessage(results), name)
-			}
+				assert.Equal(t, expected.Err, err)
+				if expected.Err == nil {
+					assert.Equal(t, expected.Result, results[tst.WorkloadID])
+					assert.Equal(t, expected.Commit, specs.CommitMessage(results))
+				}
+			})
 		}
 	}
 }


### PR DESCRIPTION
For `containers` type releases, locked workloads are now excluded. In
case one wants to include them nevertheless, a `Force` option can be set
to ignore the lock-flag. For `fluxctl`, the `--force` flag will allow
updating containers of locked workloads interactively.

Fixes #1313