### PR TITLE
Update contributor docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,14 @@ These things will make a PR more likely to be accepted:
  * tests for old code!
  * new code and tests follow the conventions in old code and tests
  * a good commit message (see below)
+ * All code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+ * Names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
+ * Code must build on both Linux and Darwin, via plain `go build`
+ * Code should have appropriate test coverage, invoked via plain `go test`
+
+In addition, several mechanical checks are enforced.
+See [the lint script](/lint) for details.
+
 
 In general, we will merge a PR once two maintainers have endorsed it.
 Trivial changes (e.g., corrections to spelling) may get waved through.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,8 @@ These things will make a PR more likely to be accepted:
 - All code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
 - Names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
 - Code must build on both Linux and Darwin, via plain `go build`
-- Code should have appropriate test coverage, invoked via plain `go test`
+- Code should have appropriate test coverage and tests should be written
+  to work with `go test`
 
 In general, we will merge a PR once one maintainer has endorsed it.
 For substantial changes, more people may become involved, and you might

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ it easier to get your contribution accepted.
 
 We gratefully welcome improvements to documentation as well as to code.
 
-# Certificate of Origin
+## Certificate of Origin
 
 By contributing to this project you agree to the Developer Certificate of
 Origin (DCO). This document was created by the Linux Kernel community and is a
@@ -15,7 +15,7 @@ simple statement that you, as a contributor, have the legal right to make the
 contribution. No action from you is required, but it's a good idea to see the
 [DCO](DCO) file for details before you start contributing code to Flux.
 
