### PR TITLE
Fix verification of initContainer releases

### DIFF
--- a/cluster/kubernetes/resource/spec.go
+++ b/cluster/kubernetes/resource/spec.go
@@ -43,7 +43,7 @@ func (t PodTemplate) SetContainerImage(container string, ref image.Ref) error {
 	}
 	for i, c := range t.Spec.InitContainers {
 		if c.Name == container {
-			t.Spec.Containers[i].Image = ref.String()
+			t.Spec.InitContainers[i].Image = ref.String()
 			return nil
 		}
 	}

--- a/cluster/kubernetes/testfiles/data.go
+++ b/cluster/kubernetes/testfiles/data.go
@@ -53,6 +53,7 @@ var ResourceMap = map[flux.ResourceID]string{
 	flux.MustParseResourceID("default:deployment/list-deploy"):    "list.yaml",
 	flux.MustParseResourceID("default:service/list-service"):      "list.yaml",
 	flux.MustParseResourceID("default:deployment/semver"):         "semver-deploy.yaml",
+	flux.MustParseResourceID("default:daemonset/init"):            "init.yaml",
 }
 
 // ServiceMap ... given a base path, construct the map representing
@@ -66,6 +67,7 @@ func ServiceMap(dir string) map[flux.ResourceID][]string {
 		flux.MustParseResourceID("default:deployment/multi-deploy"):   []string{filepath.Join(dir, "multi.yaml")},
 		flux.MustParseResourceID("default:deployment/list-deploy"):    []string{filepath.Join(dir, "list.yaml")},
 		flux.MustParseResourceID("default:deployment/semver"):         []string{filepath.Join(dir, "semver-deploy.yaml")},
+		flux.MustParseResourceID("default:daemonset/init"):            []string{filepath.Join(dir, "init.yaml")},
 	}
 }
 
@@ -236,6 +238,23 @@ items:
       protocol: TCP
     selector:
       app: list-app
+`,
+
+	// A daemonset using initContainers
+	"init.yaml": `---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: init
+spec:
+  template:
+    spec:
+      initContainers:
+      - name: greeter
+        image: quay.io/weaveworks/helloworld:master-a000001
+      containers:
+      - name: unimportant
+        image: alpine:1.0
 `,
 
 	// A tricksy chart directory, which should be skipped entirely. Adapted from

--- a/cluster/kubernetes/update_test.go
+++ b/cluster/kubernetes/update_test.go
@@ -51,8 +51,10 @@ func TestUpdates(t *testing.T) {
 		{"in kubernetes List resource", case10resource, case10containers, case10image, case10, case10out},
 		{"FluxHelmRelease (simple image encoding)", case11resource, case11containers, case11image, case11, case11out},
 		{"FluxHelmRelease (multi image encoding)", case12resource, case12containers, case12image, case12, case12out},
+		{"initContainer", case13resource, case13containers, case13image, case13, case13out},
 	} {
 		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
 			testUpdate(t, c)
 		})
 	}
@@ -867,4 +869,43 @@ spec:
     workProperly: true
     sidecar:
       image: sidecar:v1
+`
+
+const case13 = `---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: weave
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: weave
+    spec:
+      initContainers:
+      - name: weave
+        image: 'weaveworks/weave-kube:2.2.0'
+`
+
+const case13resource = "default:deployment/weave"
+const case13image = "weaveworks/weave-kube:2.2.1"
+
+var case13containers = []string{"weave"}
+
+const case13out = `---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: weave
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: weave
+    spec:
+      initContainers:
+      - name: weave
+        image: 'weaveworks/weave-kube:2.2.1'
 `

--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -1,12 +1,13 @@
 package gittest
 
 import (
+	"context"
 	"io/ioutil"
 	"os/exec"
 	"path/filepath"
 	"testing"
 
-	"context"
+	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 	"github.com/weaveworks/flux/git"
 )
@@ -59,6 +60,16 @@ func Repo(t *testing.T) (*git.Repo, func()) {
 		mirror.Clean()
 		cleanup()
 	}
+}
+
+// Workloads is a shortcut to getting the names of the workloads (NB
+// not all resources, just the workloads) represented in the test
+// files.
+func Workloads() (res []flux.ResourceID) {
+	for k, _ := range testfiles.ServiceMap("") {
+		res = append(res, k)
+	}
+	return res
 }
 
 // CheckoutWithConfig makes a standard repo, clones it, and returns

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -191,14 +191,34 @@ var skippedNotInRepo = update.ControllerResult{
 	Error:  update.NotInRepo,
 }
 
