### PR TITLE
Provide detailed pod status when listing services

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "64a2037ec6be8a4b0c1d1f706ed35b428b989239"
-  version = "v0.26.0"
+  revision = "c728a003b238b26cef9ab6753a5dc424b331c3ad"
+  version = "v0.27.0"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
@@ -228,7 +228,7 @@
     "openstack/utils",
     "pagination"
   ]
-  revision = "07d15af37699505fb5535c0962f49a10379d12ff"
+  revision = "13af1c2a38cfbc60a7a13062338838301035d91d"
 
 [[projects]]
   name = "github.com/gorilla/context"

--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/ssh"
@@ -34,6 +35,7 @@ type ControllerStatus struct {
 	Containers []Container
 	ReadOnly   ReadOnlyReason
 	Status     string
+	PodStatus  cluster.ControllerPodStatus
 	Antecedent flux.ResourceID
 	Labels     map[string]string
 	Automated  bool

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -21,10 +21,49 @@ type Cluster interface {
 	PublicSSHKey(regenerate bool) (ssh.PublicKey, error)
 }
 
+// ControllerPodStatus describes detailed controller pod status
+type ControllerPodStatus struct {
+	// Status of controller pod
+	Status string
+	// Desired number of pods as defined in spec.
+	Desired int32
+	// Updated number of pods that are on the desired pod spec.
+	Updated int32
+	// Ready number of pods that are on the desired pod spec and ready.
+	Ready int32
+	// Outdated number of pods that are on a different pod spec.
+	Outdated int32
+	// PodConditions represents the latest available observations of a controller's current state.
+	PodConditions []PodCondition
+}
+
+// PodCondition describes pod condition
+type PodCondition struct {
+	Name string
+	// A human readable message indicating details about why the pod is in this condition.
+	Message string
+	// A brief CamelCase message indicating details about why the pod is in this state.
+	Reason     string
+	Conditions []Condition
+}
+
+// Condition describes the state of a Controller at a certain point.
+type Condition struct {
+	// Type of condition.
+	Type string
+	// Status of the condition, one of True, False, Unknown.
+	Status string
+	// The reason for the condition's last transition.
+	Reason string
+	// A human readable message indicating details about the transition.
+	Message string
+}
+
 // Controller describes a cluster resource that declares versioned images.
 type Controller struct {
-	ID     flux.ResourceID
-	Status string // A status summary for display
+	ID        flux.ResourceID
+	Status    string // A status summary for display
+	PodStatus ControllerPodStatus
 	// Is the controller considered read-only because it's under the
 	// control of the platform. In the case of Kubernetes, we simply
 	// omit these controllers; but this may not always be the case.

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -23,8 +23,10 @@ import (
 
 const (
 	StatusUnknown  = "unknown"
+	StatusError    = "error"
 	StatusReady    = "ready"
 	StatusUpdating = "updating"
+	StatusStarted  = "started"
 )
 
 type coreClient k8sclient.Interface

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -126,6 +126,7 @@ func (d *Daemon) ListServices(ctx context.Context, namespace string) ([]v6.Contr
 			Containers: containers2containers(service.ContainersOrNil()),
 			ReadOnly:   readOnly,
 			Status:     service.Status,
+			PodStatus:  service.PodStatus,
 			Antecedent: service.Antecedent,
 			Labels:     service.Labels,
 			Automated:  policies.Has(policy.Automated),


### PR DESCRIPTION
For deployments, daemonSet, statefulSet provide structure with:
 - status
 - numbers of desired, updated, ready, outdated pods
 - pod conditions with message and reason

Fixes https://github.com/weaveworks/flux/issues/1303