### PR TITLE
Reduce memcache logging by default

### DIFF
--- a/deploy/memcache-dep.yaml
+++ b/deploy/memcache-dep.yaml
@@ -22,7 +22,7 @@ spec:
         args:
         - -m 64    # Maximum memory to use, in megabytes. 64MB is default.
         - -p 11211    # Default port, but being explicit is nice.
-        - -vv    # This gets us to the level of request logs.
+        # - -vv    # Uncomment to get logs of each request and response.
         ports:
         - name: clients
           containerPort: 11211


### PR DESCRIPTION
Unless debugging the image data being cached in memcached,
there is no value in recording all requests and responses between
fluxd and memcached into the logs. Reduce the logging, but
leave behind the comment in case someone needs it.