+type expected struct {
+	// The result we care about
+	Specific update.Result
+	// What everything not mentioned gets
+	Else update.ControllerResult
+}
+
+// Result returns the expected result taking into account what is
+// specified with Specific and what is elided with Else
+func (x expected) Result() update.Result {
+	result := x.Specific
+	for _, id := range gittest.Workloads() {
+		if _, ok := result[id]; !ok {
+			result[id] = x.Else
+		}
+	}
+	return result
+}
+
 func Test_FilterLogic(t *testing.T) {
 	cluster := mockCluster(hwSvc, lockedSvc) // no testsvc in cluster, but it _is_ in repo
+
 	notInRepoService := "default:deployment/notInRepo"
 	notInRepoSpec, _ := update.ParseResourceSpec(notInRepoService)
 	for _, tst := range []struct {
 		Name     string
 		Spec     update.ReleaseSpec
-		Expected update.Result
+		Expected expected
 	}{
 		// ignored if: excluded OR not included OR not correct image.
 		{
@@ -209,27 +229,25 @@ func Test_FilterLogic(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusSuccess,
-					PerContainer: []update.ContainerUpdate{
-						update.ContainerUpdate{
-							Container: helloContainer,
-							Current:   oldRef,
-							Target:    newHwRef,
-						},
-						update.ContainerUpdate{
-							Container: sidecarContainer,
-							Current:   sidecarRef,
-							Target:    newSidecarRef,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
+						Status: update.ReleaseStatusSuccess,
+						PerContainer: []update.ContainerUpdate{
+							update.ContainerUpdate{
+								Container: helloContainer,
+								Current:   oldRef,
+								Target:    newHwRef,
+							},
+							update.ContainerUpdate{
+								Container: sidecarContainer,
+								Current:   sidecarRef,
+								Target:    newSidecarRef,
+							},
 						},
 					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
+				Else: ignoredNotIncluded,
 			},
 		}, {
 			Name: "exclude specific service",
@@ -239,30 +257,29 @@ func Test_FilterLogic(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{lockedSvcID},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusSuccess,
-					PerContainer: []update.ContainerUpdate{
-						update.ContainerUpdate{
-							Container: helloContainer,
-							Current:   oldRef,
-							Target:    newHwRef,
-						},
-						update.ContainerUpdate{
-							Container: sidecarContainer,
-							Current:   sidecarRef,
-							Target:    newSidecarRef,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
+						Status: update.ReleaseStatusSuccess,
+						PerContainer: []update.ContainerUpdate{
+							update.ContainerUpdate{
+								Container: helloContainer,
+								Current:   oldRef,
+								Target:    newHwRef,
+							},
+							update.ContainerUpdate{
+								Container: sidecarContainer,
+								Current:   sidecarRef,
+								Target:    newSidecarRef,
+							},
 						},
 					},
+					flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
+						Status: update.ReleaseStatusIgnored,
+						Error:  update.Excluded,
+					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.Excluded,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
+				Else: skippedNotInCluster,
 			},
 		}, {
 			Name: "update specific image",
@@ -272,30 +289,28 @@ func Test_FilterLogic(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusSuccess,
-					PerContainer: []update.ContainerUpdate{
-						update.ContainerUpdate{
-							Container: helloContainer,
-							Current:   oldRef,
-							Target:    newHwRef,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
+						Status: update.ReleaseStatusSuccess,
+						PerContainer: []update.ContainerUpdate{
+							update.ContainerUpdate{
+								Container: helloContainer,
+								Current:   oldRef,
+								Target:    newHwRef,
+							},
 						},
 					},
+					flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
+						Status: update.ReleaseStatusIgnored,
+						Error:  update.DifferentImage,
+					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.DifferentImage,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
+				Else: skippedNotInCluster,
 			},
-		},
-		// skipped if: not ignored AND (locked or not found in cluster)
-		// else: service is pending.
-		{
+		}, {
+			// skipped if: not ignored AND (locked or not found in cluster)
+			// else: service is pending.
 			Name: "skipped & service is pending",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
@@ -303,33 +318,31 @@ func Test_FilterLogic(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusSuccess,
-					PerContainer: []update.ContainerUpdate{
-						update.ContainerUpdate{
-							Container: helloContainer,
-							Current:   oldRef,
-							Target:    newHwRef,
-						},
-						update.ContainerUpdate{
-							Container: sidecarContainer,
-							Current:   sidecarRef,
-							Target:    newSidecarRef,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
+						Status: update.ReleaseStatusSuccess,
+						PerContainer: []update.ContainerUpdate{
+							update.ContainerUpdate{
+								Container: helloContainer,
+								Current:   oldRef,
+								Target:    newHwRef,
+							},
+							update.ContainerUpdate{
+								Container: sidecarContainer,
+								Current:   sidecarRef,
+								Target:    newSidecarRef,
+							},
 						},
 					},
+					flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
+						Status: update.ReleaseStatusSkipped,
+						Error:  update.Locked,
+					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.Locked,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
+				Else: skippedNotInCluster,
 			},
-		},
-		{
+		}, {
 			Name: "all overrides spec",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{hwSvcSpec, update.ResourceSpecAll},
@@ -337,33 +350,31 @@ func Test_FilterLogic(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusSuccess,
-					PerContainer: []update.ContainerUpdate{
-						update.ContainerUpdate{
-							Container: helloContainer,
-							Current:   oldRef,
-							Target:    newHwRef,
-						},
-						update.ContainerUpdate{
-							Container: sidecarContainer,
-							Current:   sidecarRef,
-							Target:    newSidecarRef,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
+						Status: update.ReleaseStatusSuccess,
+						PerContainer: []update.ContainerUpdate{
+							update.ContainerUpdate{
+								Container: helloContainer,
+								Current:   oldRef,
+								Target:    newHwRef,
+							},
+							update.ContainerUpdate{
+								Container: sidecarContainer,
+								Current:   sidecarRef,
+								Target:    newSidecarRef,
+							},
 						},
 					},
+					flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
+						Status: update.ReleaseStatusSkipped,
+						Error:  update.Locked,
+					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.Locked,
-				},
-				flux.MustParseResourceID("default:deployment/test-service"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):  skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/semver"):       skippedNotInCluster,
+				Else: skippedNotInCluster,
 			},
-		},
-		{
+		}, {
 			Name: "service not in repo",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{notInRepoSpec},
@@ -371,14 +382,11 @@ func Test_FilterLogic(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
-				flux.MustParseResourceID(notInRepoService):                    skippedNotInRepo,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID(notInRepoService): skippedNotInRepo,
+				},
+				Else: ignoredNotIncluded,
 			},
 		},
 	} {
@@ -390,7 +398,7 @@ func Test_FilterLogic(t *testing.T) {
 				manifests: mockManifests,
 				registry:  mockRegistry,
 				repo:      checkout,
-			}, tst.Spec, tst.Expected)
+			}, tst.Spec, tst.Expected.Result())
 		})
 	}
 }
