### PR TITLE
helm-op: Purge release if install fails

### DIFF
--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -173,6 +173,13 @@ func (r *Release) Install(repoDir, releaseName string, fhr ifv1.FluxHelmRelease,
 
 		if err != nil {
 			r.logger.Log("error", fmt.Sprintf("Chart release failed: %s: %#v", releaseName, err))
+			// if an install fails, purge the release and keep retrying
+			r.logger.Log("info", fmt.Sprintf("Deleting failed release: [%s]", releaseName))
+			_, err = r.HelmClient.DeleteRelease(releaseName, k8shelm.DeletePurge(true))
+			if err != nil {
+				r.logger.Log("error", fmt.Sprintf("Release deletion error: %#v", err))
+				return nil, err
+			}
 			return nil, err
 		}
 		if !opts.DryRun {


### PR DESCRIPTION
If a chart is broken, Tiller will reserve the name and mark the release as failed. If at a later time the chart is fixed, helm-op can't install it anymore because the release name is in use. Purging the release after each failed install allows helm-op to keep retrying the installation.

Fix #1343