### PR TITLE
Small manifest improvements

### DIFF
--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flux-helm-operator
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: flux-helm-operator
   strategy:
     type: Recreate
   template:

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -31,7 +31,7 @@ spec:
         # There are no ":latest" images for helm-operator. Find the most recent
         # release or image version at https://quay.io/weaveworks/helm-operator
         # and replace the tag here.
-        image: quay.io/weaveworks/helm-operator:0.1.1-alpha
+        image: quay.io/weaveworks/helm-operator:0.2.0
         imagePullPolicy: IfNotPresent
         volumeMounts:
         # Include this if you need to mount a customised known_hosts

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -1,10 +1,13 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: flux
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: flux
   strategy:
     type: Recreate
   template:

--- a/deploy/memcache-dep.yaml
+++ b/deploy/memcache-dep.yaml
@@ -1,12 +1,15 @@
 ---
 # You can optionally deploy memcache, for the Flux daemon to cache
 # container image metadata.
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: memcached
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: memcached
   template:
     metadata:
       labels:


### PR DESCRIPTION
In my opinion we should advocate to not get too far behind with cluster upgrades.

Kubernetes `1.9` was released more than 8 months ago, which also announced the GA of the `apps/v1` Workloads API.

I have updated the `Deployment` manifests to use this `apiVersion` and also added the required `spec.selector.Matchlabels`.

During the `0.2.0` release of the new Helm operator the version wasn't bumped for the manifest in the `master` branch so I added this as well.