@@ -410,7 +418,7 @@ func Test_Force_lockedController(t *testing.T) {
 	for _, tst := range []struct {
 		Name     string
 		Spec     update.ReleaseSpec
-		Expected update.Result
+		Expected expected
 	}{
 		{
 			Name: "force ignores service lock (--controller --update-image)",
@@ -421,16 +429,13 @@ func Test_Force_lockedController(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/locked-service"): success,
-				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/locked-service"): success,
+				},
+				Else: ignoredNotIncluded,
 			},
-		},
-		{
+		}, {
 			Name: "force does not ignore lock if updating all controllers (--all --update-image)",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
@@ -439,13 +444,11 @@ func Test_Force_lockedController(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/locked-service"): skippedLocked,
-				flux.MustParseResourceID("default:deployment/helloworld"):     skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/semver"):         skippedNotInCluster,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/locked-service"): skippedLocked,
+				},
+				Else: skippedNotInCluster,
 			},
 		},
 		{
@@ -457,16 +460,13 @@ func Test_Force_lockedController(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/locked-service"): success,
-				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/locked-service"): success,
+				},
+				Else: ignoredNotIncluded,
 			},
-		},
-		{
+		}, {
 			Name: "force does not ignore lock if updating all controllers (--all --update-all-images)",
 			Spec: update.ReleaseSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
@@ -475,13 +475,11 @@ func Test_Force_lockedController(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/locked-service"): skippedLocked,
-				flux.MustParseResourceID("default:deployment/helloworld"):     skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/semver"):         skippedNotInCluster,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/locked-service"): skippedLocked,
+				},
+				Else: skippedNotInCluster,
 			},
 		},
 	} {
@@ -493,7 +491,7 @@ func Test_Force_lockedController(t *testing.T) {
 				manifests: mockManifests,
 				registry:  mockRegistry,
 				repo:      checkout,
-			}, tst.Spec, tst.Expected)
+			}, tst.Spec, tst.Expected.Result())
 		})
 	}
 }
