### PR TITLE
Add --git-timeout configuration flags

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -190,7 +190,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `git.label` | Label to keep track of sync progress, used to tag the Git branch | `flux-sync`
 | `git.ciSkip` | Append "[ci skip]" to commit messages so that CI will skip builds | `false`
 | `git.pollInterval` | Period at which to poll git repo for new commits | `5m`
-| `git.timeOut` | Duration after which git operations time out | `20s`
+| `git.timeout` | Duration after which git operations time out | `20s`
 | `git.secretName` | Kubernetes secret with the SSH private key | None
 | `ssh.known_hosts`  | The contents of an SSH `known_hosts` file, if you need to supply host key(s) | None
 | `registry.cacheExpiry` | Duration to keep cached image info in memcached | `1h`
@@ -209,7 +209,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.git.branch` | Branch of git repo to use for Helm charts | `master`
 | `helmOperator.git.chartsPath` | Path within git repo to locate Helm charts (relative path) | `charts`
 | `helmOperator.git.pollInterval` | Period at which to poll git repo for new commits | `git.pollInterval`
-| `helmOperator.git.timeOut` | Duration after which git operations time out | `git.timeOut`
+| `helmOperator.git.timeout` | Duration after which git operations time out | `git.timeout`
 | `helmOperator.git.secretName` | Kubernetes secret with the SSH private key | None
 | `helmOperator.logReleaseDiffs` | Helm operator should log the diff when a chart release diverges (possibly insecure) | `false`
 | `helmOperator.tillerNamespace` | Namespace in which the Tiller server can be found | `kube-system`

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -190,6 +190,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `git.label` | Label to keep track of sync progress, used to tag the Git branch | `flux-sync`
 | `git.ciSkip` | Append "[ci skip]" to commit messages so that CI will skip builds | `false`
 | `git.pollInterval` | Period at which to poll git repo for new commits | `5m`
+| `git.timeOut` | Duration after which git operations time out | `20s`
 | `git.secretName` | Kubernetes secret with the SSH private key | None
 | `ssh.known_hosts`  | The contents of an SSH `known_hosts` file, if you need to supply host key(s) | None
 | `registry.cacheExpiry` | Duration to keep cached image info in memcached | `1h`
@@ -208,6 +209,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.git.branch` | Branch of git repo to use for Helm charts | `master`
 | `helmOperator.git.chartsPath` | Path within git repo to locate Helm charts (relative path) | `charts`
 | `helmOperator.git.pollInterval` | Period at which to poll git repo for new commits | `git.pollInterval`
+| `helmOperator.git.timeOut` | Duration after which git operations time out | `git.timeOut`
 | `helmOperator.git.secretName` | Kubernetes secret with the SSH private key | None
 | `helmOperator.logReleaseDiffs` | Helm operator should log the diff when a chart release diverges (possibly insecure) | `false`
 | `helmOperator.tillerNamespace` | Namespace in which the Tiller server can be found | `kube-system`

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -71,7 +71,7 @@ spec:
           - --git-email={{ .Values.git.email }}
           - --git-set-author={{ .Values.git.setAuthor }}
           - --git-poll-interval={{ .Values.git.pollInterval }}
-          - --git-time-out={{ .Values.git.timeOut }}
+          - --git-timeout={{ .Values.git.timeout }}
           - --sync-interval={{ .Values.git.pollInterval }}
           - --git-ci-skip={{ .Values.git.ciSkip }}
           {{- if .Values.git.label }}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
           - --git-email={{ .Values.git.email }}
           - --git-set-author={{ .Values.git.setAuthor }}
           - --git-poll-interval={{ .Values.git.pollInterval }}
