### PR TITLE
Add memcached verbose option

### DIFF
--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -28,7 +28,9 @@ spec:
         args:
         - -m 64    # Maximum memory to use, in megabytes. 64MB is default.
         - -p 11211    # Default port, but being explicit is nice.
+        {{- if .Values.memcached.verbose }}
         - -vv    # This gets us to the level of request logs.
+        {{- end }}
         ports:
         - name: memcached
           containerPort: 11211

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -108,6 +108,9 @@ registry:
   trace: false
   # Use HTTP rather than HTTPS for these image registry domains eg --set registry.insecureHosts="registry1.cluster.local,registry2.cluster.local"
   insecureHosts:
+ 
+memcached:
+  verbose: false
 
 ssh:
   # Overrides for git over SSH. If you use your own git server, you


### PR DESCRIPTION
Fixes https://github.com/weaveworks/flux/issues/1294

This PR adds helm chart option to turn on verbose logging for helm chart. In addition, it turns off verbose logging by default