@@ -523,7 +521,7 @@ func Test_Force_filteredContainer(t *testing.T) {
 	for _, tst := range []struct {
 		Name     string
 		Spec     update.ReleaseSpec
-		Expected update.Result
+		Expected expected
 	}{
 		{
 			Name: "force ignores container tag pattern (--controller --update-image)",
@@ -534,13 +532,11 @@ func Test_Force_filteredContainer(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/semver"):         successNew,
-				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/semver"): successNew,
+				},
+				Else: ignoredNotIncluded,
 			},
 		},
 		{
@@ -552,13 +548,11 @@ func Test_Force_filteredContainer(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/semver"):         successNew,
-				flux.MustParseResourceID("default:deployment/locked-service"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/helloworld"):     skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    skippedNotInCluster,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/semver"): successNew,
+				},
+				Else: skippedNotInCluster,
 			},
 		},
 		{
@@ -570,13 +564,11 @@ func Test_Force_filteredContainer(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/semver"):         successSemver,
-				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/semver"): successSemver,
+				},
+				Else: ignoredNotIncluded,
 			},
 		},
 		{
@@ -588,13 +580,11 @@ func Test_Force_filteredContainer(t *testing.T) {
 				Excludes:     []flux.ResourceID{},
 				Force:        true,
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/semver"):         successSemver,
-				flux.MustParseResourceID("default:deployment/locked-service"): skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/helloworld"):     skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/test-service"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   skippedNotInCluster,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    skippedNotInCluster,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/semver"): successSemver,
+				},
+				Else: skippedNotInCluster,
 			},
 		},
 	} {
@@ -606,7 +596,7 @@ func Test_Force_filteredContainer(t *testing.T) {
 				manifests: mockManifests,
 				registry:  mockRegistry,
 				repo:      checkout,
-			}, tst.Spec, tst.Expected)
+			}, tst.Spec, tst.Expected.Result())
 		})
 	}
 }
@@ -630,7 +620,7 @@ func Test_ImageStatus(t *testing.T) {
 	for _, tst := range []struct {
 		Name     string
 		Spec     update.ReleaseSpec
-		Expected update.Result
+		Expected expected
 	}{
 		{
 			Name: "image not found",
@@ -640,16 +630,14 @@ func Test_ImageStatus(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"):     ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
-					Status: update.ReleaseStatusIgnored,
-					Error:  update.DoesNotUseImage,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/test-service"): update.ControllerResult{
+						Status: update.ReleaseStatusIgnored,
+						Error:  update.DoesNotUseImage,
+					},
 				},
+				Else: ignoredNotIncluded,
 			},
 		}, {
 			Name: "image up to date",
@@ -659,16 +647,14 @@ func Test_ImageStatus(t *testing.T) {
 				Kind:         update.ReleaseKindExecute,
 				Excludes:     []flux.ResourceID{},
 			},
-			Expected: update.Result{
-				flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
-					Status: update.ReleaseStatusSkipped,
-					Error:  update.ImageUpToDate,
+			Expected: expected{
+				Specific: update.Result{
+					flux.MustParseResourceID("default:deployment/helloworld"): update.ControllerResult{
+						Status: update.ReleaseStatusSkipped,
+						Error:  update.ImageUpToDate,
+					},
 				},
-				flux.MustParseResourceID("default:deployment/locked-service"): ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/test-service"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/multi-deploy"):   ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/list-deploy"):    ignoredNotIncluded,
-				flux.MustParseResourceID("default:deployment/semver"):         ignoredNotIncluded,
+				Else: ignoredNotIncluded,
 			},
 		},
 	} {
@@ -681,7 +667,7 @@ func Test_ImageStatus(t *testing.T) {
 				repo:      checkout,
 				registry:  upToDateRegistry,
 			}
-			testRelease(t, ctx, tst.Spec, tst.Expected)
+			testRelease(t, ctx, tst.Spec, tst.Expected.Result())
 		})
 	}
 }


### PR DESCRIPTION
There was a mistake in `spec.SetContainer`, a method which is used only when verifying releases; it meant that any update to an initContainer would fail verification.

I've fixed that and added a couple of tests to cover updating (just changing a manifest) and releasing (updating and verifying and so on) workloads that have initContainers.

Fixes #1345.