### PR TITLE
Polyfill rollout status for older daemons

### DIFF
--- a/remote/rpc/clientV11.go
+++ b/remote/rpc/clientV11.go
@@ -38,6 +38,7 @@ func (p *RPCClientV11) ListServicesWithOptions(ctx context.Context, opts v11.Lis
 	}
 
 	err := p.client.Call("RPCServer.ListServicesWithOptions", opts, &resp)
+	listServicesRolloutStatus(resp.Result)
 	if err != nil {
 		if _, ok := err.(rpc.ServerError); !ok && err != nil {
 			err = remote.FatalError{err}

--- a/remote/rpc/clientV6.go
+++ b/remote/rpc/clientV6.go
@@ -92,6 +92,7 @@ func (p *RPCClientV6) Export(ctx context.Context) ([]byte, error) {
 func (p *RPCClientV6) ListServices(ctx context.Context, namespace string) ([]v6.ControllerStatus, error) {
 	var services []v6.ControllerStatus
 	err := p.client.Call("RPCServer.ListServices", namespace, &services)
+	listServicesRolloutStatus(services)
 	if _, ok := err.(rpc.ServerError); !ok && err != nil {
 		return nil, remote.FatalError{err}
 	}

--- a/remote/rpc/clientV7.go
+++ b/remote/rpc/clientV7.go
@@ -53,6 +53,7 @@ func (p *RPCClientV7) Export(ctx context.Context) ([]byte, error) {
 func (p *RPCClientV7) ListServices(ctx context.Context, namespace string) ([]v6.ControllerStatus, error) {
 	var resp ListServicesResponse
 	err := p.client.Call("RPCServer.ListServices", namespace, &resp)
+	listServicesRolloutStatus(resp.Result)
 	if err != nil {
 		if _, ok := err.(rpc.ServerError); !ok && err != nil {
 			return resp.Result, remote.FatalError{err}


### PR DESCRIPTION
Polyfills the newly introduced rollout status (#1303) for daemons older than
commit 38d15071.

It parses the `v6.ControllerStatus.Status` field which contains count
of updated pods during rollout and populates `v6.ControllerStatus.Rollout`.