### PR TITLE
fix wrong link to using.md from helm-get-started.md

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -182,4 +182,4 @@ very straight-forward and are a quite natural work-flow.
 # Next
 
 As a next step, you might want to dive deeper into [how to control
-Flux](../using.md).
+Flux](using.md).


### PR DESCRIPTION
They are both in the same folder.