### PR TITLE
Allow custom ssh keys for flux and helm operators

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -190,6 +190,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `git.label` | Label to keep track of sync progress, used to tag the Git branch | `flux-sync`
 | `git.ciSkip` | Append "[ci skip]" to commit messages so that CI will skip builds | `false`
 | `git.pollInterval` | Period at which to poll git repo for new commits | `5m`
+| `git.secretName` | Kubernetes secret with the SSH private key | None
 | `ssh.known_hosts`  | The contents of an SSH `known_hosts` file, if you need to supply host key(s) | None
 | `registry.cacheExpiry` | Duration to keep cached image info in memcached | `1h`
 | `registry.pollInterval` | Period at which to check for updated images | `5m`

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -32,7 +32,11 @@ spec:
           defaultMode: 0600
       - name: git-key
         secret:
+          {{- if .Values.git.secretName }}
+          secretName: {{ .Values.git.secretName }}
+          {{- else }}
           secretName: {{ template "flux.fullname" . }}-git-deploy
+          {{- end }}
           defaultMode: 0400
       - name: git-keygen
         emptyDir:

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -35,6 +35,8 @@ spec:
         secret:
           {{- if .Values.helmOperator.git.secretName }}
           secretName: {{ .Values.helmOperator.git.secretName }}
+          {{- else if .Values.git.secretName }}
+          secretName: {{ .Values.git.secretName }}
           {{- else }}
           secretName: {{ template "flux.fullname" . }}-git-deploy
           {{- end }}

--- a/chart/flux/templates/secret.yaml
+++ b/chart/flux/templates/secret.yaml
@@ -1,5 +1,7 @@
+{{- if not .Values.git.secretName -}}
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "flux.fullname" . }}-git-deploy
 type: Opaque
+{{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -94,6 +94,12 @@ git:
   ciSkip: false
   # Period at which to poll git repo for new commits
   pollInterval: "5m"
+  # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
+  # create a Kubernetes secret: kubectl -n flux create secret generic flux-ssh --from-file=./identity
+  # delete the private key: rm ./identity
+  # add ./identity.pub as a read-only deployment key in your GitHub repo where the charts are
+  # set the secret name (flux-ssh) below
+  secretName: ""
 
 registry:
   # Duration to keep cached image info. Must be < 1 month.


### PR DESCRIPTION
- Add `git.secretName` to allow custom ssh key for flux operator
- `git.secretName` and `helmOperator.git.secretName` can be set to different values to use different keys for both operators
- If only `git.secretName` is set the secret will be used by both operators
- If only `helmOperator.git.secretName` is set it will be used for helm. Flux uses the auto-generated key (this is the same behaviour as with the previous version of the chart)

Should also fix https://github.com/weaveworks/flux/issues/1386