### PR TITLE
Include initContainers in images to fetch

### DIFF
--- a/cluster/kubernetes/images.go
+++ b/cluster/kubernetes/images.go
@@ -89,6 +89,14 @@ func mergeCredentials(log func(...interface{}) error, client extendedClient, nam
 		}
 		imageCreds[r.Name] = creds
 	}
+	for _, container := range podTemplate.Spec.InitContainers {
+		r, err := image.ParseRef(container.Image)
+		if err != nil {
+			log("err", err.Error())
+			continue
+		}
+		imageCreds[r.Name] = creds
+	}
 }
 
 // ImagesToFetch is a k8s specific method to get a list of images to update along with their credentials


### PR DESCRIPTION
Symptom: images used in initContainers, but not elsewhere, don't get
metadata fetched for them, and don't get automated updates.

Fix: the ImagesToFetch method of the cluster, supplied to the image DB
as the way to get a list of all the images to fetch, didn't look in
initContainers. So, make it do that.

Fixes #1371.