+          - --git-time-out={{ .Values.git.timeOut }}
           - --sync-interval={{ .Values.git.pollInterval }}
           - --git-ci-skip={{ .Values.git.ciSkip }}
           {{- if .Values.git.label }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -1,7 +1,7 @@
 {{- $gitURL := default .Values.git.url .Values.helmOperator.git.url }}
 {{- $gitBranch := default .Values.git.branch .Values.helmOperator.git.branch }}
 {{- $gitPollInterval := default .Values.git.pollInterval .Values.helmOperator.git.pollInterval }}
-{{- $gitTimeOut := default .Values.git.timeOut .Values.helmOperator.git.timeOut }}
+{{- $gitTimeout := default .Values.git.timeout .Values.helmOperator.git.timeout }}
 {{- if .Values.helmOperator.create -}}
 apiVersion: apps/v1beta2
 kind: Deployment
@@ -80,7 +80,7 @@ spec:
         - --git-url={{ $gitURL }}
         - --git-branch={{ $gitBranch }}
         - --git-poll-interval={{ $gitPollInterval }}
-        - --git-time-out={{ $gitTimeOut }}
+        - --git-timeout={{ $gitTimeout }}
         - --git-charts-path={{ .Values.helmOperator.git.chartsPath }}
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --charts-sync-timeout={{ .Values.helmOperator.chartsSyncTimeout }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -1,6 +1,7 @@
 {{- $gitURL := default .Values.git.url .Values.helmOperator.git.url }}
 {{- $gitBranch := default .Values.git.branch .Values.helmOperator.git.branch }}
 {{- $gitPollInterval := default .Values.git.pollInterval .Values.helmOperator.git.pollInterval }}
+{{- $gitTimeOut := default .Values.git.timeOut .Values.helmOperator.git.timeOut }}
 {{- if .Values.helmOperator.create -}}
 apiVersion: apps/v1beta2
 kind: Deployment
@@ -79,6 +80,7 @@ spec:
         - --git-url={{ $gitURL }}
         - --git-branch={{ $gitBranch }}
         - --git-poll-interval={{ $gitPollInterval }}
+        - --git-time-out={{ $gitTimeOut }}
         - --git-charts-path={{ .Values.helmOperator.git.chartsPath }}
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --charts-sync-timeout={{ .Values.helmOperator.chartsSyncTimeout }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -41,6 +41,7 @@ helmOperator:
     branch: ""
     chartsPath: "charts"
     pollInterval: ""
+    timeOut: ""
     # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
     # create a Kubernetes secret: kubectl -n flux create secret generic helm-ssh --from-file=./identity
     # delete the private key: rm ./identity
@@ -94,6 +95,8 @@ git:
   ciSkip: false
   # Period at which to poll git repo for new commits
   pollInterval: "5m"
+  # Duration after which git operations time out
+  timeOut: "20s"
   # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
   # create a Kubernetes secret: kubectl -n flux create secret generic flux-ssh --from-file=./identity
   # delete the private key: rm ./identity

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -41,7 +41,7 @@ helmOperator:
     branch: ""
     chartsPath: "charts"
     pollInterval: ""
-    timeOut: ""
+    timeout: ""
     # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
     # create a Kubernetes secret: kubectl -n flux create secret generic helm-ssh --from-file=./identity
     # delete the private key: rm ./identity
@@ -96,7 +96,7 @@ git:
   # Period at which to poll git repo for new commits
   pollInterval: "5m"
   # Duration after which git operations time out
-  timeOut: "20s"
+  timeout: "20s"
   # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
   # create a Kubernetes secret: kubectl -n flux create secret generic flux-ssh --from-file=./identity
   # delete the private key: rm ./identity

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -93,7 +93,7 @@ func main() {
 		gitSkipMessage = fs.String("git-ci-skip-message", "", "additional text for commit messages, useful for skipping builds in CI. Use this to supply specific text, or set --git-ci-skip")
 
 		gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period at which to poll git repo for new commits")
-		gitTimeOut      = fs.Duration("git-time-out", 20*time.Second, "duration after which git operations time out")
+		gitTimeout      = fs.Duration("git-timeout", 20*time.Second, "duration after which git operations time out")
 		// syncing
 		syncInterval = fs.Duration("sync-interval", 5*time.Minute, "apply config in git to cluster at least this often, even if there are no new commits")
 		// registry
@@ -370,7 +370,7 @@ func main() {
 		SkipMessage: *gitSkipMessage,
 	}
 
-	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.TimeOut(*gitTimeOut))
+	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.Timeout(*gitTimeout))
 	{
 		shutdownWg.Add(1)
 		go func() {

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -93,6 +93,7 @@ func main() {
 		gitSkipMessage = fs.String("git-ci-skip-message", "", "additional text for commit messages, useful for skipping builds in CI. Use this to supply specific text, or set --git-ci-skip")
 
 		gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period at which to poll git repo for new commits")
+		gitTimeOut      = fs.Duration("git-time-out", 20*time.Second, "duration after which git operations time out")
 		// syncing
 		syncInterval = fs.Duration("sync-interval", 5*time.Minute, "apply config in git to cluster at least this often, even if there are no new commits")
 		// registry
@@ -369,7 +370,7 @@ func main() {
 		SkipMessage: *gitSkipMessage,
 	}
 
-	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval))
+	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.TimeOut(*gitTimeOut))
 	{
 		shutdownWg.Add(1)
 		go func() {

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -56,6 +56,7 @@ var (
 	gitBranch       *string
 	gitChartsPath   *string
 	gitPollInterval *time.Duration
+	gitTimeOut      *time.Duration
 
 	queueWorkerCount *int
 
@@ -107,6 +108,7 @@ func init() {
 	gitBranch = fs.String("git-branch", "master", "branch of git repo")
 	gitChartsPath = fs.String("git-charts-path", defaultGitChartsPath, "path within git repo to locate Helm Charts (relative path)")
 	gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period on which to poll for changes to the git repo")
+	gitTimeOut = fs.Duration("git-time-out", 20*time.Second, "duration after which git operations time out")
 
 	queueWorkerCount = fs.Int("queue-worker-count", 2, "Number of workers to process queue with Chart release jobs. Two by default")
 }
@@ -189,12 +191,12 @@ func main() {
 	go statusUpdater.Loop(shutdown, log.With(logger, "component", "annotator"))
 
 	gitRemote := git.Remote{URL: *gitURL}
-	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.ReadOnly)
+	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.TimeOut(*gitTimeOut), git.ReadOnly)
 
 	// 		Chart releases sync due to Custom Resources changes -------------------------------
 	{
 		mainLogger.Log("info", "Attempting to clone repo ...", "url", gitRemote.URL)
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+		ctx, cancel := context.WithCancel(context.Background())
 		err := repo.Ready(ctx)
 		cancel()
 		if err != nil {

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -56,7 +56,7 @@ var (
 	gitBranch       *string
 	gitChartsPath   *string
 	gitPollInterval *time.Duration
-	gitTimeOut      *time.Duration
+	gitTimeout      *time.Duration
 
 	queueWorkerCount *int
 
@@ -108,7 +108,7 @@ func init() {
 	gitBranch = fs.String("git-branch", "master", "branch of git repo")
 	gitChartsPath = fs.String("git-charts-path", defaultGitChartsPath, "path within git repo to locate Helm Charts (relative path)")
 	gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period on which to poll for changes to the git repo")
-	gitTimeOut = fs.Duration("git-time-out", 20*time.Second, "duration after which git operations time out")
+	gitTimeout = fs.Duration("git-timeout", 20*time.Second, "duration after which git operations time out")
 
 	queueWorkerCount = fs.Int("queue-worker-count", 2, "Number of workers to process queue with Chart release jobs. Two by default")
 }
@@ -191,7 +191,7 @@ func main() {
 	go statusUpdater.Loop(shutdown, log.With(logger, "component", "annotator"))
 
 	gitRemote := git.Remote{URL: *gitURL}
-	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.TimeOut(*gitTimeOut), git.ReadOnly)
+	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.Timeout(*gitTimeout), git.ReadOnly)
 
 	// 		Chart releases sync due to Custom Resources changes -------------------------------
 	{

--- a/git/repo.go
+++ b/git/repo.go
@@ -14,7 +14,7 @@ const (
 	defaultInterval = 5 * time.Minute
 	defaultTimeout  = 20 * time.Second
 
-	CheckPushTag 	= "flux-write-check"
+	CheckPushTag = "flux-write-check"
 )
 
 var (
@@ -82,9 +82,9 @@ func (p PollInterval) apply(r *Repo) {
 	r.interval = time.Duration(p)
 }
 
-type TimeOut time.Duration
+type Timeout time.Duration
 
-func (t TimeOut) apply(r *Repo) {
+func (t Timeout) apply(r *Repo) {
 	r.timeout = time.Duration(t)
 }
 

--- a/git/repo.go
+++ b/git/repo.go
@@ -12,10 +12,9 @@ import (
 
 const (
 	defaultInterval = 5 * time.Minute
-	opTimeout       = 20 * time.Second
+	defaultTimeout  = 20 * time.Second
 
-	DefaultCloneTimeout = 2 * time.Minute
-	CheckPushTag        = "flux-write-check"
+	CheckPushTag 	= "flux-write-check"
 )
 
 var (
@@ -54,6 +53,7 @@ type Repo struct {
 	// As supplied to constructor
 	origin   Remote
 	interval time.Duration
+	timeout  time.Duration
 	readonly bool
 
 	// State
@@ -82,6 +82,12 @@ func (p PollInterval) apply(r *Repo) {
 	r.interval = time.Duration(p)
 }
 
+type TimeOut time.Duration
+
+func (t TimeOut) apply(r *Repo) {
+	r.timeout = time.Duration(t)
+}
+
 var ReadOnly optionFunc = func(r *Repo) {
 	r.readonly = true
 }
@@ -96,6 +102,7 @@ func NewRepo(origin Remote, opts ...Option) *Repo {
 		origin:   origin,
 		status:   status,
 		interval: defaultInterval,
+		timeout:  defaultTimeout,
 		err:      ErrNotCloned,
 		notify:   make(chan struct{}, 1), // `1` so that Notify doesn't block
 		C:        make(chan struct{}, 1), // `1` so we don't block on completing a refresh
@@ -238,13 +245,13 @@ func (r *Repo) step(bg context.Context) bool {
 			panic(err)
 		}
 
-		ctx, cancel := context.WithTimeout(bg, opTimeout)
+		ctx, cancel := context.WithTimeout(bg, r.timeout)
 		dir, err = mirror(ctx, rootdir, url)
 		cancel()
 		if err == nil {
 			r.mu.Lock()
 			r.dir = dir
-			ctx, cancel := context.WithTimeout(bg, opTimeout)
+			ctx, cancel := context.WithTimeout(bg, r.timeout)
 			err = r.fetch(ctx)
 			cancel()
 			r.mu.Unlock()
@@ -260,7 +267,7 @@ func (r *Repo) step(bg context.Context) bool {
 
 	case RepoCloned:
 		if !r.readonly {
-			ctx, cancel := context.WithTimeout(bg, opTimeout)
+			ctx, cancel := context.WithTimeout(bg, r.timeout)
 			err := checkPush(ctx, dir, url)
 			cancel()
 			if err != nil {
@@ -299,7 +306,7 @@ func (r *Repo) Start(shutdown <-chan struct{}, done *sync.WaitGroup) error {
 	defer done.Done()
 
 	for {
-		ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
 		advanced := r.step(ctx)
 		cancel()
 
@@ -364,7 +371,7 @@ func (r *Repo) refreshLoop(shutdown <-chan struct{}) error {
 				default:
 				}
 			}
-			ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+			ctx, cancel := context.WithTimeout(context.Background(), r.timeout)
 			err := r.Refresh(ctx)
 			cancel()
 			if err != nil {

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -56,7 +56,7 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--git-sync-tag          | `flux-sync`             | tag to use to mark sync progress for this cluster (old config, still used if --git-label is not supplied)|
 |--git-notes-ref         | `flux`            | ref to use for keeping commit annotations in git notes|
 |--git-poll-interval     | `5 minutes`                 | period at which to fetch any new commits from the git repo |
-|--git-time-out          | `20 seconds`                | duration after which git operations time out |
+|--git-timeout           | `20 seconds`                | duration after which git operations time out |
 |**syncing**             |                             | control over how config is applied to the cluster |
 |--sync-interval         | `5 minutes`                 | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs |
 |**registry cache**      |                               | (none of these need overriding, usually) |

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -56,6 +56,7 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--git-sync-tag          | `flux-sync`             | tag to use to mark sync progress for this cluster (old config, still used if --git-label is not supplied)|
 |--git-notes-ref         | `flux`            | ref to use for keeping commit annotations in git notes|
 |--git-poll-interval     | `5 minutes`                 | period at which to fetch any new commits from the git repo |
+|--git-time-out          | `20 seconds`                | duration after which git operations time out |
 |**syncing**             |                             | control over how config is applied to the cluster |
 |--sync-interval         | `5 minutes`                 | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs |
 |**registry cache**      |                               | (none of these need overriding, usually) |

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -28,6 +28,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--git-branch                  | `master`                      | Branch of git repo to use for Kubernetes manifests|
 |--git-charts-path             | `charts`                      | Path within git repo to locate Kubernetes Charts (relative path)|
 |                              |                               | **repo chart changes** (none of these need overriding, usually) |
+|--git-time-out                | `20 seconds`                  | duration after which git operations time out |
 |--git-poll-interval           | `5 minutes`                   | period at which to poll git repo for new commits|
 |--chartsSyncInterval          | 3*time.Minute                 | Interval at which to check for changed charts.|
 |--chartsSyncTimeout           | 1*time.Minute                 | Timeout when checking for changed charts.|

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -28,7 +28,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--git-branch                  | `master`                      | Branch of git repo to use for Kubernetes manifests|
 |--git-charts-path             | `charts`                      | Path within git repo to locate Kubernetes Charts (relative path)|
 |                              |                               | **repo chart changes** (none of these need overriding, usually) |
-|--git-time-out                | `20 seconds`                  | duration after which git operations time out |
+|--git-timeout                 | `20 seconds`                  | duration after which git operations time out |
 |--git-poll-interval           | `5 minutes`                   | period at which to poll git repo for new commits|
 |--chartsSyncInterval          | 3*time.Minute                 | Interval at which to check for changed charts.|
 |--chartsSyncTimeout           | 1*time.Minute                 | Timeout when checking for changed charts.|


### PR DESCRIPTION
Closes #1414 

This PR adds a ~`--git-time-out`~ `--git-timeout` flag to both fluxd and the helm operator.

I was unsure what to do with the `gitOpTimeout` constant in [`daemon/loop.go:25`](https://github.com/weaveworks/flux/blob/8f09ae615bc9e12e34567d5bd6e1505998c1f608/daemon/loop.go#L25). If someone could give me guidance in this I am more than happy to make additional changes.

**Resulting builds from changes in this PR can be pulled and tested from:**
[hiddeco/flux:1414-git-timeout-9dc6b2181744](https://hub.docker.com/r/hiddeco/flux/tags/)
[hiddeco/helm-operator:1414-git-timeout-9dc6b2181744](https://hub.docker.com/r/hiddeco/helm-operator/tags/)