-# Chat
+## Chat
 
 The project uses Slack: To join the conversation, simply join the
 [Weave community](https://slack.weave.works/) Slack workspace and use the
@@ -24,7 +24,7 @@ The project uses Slack: To join the conversation, simply join the
 ## Getting Started
 
 - Fork the repository on GitHub
-- Read the [README](README.md) for getting started as a user and learn how/where to ask for help 
+- Read the [README](README.md) for getting started as a user and learn how/where to ask for help
 - If you want to contribute as a developer, continue reading this document for further instructions
 - Play with the project, submit bugs, submit pull requests!
 
@@ -37,15 +37,15 @@ This is a rough outline of how to prepare a contribution:
 - Make sure your commit messages are in the proper format (see below).
 - Push your changes to a topic branch in your fork of the repository.
 - If you changed code:
-   - add automated tests to cover your changes
+  - add automated tests to cover your changes
 - Submit a pull request to the original repository.
 
-## How to build and run the project
+### How to build and run the project
 
 Refer to the [building doc](site/building.md) to find out how to build from
 source.
 
-## How to run the test suite
+### How to run the test suite
 
 You can run the linting and unit tests by simply doing
 
@@ -53,23 +53,22 @@ You can run the linting and unit tests by simply doing
 make test
 ```
 
-# Acceptance policy
+## Acceptance policy
 
 These things will make a PR more likely to be accepted:
 
- * a well-described requirement
- * tests for new code
- * tests for old code!
- * new code and tests follow the conventions in old code and tests
- * a good commit message (see below)
- * All code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
- * Names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
- * Code must build on both Linux and Darwin, via plain `go build`
- * Code should have appropriate test coverage, invoked via plain `go test`
+- a well-described requirement
+- tests for new code
+- tests for old code!
+- new code and tests follow the conventions in old code and tests
+- a good commit message (see below)
+- All code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
+- Names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
+- Code must build on both Linux and Darwin, via plain `go build`
+- Code should have appropriate test coverage, invoked via plain `go test`
 
 In addition, several mechanical checks are enforced.
 See [the lint script](/lint) for details.
-
 
 In general, we will merge a PR once two maintainers have endorsed it.
 Trivial changes (e.g., corrections to spelling) may get waved through.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,8 +71,7 @@ These things will make a PR more likely to be accepted:
 In addition, several mechanical checks are enforced.
 See [the lint script](/lint) for details.
 
-In general, we will merge a PR once two maintainers have endorsed it.
-Trivial changes (e.g., corrections to spelling) may get waved through.
+In general, we will merge a PR once one maintainer has endorsed it.
 For substantial changes, more people may become involved, and you might
 get asked to resubmit the PR or divide the changes into more than one PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,8 @@ The project uses Slack: To join the conversation, simply join the
 ## Getting Started
 
 - Fork the repository on GitHub
-- Read the [README](README.md) for getting started as a user and learn how/where to ask for help
+- Read the [README](README.md#get-started-with-flux) for getting started as
+  a user and learn how/where to ask for help
 - If you want to contribute as a developer, continue reading this document for further instructions
 - Play with the project, submit bugs, submit pull requests!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,9 +68,6 @@ These things will make a PR more likely to be accepted:
 - Code must build on both Linux and Darwin, via plain `go build`
 - Code should have appropriate test coverage, invoked via plain `go test`
 
-In addition, several mechanical checks are enforced.
-See [the lint script](/lint) for details.
-
 In general, we will merge a PR once one maintainer has endorsed it.
 For substantial changes, more people may become involved, and you might
 get asked to resubmit the PR or divide the changes into more than one PR.

--- a/README.md
+++ b/README.md
@@ -87,26 +87,24 @@ Get started by browsing through the documentation below:
   - [Frequently encountered issues](https://github.com/weaveworks/flux/labels/FAQ)
   - [Upgrading to Flux v1](/site/upgrading-to-1.0.md)
 
-## Developer information
+## Community & Developer information
 
-[Build documentation](/site/building.md)
+We welcome all kinds of contributions to Flux, be it code, issues you found,
+documentation, external tools, help and support or anything else really.
 
-[Release documentation](/internal_docs/releasing.md)
+Flux follows the [CNCF Code of
+Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
-### Contribution
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by contacting a *flux* project maintainer, or Alexis Richardson
+`<alexis@weave.works>`.
 
-Flux follows a typical PR workflow.
-All contributions should be made as PRs that satisfy the guidelines below.
+To familiarise yourself with the project and how things work, you might
+be interested in the following:
 
-### Guidelines
-
-- All code must abide [Go Code Review Comments](https://github.com/golang/go/wiki/CodeReviewComments)
-- Names should abide [What's in a name](https://talks.golang.org/2014/names.slide#1)
-- Code must build on both Linux and Darwin, via plain `go build`
-- Code should have appropriate test coverage, invoked via plain `go test`
-
-In addition, several mechanical checks are enforced.
-See [the lint script](/lint) for details.
+- [Our contributions guidelines](CONTRIBUTING.md)
+- [Build documentation](/site/building.md)
+- [Release documentation](/internal_docs/releasing.md)
 
 ## <a name="help"></a>Getting Help
 

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ Its major features are:
 Weave Cloud is a SaaS product by Weaveworks that includes Flux, as well
 as:
 
- - a UI and alerts for deployments: nicely integrated overview, all flux
-   operations just a click away.
- - full observability and insights into your cluster: Instantly start using
-   monitoring dashboards for your cluster, hosted 13 months of history, use
-   a realtime map of your cluster to debug and analyse its state.
+- a UI and alerts for deployments: nicely integrated overview, all flux
+  operations just a click away.
+ full observability and insights into your cluster: Instantly start using
+  monitoring dashboards for your cluster, hosted 13 months of history, use
+  a realtime map of your cluster to debug and analyse its state.
 
 If you want to learn more about Weave Cloud, you can see it in action on
 [its homepage](https://www.weave.works/product/cloud/).
@@ -96,8 +96,8 @@ Flux follows the [CNCF Code of
 Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
 
 Instances of abusive, harassing, or otherwise unacceptable behavior
-may be reported by contacting a *flux* project maintainer, or Alexis Richardson
-`<alexis@weave.works>`.
+may be reported by contacting a *flux* project maintainer, or Alexis
+Richardson `<alexis@weave.works>`.
 
 To familiarise yourself with the project and how things work, you might
 be interested in the following:
@@ -111,10 +111,11 @@ be interested in the following:
 If you have any questions about Flux and continuous delivery:
 
 - Read [the Weave Flux docs](https://github.com/weaveworks/flux/tree/master/site).
-- Invite yourself to the <a href="https://weaveworks.github.io/community-slack/" target="_blank">Weave community</a> slack.
+- Invite yourself to the <a href="https://slack.weave.works/" target="_blank">Weave community</a> slack.
 - Ask a question on the [#flux](https://weave-community.slack.com/messages/flux/) slack channel.
-- Join the <a href="https://www.meetup.com/pro/Weave/"> Weave User Group </a> and get invited to online talks, hands-on training and meetups in your area.
+- Join the [Weave User Group](https://www.meetup.com/pro/Weave/) and get
+  invited to online talks, hands-on training and meetups in your area.
 - Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
-- <a href="https://github.com/weaveworks/flux/issues/new">File an issue.</a>
+- [File an issue.](https://github.com/weaveworks/flux/issues/new)
 
 Your feedback is always welcome!


### PR DESCRIPTION
This is a follow-up to #1315, adds link to CoC, is clearer in a few places.

@squaremo Can you take a brief look at https://github.com/weaveworks/flux/blame/master/CONTRIBUTING.md#L66 - it talks about an ACK from two maintainers. That's not actually what we want, right? :-)