### PR TITLE
Provide detailed pod status when listing services

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -4,8 +4,8 @@
 [[projects]]
   name = "cloud.google.com/go"
   packages = ["compute/metadata"]
-  revision = "64a2037ec6be8a4b0c1d1f706ed35b428b989239"
-  version = "v0.26.0"
+  revision = "c728a003b238b26cef9ab6753a5dc424b331c3ad"
+  version = "v0.27.0"
 
 [[projects]]
   name = "github.com/Azure/go-autorest"
@@ -228,7 +228,7 @@
     "openstack/utils",
     "pagination"
   ]
-  revision = "07d15af37699505fb5535c0962f49a10379d12ff"
+  revision = "13af1c2a38cfbc60a7a13062338838301035d91d"
 
 [[projects]]
   name = "github.com/gorilla/context"

--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/git"
 	"github.com/weaveworks/flux/job"
 	"github.com/weaveworks/flux/ssh"
@@ -34,6 +35,7 @@ type ControllerStatus struct {
 	Containers []Container
 	ReadOnly   ReadOnlyReason
 	Status     string
+	Rollout    cluster.RolloutStatus
 	Antecedent flux.ResourceID
 	Labels     map[string]string
 	Automated  bool

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -21,6 +21,29 @@ type Cluster interface {
 	PublicSSHKey(regenerate bool) (ssh.PublicKey, error)
 }
 
+// RolloutStatus describes numbers of pods in different states and
+// the messages about unexpected rollout progress
+// a rollout status might be:
+// - in progress: Updated, Ready or Available numbers are not equal to Desired, or Outdated not equal to 0
+// - stuck: Messages contains info if deployment unavailable or exceeded its progress deadline
+// - complete: Updated, Ready and Available numbers are equal to Desired and Outdated equal to 0
+// See https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#deployment-status
+type RolloutStatus struct {
+	// Desired number of pods as defined in spec.
+	Desired int32
+	// Updated number of pods that are on the desired pod spec.
+	Updated int32
+	// Ready number of pods targeted by this deployment.
+	Ready int32
+	// Available number of available pods (ready for at least minReadySeconds) targeted by this deployment.
+	Available int32
+	// Outdated number of pods that are on a different pod spec.
+	Outdated int32
+	// Messages about unexpected rollout progress
+	// if there's a message here, the rollout will not make progress without intervention
+	Messages []string
+}
+
 // Controller describes a cluster resource that declares versioned images.
 type Controller struct {
 	ID     flux.ResourceID
@@ -35,6 +58,7 @@ type Controller struct {
 	// in this field.
 	Antecedent flux.ResourceID
 	Labels     map[string]string
+	Rollout    RolloutStatus
 
 	Containers ContainersOrExcuse
 }

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -23,8 +23,10 @@ import (
 
 const (
 	StatusUnknown  = "unknown"
+	StatusError    = "error"
 	StatusReady    = "ready"
 	StatusUpdating = "updating"
+	StatusStarted  = "started"
 )
 
 type coreClient k8sclient.Interface

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -126,6 +126,7 @@ func (d *Daemon) ListServices(ctx context.Context, namespace string) ([]v6.Contr
 			Containers: containers2containers(service.ContainersOrNil()),
 			ReadOnly:   readOnly,
 			Status:     service.Status,
+			Rollout:    service.Rollout,
 			Antecedent: service.Antecedent,
 			Labels:     service.Labels,
 			Automated:  policies.Has(policy.Automated),


### PR DESCRIPTION
For deployments, daemonSet, statefulSet provide:
 - status of rollout
 - numbers of desired, updated, ready, available, outdated pods
 - slice of errors for controller

Fixes https://github.com/weaveworks/flux/issues/1303