### PR TITLE
 Add ListServicesWithOptions in API v11

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -1,17 +1,17 @@
 package api
 
-import "github.com/weaveworks/flux/api/v10"
+import "github.com/weaveworks/flux/api/v11"
 
 // Server defines the minimal interface a Flux must satisfy to adequately serve a
 // connecting fluxctl. This interface specifically does not facilitate connecting
 // to Weave Cloud.
 type Server interface {
-	v10.Server
+	v11.Server
 }
 
 // UpstreamServer is the interface a Flux must satisfy in order to communicate with
 // Weave Cloud.
 type UpstreamServer interface {
-	v10.Server
-	v10.Upstream
+	v11.Server
+	v11.Upstream
 }

--- a/api/v11/api.go
+++ b/api/v11/api.go
@@ -1,0 +1,25 @@
+// This package defines the types for Flux API version 11.
+package v11
+
+import (
+	"context"
+
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v6"
+)
+
+type ListServicesOptions struct {
+	Namespace string
+	Services  []flux.ResourceID
+}
+
+type Server interface {
+	v10.Server
+
+	ListServicesWithOptions(ctx context.Context, opts ListServicesOptions) ([]v6.ControllerStatus, error)
+}
+
+type Upstream interface {
+	v10.Upstream
+}

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/weaveworks/flux/api"
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/event"
@@ -55,6 +56,16 @@ func New(c *http.Client, router *mux.Router, endpoint string, t Token) *Client {
 func (c *Client) ListServices(ctx context.Context, namespace string) ([]v6.ControllerStatus, error) {
 	var res []v6.ControllerStatus
 	err := c.Get(ctx, &res, transport.ListServices, "namespace", namespace)
+	return res, err
+}
+
+func (c *Client) ListServicesWithOptions(ctx context.Context, opts v11.ListServicesOptions) ([]v6.ControllerStatus, error) {
+	var res []v6.ControllerStatus
+	var services []string
+	for _, svc := range opts.Services {
+		services = append(services, svc.String())
+	}
+	err := c.Get(ctx, &res, transport.ListServicesWithOptions, "namespace", opts.Namespace, "services", strings.Join(services, ","))
 	return res, err
 }
 

--- a/http/routes.go
+++ b/http/routes.go
@@ -1,14 +1,15 @@
 package http
 
 const (
-	ListServices          = "ListServices"
-	ListImages            = "ListImages"
-	ListImagesWithOptions = "ListImagesWithOptions"
-	UpdateManifests       = "UpdateManifests"
-	JobStatus             = "JobStatus"
-	SyncStatus            = "SyncStatus"
-	Export                = "Export"
-	GitRepoConfig         = "GitRepoConfig"
+	ListServices            = "ListServices"
+	ListServicesWithOptions = "ListServicesWithOptions"
+	ListImages              = "ListImages"
+	ListImagesWithOptions   = "ListImagesWithOptions"
+	UpdateManifests         = "UpdateManifests"
+	JobStatus               = "JobStatus"
+	SyncStatus              = "SyncStatus"
+	Export                  = "Export"
+	GitRepoConfig           = "GitRepoConfig"
 
 	UpdateImages           = "UpdateImages"
 	UpdatePolicies         = "UpdatePolicies"
@@ -22,5 +23,6 @@ var (
 	RegisterDaemonV8  = "RegisterDaemonV8"
 	RegisterDaemonV9  = "RegisterDaemonV9"
 	RegisterDaemonV10 = "RegisterDaemonV10"
+	RegisterDaemonV11 = "RegisterDaemonV11"
 	LogEvent          = "LogEvent"
 )

--- a/http/transport.go
+++ b/http/transport.go
@@ -30,6 +30,7 @@ func NewAPIRouter() *mux.Router {
 	r := mux.NewRouter()
 
 	r.NewRoute().Name(ListServices).Methods("GET").Path("/v6/services")
+	r.NewRoute().Name(ListServicesWithOptions).Methods("GET").Path("/v11/services")
 	r.NewRoute().Name(ListImages).Methods("GET").Path("/v6/images")
 	r.NewRoute().Name(ListImagesWithOptions).Methods("GET").Path("/v10/images")
 

--- a/remote/logging.go
+++ b/remote/logging.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/weaveworks/flux/api"
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	"github.com/weaveworks/flux/api/v9"
 	"github.com/weaveworks/flux/job"
@@ -42,6 +43,15 @@ func (p *ErrorLoggingServer) ListServices(ctx context.Context, maybeNamespace st
 		}
 	}()
 	return p.server.ListServices(ctx, maybeNamespace)
+}
+
+func (p *ErrorLoggingServer) ListServicesWithOptions(ctx context.Context, opts v11.ListServicesOptions) (_ []v6.ControllerStatus, err error) {
+	defer func() {
+		if err != nil {
+			p.logger.Log("method", "ListServicesWithOptions", "error", err)
+		}
+	}()
+	return p.server.ListServicesWithOptions(ctx, opts)
 }
 
 func (p *ErrorLoggingServer) ListImages(ctx context.Context, spec update.ResourceSpec) (_ []v6.ImageStatus, err error) {

--- a/remote/metrics.go
+++ b/remote/metrics.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/weaveworks/flux/api"
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	"github.com/weaveworks/flux/api/v9"
 	"github.com/weaveworks/flux/job"
@@ -55,6 +56,16 @@ func (i *instrumentedServer) ListServices(ctx context.Context, namespace string)
 		).Observe(time.Since(begin).Seconds())
 	}(time.Now())
 	return i.s.ListServices(ctx, namespace)
