### PR TITLE
Vary sampling rate in image metadata cache, and back off on HTTP 429

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -444,6 +444,7 @@ func main() {
 
 	cacheWarmer.Notify = daemon.AskForImagePoll
 	cacheWarmer.Priority = daemon.ImageRefresh
+	cacheWarmer.Trace = *registryTrace
 	shutdownWg.Add(1)
 	go cacheWarmer.Loop(log.With(logger, "component", "warmer"), shutdown, shutdownWg, imageCreds)
 

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -3,7 +3,6 @@ package image
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 	"strconv"
 	"testing"
 	"time"
@@ -149,9 +148,11 @@ func mustMakeInfo(ref string, created time.Time) Info {
 
 func TestImageInfoSerialisation(t *testing.T) {
 	t0 := time.Now().UTC() // UTC so it has nil location, otherwise it won't compare
+	t1 := time.Now().Add(5 * time.Minute).UTC()
 	info := mustMakeInfo("my/image:tag", t0)
 	info.Digest = "sha256:digest"
 	info.ImageID = "sha256:layerID"
+	info.LastFetched = t1
 	bytes, err := json.Marshal(info)
 	if err != nil {
 		t.Fatal(err)
@@ -160,9 +161,7 @@ func TestImageInfoSerialisation(t *testing.T) {
 	if err = json.Unmarshal(bytes, &info1); err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(info, info1) {
-		t.Errorf("roundtrip serialisation failed:\n original: %#v\nroundtripped: %#v", info, info1)
-	}
+	assert.Equal(t, info, info1)
 }
 
 func TestImageInfoCreatedAtZero(t *testing.T) {
@@ -248,4 +247,3 @@ func reverse(imgs []Info) {
 		imgs[i], imgs[opp] = imgs[opp], imgs[i]
 	}
 }
-

--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -8,11 +8,13 @@ import (
 )
 
 type Reader interface {
+	// GetKey gets the value at a key, along with its refresh deadline
 	GetKey(k Keyer) ([]byte, time.Time, error)
 }
 
 type Writer interface {
-	SetKey(k Keyer, v []byte) error
+	// SetKey sets the value at a key, along with its refresh deadline
+	SetKey(k Keyer, deadline time.Time, v []byte) error
 }
 
 type Client interface {

--- a/registry/cache/memcached/memcached_test.go
+++ b/registry/cache/memcached/memcached_test.go
@@ -34,20 +34,18 @@ func TestMemcache_ExpiryReadWrite(t *testing.T) {
 	}, strings.Fields(*memcachedIPs)...)
 
 	// Set some dummy data
-	err := mc.SetKey(key, val)
+	now := time.Now().Round(time.Second)
+	err := mc.SetKey(key, now, val)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cached, expiry, err := mc.GetKey(key)
+	cached, deadline, err := mc.GetKey(key)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if expiry.IsZero() {
-		t.Fatal("Time should not be zero")
-	}
-	if expiry.Before(time.Now()) {
-		t.Fatal("Expiry should be in the future")
+	if !deadline.Equal(now) {
+		t.Fatalf("Deadline should be %s, but is %s", now.String(), deadline.String())
 	}
 
 	if string(cached) != string(val) {

--- a/registry/cache/monitoring.go
+++ b/registry/cache/monitoring.go
@@ -40,12 +40,12 @@ func (i *instrumentedClient) GetKey(k Keyer) (_ []byte, ex time.Time, err error)
 	return i.next.GetKey(k)
 }
 
-func (i *instrumentedClient) SetKey(k Keyer, v []byte) (err error) {
+func (i *instrumentedClient) SetKey(k Keyer, d time.Time, v []byte) (err error) {
 	defer func(begin time.Time) {
 		cacheRequestDuration.With(
 			fluxmetrics.LabelMethod, "SetKey",
 			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
-	return i.next.SetKey(k, v)
+	return i.next.SetKey(k, d, v)
 }

--- a/registry/cache/warming.go
+++ b/registry/cache/warming.go
@@ -334,6 +334,10 @@ func (w *Warmer) warm(ctx context.Context, now time.Time, logger log.Logger, id 
 			LastUpdate: time.Now(),
 			Images:     newImages,
 		}
+		// If we got through all that without bumping into `HTTP 429
+		// Too Many Requests` (or other problems), we can potentially
+		// creep the rate limit up
+		w.clientFactory.Succeed(id.CanonicalName())
 	}
 
 	if w.Notify != nil {

--- a/registry/cache/warming_test.go
+++ b/registry/cache/warming_test.go
@@ -7,24 +7,41 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/registry/mock"
 )
 
+type entry struct {
+	b []byte
+	d time.Time
+}
+
 type mem struct {
-	kv map[string][]byte
+	kv map[string]entry
 	mx sync.Mutex
 }
 
-func (c *mem) SetKey(k Keyer, v []byte) error {
+var (
+	ref  image.Ref
+	repo image.Name
+)
+
+func init() {
+	ref, _ = image.ParseRef("example.com/path/image:tag")
+	repo = ref.Name
+}
+
+func (c *mem) SetKey(k Keyer, deadline time.Time, v []byte) error {
+	println("set key", k.Key(), deadline.Format(time.RFC3339))
 	c.mx.Lock()
 	defer c.mx.Unlock()
 	if c.kv == nil {
-		c.kv = make(map[string][]byte)
+		c.kv = make(map[string]entry)
 	}
-	c.kv[k.Key()] = v
+	c.kv[k.Key()] = entry{v, deadline}
 	return nil
 }
 
@@ -32,12 +49,14 @@ func (c *mem) GetKey(k Keyer) ([]byte, time.Time, error) {
 	c.mx.Lock()
 	defer c.mx.Unlock()
 	if c.kv == nil {
-		c.kv = make(map[string][]byte)
+		c.kv = make(map[string]entry)
 	}
 
-	if v, ok := c.kv[k.Key()]; ok {
-		return v, time.Now().Add(time.Hour), nil
+	if e, ok := c.kv[k.Key()]; ok {
+		println("get key", k.Key(), e.d.Format(time.RFC3339))
+		return e.b, e.d, nil
 	}
+	println("get key", k.Key(), "nil")
 	return nil, time.Time{}, ErrNotCached
 }
 
@@ -45,17 +64,65 @@ func (c *mem) GetKey(k Keyer) ([]byte, time.Time, error) {
 // cache.Registry work together as intended: that is, if you ask the
 // warmer to fetch information, the cached gets populated, and the
 // Registry implementation will see it.
-func TestWarm(t *testing.T) {
-	ref, _ := image.ParseRef("example.com/path/image:tag")
-	repo := ref.Name
-
+func TestWarmThenQuery(t *testing.T) {
+	digest := "abc"
+	warmer, cache := setup(t, &digest)
 	logger := log.NewNopLogger()
 
+	now := time.Now()
+	warmer.warm(context.TODO(), now, logger, repo, registry.NoCredentials())
+
+	registry := &Cache{Reader: cache}
+	repoInfo, err := registry.GetRepositoryImages(ref.Name)
+	assert.NoError(t, err)
+
+	// Otherwise, we should get what we put in ...
+	assert.Len(t, repoInfo, 1)
+	assert.Equal(t, ref.String(), repoInfo[0].ID.String())
+}
+
+func TestRefreshDeadline(t *testing.T) {
+	digest := "abc"
+	warmer, cache := setup(t, &digest)
+	logger := log.NewNopLogger()
+
+	now0 := time.Now()
+	warmer.warm(context.TODO(), now0, logger, repo, registry.NoCredentials())
+
+	// We should see that there's an entry for the manifest, and that
+	// it's set to be refreshed
+	k := NewManifestKey(ref.CanonicalRef())
+	_, deadline0, err := cache.GetKey(k)
+	assert.NoError(t, err)
+	assert.True(t, deadline0.After(now0))
+
+	// Fast-forward to after the refresh deadline; check that the
+	// entry is given a longer deadline
+	now1 := deadline0.Add(time.Minute)
+	warmer.warm(context.TODO(), now1, logger, repo, registry.NoCredentials())
+	_, deadline1, err := cache.GetKey(k)
+	assert.NoError(t, err)
+	assert.True(t, deadline1.After(now1))
+	assert.True(t, deadline0.Sub(now0) < deadline1.Sub(now1), "%s < %s", deadline0.Sub(now0), deadline1.Sub(now1))
+
+	// Fast-forward again, check that a _differing_ manifest results
+	// in a shorter deadline
+	digest = "cba" // <-- means manifest points at a different image
+	now2 := deadline1.Add(time.Minute)
+	warmer.warm(context.TODO(), now2, logger, repo, registry.NoCredentials())
+	_, deadline2, err := cache.GetKey(k)
+	assert.NoError(t, err)
+	assert.True(t, deadline1.Sub(now1) > deadline2.Sub(now2), "%s > %s", deadline1.Sub(now1), deadline2.Sub(now2))
+}
+
+func setup(t *testing.T, digest *string) (*Warmer, Client) {
 	client := &mock.Client{
 		TagsFn: func() ([]string, error) {
+			println("asked for tags")
 			return []string{"tag"}, nil
 		},
 		ManifestFn: func(tag string) (registry.ImageEntry, error) {
+			println("asked for manifest", tag)
 			if tag != "tag" {
 				t.Errorf("remote client was asked for %q instead of %q", tag, "tag")
 			}
@@ -63,6 +130,7 @@ func TestWarm(t *testing.T) {
 				Info: image.Info{
 					ID:        ref,
 					CreatedAt: time.Now(),
+					Digest:    *digest,
 				},
 			}, nil
 		},
@@ -70,19 +138,5 @@ func TestWarm(t *testing.T) {
 	factory := &mock.ClientFactory{Client: client}
 	c := &mem{}
 	warmer := &Warmer{clientFactory: factory, cache: c, burst: 10}
-	warmer.warm(context.TODO(), logger, repo, registry.NoCredentials())
-
-	registry := &Cache{Reader: c}
-	repoInfo, err := registry.GetRepositoryImages(ref.Name)
-	if err != nil {
-		t.Error(err)
-	}
-	// Otherwise, we should get what we put in ...
-	if len(repoInfo) != 1 {
-		t.Errorf("expected an image.Info item; got %#v", repoInfo)
-	} else {
-		if got := repoInfo[0].ID.String(); got != ref.String() {
-			t.Errorf("expected image %q from registry cache; got %q", ref.String(), got)
-		}
-	}
+	return warmer, c
 }

--- a/registry/client.go
+++ b/registry/client.go
@@ -69,6 +69,7 @@ type Client interface {
 // implementations.
 type ClientFactory interface {
 	ClientFor(image.CanonicalName, Credentials) (Client, error)
+	Succeed(image.CanonicalName)
 }
 
 type Remote struct {

--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -108,6 +108,13 @@ func (f *RemoteClientFactory) ClientFor(repo image.CanonicalName, creds Credenti
 	return NewInstrumentedClient(client), nil
 }
 
+// Succeed exists merely so that the user of the ClientFactory can
+// bump rate limits up if a repo's metadata has successfully been
+// fetched.
+func (f *RemoteClientFactory) Succeed(repo image.CanonicalName) {
+	f.Limiters.Recover(repo.Domain)
+}
+
 // store adapts a set of pre-selected creds to be an
 // auth.CredentialsStore
 type store struct {

--- a/registry/middleware/rate_limiter.go
+++ b/registry/middleware/rate_limiter.go
@@ -2,16 +2,93 @@ package middleware
 
 import (
 	"net/http"
+	"strconv"
 	"sync"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
 )
 
+const (
+	minLimit  = 0.1
+	backOffBy = 2.0
+	recoverBy = 1.5
+)
+
+// RateLimiters keeps track of per-host rate limiting for an arbitrary
+// set of hosts.
+
+// Use `*RateLimiter.RoundTripper(host)` to obtain a rate limited HTTP
+// transport for an operation. The RoundTripper will react to a `HTTP
+// 429 Too many requests` response by reducing the limit for that
+// host. It will only do so once, so that concurrent requests don't
+// *also* reduce the limit.
+//
+// Call `*RateLimiter.Recover(host)` when an operation has succeeded
+// without incident, which will increase the rate limit modestly back
+// towards the given ideal.
 type RateLimiters struct {
-	RPS, Burst int
-	perHost    map[string]*rate.Limiter
-	mu         sync.Mutex
+	RPS     float64
+	Burst   int
+	Logger  log.Logger
+	perHost map[string]*rate.Limiter
+	mu      sync.Mutex
+}
+
+func (limiters *RateLimiters) clip(limit float64) float64 {
+	if limit < minLimit {
+		return minLimit
+	}
+	if limit > limiters.RPS {
+		return limiters.RPS
+	}
+	return limit
+}
+
+// BackOff can be called to explicitly reduce the limit for a
+// particular host. Usually this isn't necessary since a RoundTripper
+// obtained for a host will respond to `HTTP 429` by doing this for
+// you.
+func (limiters *RateLimiters) BackOff(host string) {
+	limiters.mu.Lock()
+	defer limiters.mu.Unlock()
+
+	var limiter *rate.Limiter
+	if limiters.perHost == nil {
+		limiters.perHost = map[string]*rate.Limiter{}
+	}
+	if rl, ok := limiters.perHost[host]; ok {
+		limiter = rl
+	} else {
+		limiter = rate.NewLimiter(rate.Limit(limiters.RPS), limiters.Burst)
+		limiters.perHost[host] = limiter
+	}
+
+	oldLimit := float64(limiter.Limit())
+	newLimit := limiters.clip(oldLimit / backOffBy)
+	if oldLimit != newLimit && limiters.Logger != nil {
+		limiters.Logger.Log("info", "reducing rate limit", "host", host, "limit", strconv.FormatFloat(newLimit, 'f', 2, 64))
+	}
+	limiter.SetLimit(rate.Limit(newLimit))
+}
+
+// Recover should be called when a use of a RoundTripper has
+// succeeded, to bump the limit back up again.
+func (limiters *RateLimiters) Recover(host string) {
+	limiters.mu.Lock()
+	defer limiters.mu.Unlock()
+	if limiters.perHost == nil {
+		return
+	}
+	if limiter, ok := limiters.perHost[host]; ok {
+		oldLimit := float64(limiter.Limit())
+		newLimit := limiters.clip(oldLimit * recoverBy)
+		if newLimit != oldLimit && limiters.Logger != nil {
+			limiters.Logger.Log("info", "increasing rate limit", "host", host, "limit", strconv.FormatFloat(newLimit, 'f', 2, 64))
+		}
+		limiter.SetLimit(rate.Limit(newLimit))
+	}
 }
 
 // Limit returns a RoundTripper for a particular host. We expect to do
@@ -27,23 +104,35 @@ func (limiters *RateLimiters) RoundTripper(rt http.RoundTripper, host string) ht
 		rl := rate.NewLimiter(rate.Limit(limiters.RPS), limiters.Burst)
 		limiters.perHost[host] = rl
 	}
+	var reduceOnce sync.Once
 	return &RoundTripRateLimiter{
 		rl: limiters.perHost[host],
 		tx: rt,
+		slowDown: func() {
+			reduceOnce.Do(func() { limiters.BackOff(host) })
+		},
 	}
 }
 
 type RoundTripRateLimiter struct {
-	rl *rate.Limiter
-	tx http.RoundTripper
+	rl       *rate.Limiter
+	tx       http.RoundTripper
+	slowDown func()
 }
 
 func (t *RoundTripRateLimiter) RoundTrip(r *http.Request) (*http.Response, error) {
 	// Wait errors out if the request cannot be processed within
-	// the deadline. This is preemptive, instead of waiting the
+	// the deadline. This is pre-emptive, instead of waiting the
 	// entire duration.
 	if err := t.rl.Wait(r.Context()); err != nil {
 		return nil, errors.Wrap(err, "rate limited")
 	}
-	return t.tx.RoundTrip(r)
+	resp, err := t.tx.RoundTrip(r)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		t.slowDown()
+	}
+	return resp, err
 }

--- a/registry/middleware/rate_limiter.go
+++ b/registry/middleware/rate_limiter.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 	"sync"
 
@@ -47,13 +46,4 @@ func (t *RoundTripRateLimiter) RoundTrip(r *http.Request) (*http.Response, error
 		return nil, errors.Wrap(err, "rate limited")
 	}
 	return t.tx.RoundTrip(r)
-}
-
-type ContextRoundTripper struct {
-	Transport http.RoundTripper
-	Ctx       context.Context
-}
-
-func (rt *ContextRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	return rt.Transport.RoundTrip(r.WithContext(rt.Ctx))
 }

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux/image"
@@ -30,6 +31,10 @@ type ClientFactory struct {
 
 func (m *ClientFactory) ClientFor(repository image.CanonicalName, creds registry.Credentials) (registry.Client, error) {
 	return m.Client, m.Err
+}
+
+func (_ *ClientFactory) Succeed(_ image.CanonicalName) {
+	return
 }
 
 var _ registry.ClientFactory = &ClientFactory{}


### PR DESCRIPTION
### Vary the sampling rate

To drive the refresh of cache data, we expire entries after a
configurable duration (default of 1 hour).

Because many image tags never change what they point to, this means
the image cache does thousands of needless fetches every hour (or
whatever the configured duration is). On the other hand, if you set it
to much longer (say 24h), any changes to a tag won't be noticed for
that much longer.

This commit gives each manifest its own, adaptive schedule for being
refreshed. It does this by doubling the period when a freshly fetched
manifest does not differ from the existing entry, and halving it when
it does differ. (The refresh period is clipped to `[minRefresh,
maxRefresh]`)

A tag that doesn't change will end up being polled infrequently. A tag
that changes occasionally will alternate between a number of values,
depending on how regular the changes are.

There are surely more accurate ways of arriving at a good estimate for
the polling frequency based on the past samples; this one has the
advantage of being very simple, and requiring little state to be kept.

### Back off on HTTP 429

Image registries tend to have rate limiting, and it is hard to know in
advance what the practical limits are -- and they will often
change. Nonetheless, we have to back off when we get a HTTP 429,
otherwise the registry could e.g., decide to blacklist our IP.

Therefore:

 - decrease the rate limit for a registry domain if we get HTTP 429
   - we only reliably see this in the round-tripper, but that's where
     the rate limiting is anyway
   - this goes through the RateLimiters struct so that we can log it

 - we also want to edge back towards the configured rate when we have
   succeeded
   - but we only know if we succeeded in the calling code, so it has
     to be wired through
