### PR TITLE
Fix indentation of additionalArgs in helm chart

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
           - --token={{ .Values.token }}
           {{- end }}
           {{- if .Values.additionalArgs }}
-          {{ toYaml .Values.additionalArgs }}
+{{ toYaml .Values.additionalArgs | indent 10 }}
           {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}


### PR DESCRIPTION
- This indents the `additionalArgs` block from `chart/flux/templates/deployment.yaml` properly
- Fixes #1347 
- Tested with `helm install --dry-run --debug`

**user-values.yaml**
```yaml
additionalArgs:
- --connect=ws://fluxcloud
- --somenew=args
- --more=args
- --good=args
```
**deployment.yaml**
```yaml
          args:
          - --ssh-keygen-dir=/var/fluxd/keygen
          - --k8s-secret-name=hipster-hare-flux-git-deploy
          - --memcached-hostname=hipster-hare-flux-memcached
          - --git-url=
          - --git-branch=master
          - --git-path=
          - --git-user=Weave Flux
          - --git-email=support@weave.works
          - --git-set-author=false
          - --git-poll-interval=5m
          - --sync-interval=5m
          - --git-ci-skip=false
          - --registry-cache-expiry=1h
          - --registry-poll-interval=5m
          - --registry-rps=200
          - --registry-burst=125
          - --registry-trace=false
          - --connect=ws://fluxcloud
          - --somenew=args
          - --more=args
          - --good=args
```
Should I add entry of this change to [CHANGELOG-helmop.md](https://github.com/weaveworks/flux/blob/master/CHANGELOG-helmop.md ) ?