+}
+
+func (i *instrumentedServer) ListServicesWithOptions(ctx context.Context, opts v11.ListServicesOptions) (_ []v6.ControllerStatus, err error) {
+	defer func(begin time.Time) {
+		requestDuration.With(
+			fluxmetrics.LabelMethod, "ListServicesWithOptions",
+			fluxmetrics.LabelSuccess, fmt.Sprint(err == nil),
+		).Observe(time.Since(begin).Seconds())
+	}(time.Now())
+	return i.s.ListServicesWithOptions(ctx, opts)
 }
 
 func (i *instrumentedServer) ListImages(ctx context.Context, spec update.ResourceSpec) (_ []v6.ImageStatus, err error) {

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -11,6 +11,7 @@ import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/api"
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	"github.com/weaveworks/flux/api/v9"
 	"github.com/weaveworks/flux/guid"
@@ -63,6 +64,10 @@ func (p *MockServer) Export(ctx context.Context) ([]byte, error) {
 }
 
 func (p *MockServer) ListServices(ctx context.Context, ns string) ([]v6.ControllerStatus, error) {
+	return p.ListServicesAnswer, p.ListServicesError
+}
+
+func (p *MockServer) ListServicesWithOptions(context.Context, v11.ListServicesOptions) ([]v6.ControllerStatus, error) {
 	return p.ListServicesAnswer, p.ListServicesError
 }
 

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/weaveworks/flux/api"
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	"github.com/weaveworks/flux/api/v9"
 	"github.com/weaveworks/flux/job"
@@ -32,6 +33,10 @@ func (bc baseClient) Export(context.Context) ([]byte, error) {
 
 func (bc baseClient) ListServices(context.Context, string) ([]v6.ControllerStatus, error) {
 	return nil, remote.UpgradeNeededError(errors.New("ListServices method not implemented"))
+}
+
+func (bc baseClient) ListServicesWithOptions(context.Context, v11.ListServicesOptions) ([]v6.ControllerStatus, error) {
+	return nil, remote.UpgradeNeededError(errors.New("ListServicesWithOptions method not implemented"))
 }
 
 func (bc baseClient) ListImages(context.Context, update.ResourceSpec) ([]v6.ImageStatus, error) {

--- a/remote/rpc/clientV11.go
+++ b/remote/rpc/clientV11.go
@@ -1,0 +1,49 @@
+package rpc
+
+import (
+	"context"
+	"io"
+	"net/rpc"
+
+	"github.com/weaveworks/flux/api/v11"
+	"github.com/weaveworks/flux/api/v6"
+	"github.com/weaveworks/flux/remote"
+	)
+
+// RPCClientV11 is the rpc-backed implementation of a server, for
+// talking to remote daemons. This version introduces methods which accept an
+// options struct as the first argument. e.g. ListServicesWithOptions
+type RPCClientV11 struct {
+	*RPCClientV10
+}
+
+type clientV11 interface {
+	v11.Server
+	v11.Upstream
+}
+
+var _ clientV11 = &RPCClientV11{}
+
+// NewClientV11 creates a new rpc-backed implementation of the server.
+func NewClientV11(conn io.ReadWriteCloser) *RPCClientV11 {
+	return &RPCClientV11{NewClientV10(conn)}
+}
+
+func (p *RPCClientV11) ListServicesWithOptions(ctx context.Context, opts v11.ListServicesOptions) ([]v6.ControllerStatus, error) {
+	var resp ListServicesResponse
+	for _, svc := range opts.Services {
+		if err := requireServiceIDKinds(svc, supportedKindsV8); err != nil {
+			return resp.Result, remote.UnsupportedResourceKind(err)
+		}
+	}
+
+	err := p.client.Call("RPCServer.ListServicesWithOptions", opts, &resp)
+	if err != nil {
+		if _, ok := err.(rpc.ServerError); !ok && err != nil {
+			err = remote.FatalError{err}
+		}
+	} else if resp.ApplicationError != nil {
+		err = resp.ApplicationError
+	}
+	return resp.Result, err
+}

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -6,6 +6,7 @@ import (
 	"net/rpc"
 
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/job"
@@ -61,6 +62,10 @@ func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]v6.
 		err = resp.ApplicationError
 	}
 	return resp.Result, err
+}
+
+func (p *RPCClientV7) ListServicesWithOptions(ctx context.Context, opts v11.ListServicesOptions) ([]v6.ControllerStatus, error) {
+	return listServicesWithOptions(ctx, p, opts, supportedKindsV7)
 }
 
 func (p *RPCClientV7) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6.ImageStatus, error) {

--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -6,6 +6,7 @@ import (
 	"net/rpc"
 
 	"github.com/weaveworks/flux/api/v10"
+	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/remote"
@@ -31,6 +32,10 @@ var supportedKindsV8 = []string{"deployment", "daemonset", "statefulset", "cronj
 // NewClient creates a new rpc-backed implementation of the server.
 func NewClientV8(conn io.ReadWriteCloser) *RPCClientV8 {
 	return &RPCClientV8{NewClientV7(conn)}
+}
+
+func (p *RPCClientV8) ListServicesWithOptions(ctx context.Context, opts v11.ListServicesOptions) ([]v6.ControllerStatus, error) {
+	return listServicesWithOptions(ctx, p, opts, supportedKindsV8)
 }
 
 func (p *RPCClientV8) ListImages(ctx context.Context, spec update.ResourceSpec) ([]v6.ImageStatus, error) {

--- a/remote/rpc/clientV9.go
+++ b/remote/rpc/clientV9.go
@@ -18,6 +18,8 @@ type clientV9 interface {
 	v9.Upstream
 }
 
+var _ clientV9 = &RPCClientV9{}
+
 func NewClientV9(conn io.ReadWriteCloser) *RPCClientV9 {
 	return &RPCClientV9{NewClientV8(conn)}
 }

--- a/remote/rpc/rpc_test.go
+++ b/remote/rpc/rpc_test.go
@@ -31,7 +31,7 @@ func TestRPC(t *testing.T) {
 			t.Fatal(err)
 		}
 		go server.ServeConn(serverConn)
-		return NewClientV10(clientConn)
+		return NewClientV11(clientConn)
 	}
 	remote.ServerTestBattery(t, wrap)
 }


### PR DESCRIPTION
Adds the endpoint `ListServicesWithOptions` supporting `namespace` and
`services` as a parameter. `services` filters the result by resource
ids.

It introduces a new API v11 which builds on top of v10 but adds the
`ListServicesWithOptions` call. It is polyfilled back to API v6 by
using `ListServices` and then manually removing the unwanted services.

Closes #1352 