### PR TITLE
Added workloads alias for controllers

### DIFF
--- a/cmd/fluxctl/list_controllers_cmd.go
+++ b/cmd/fluxctl/list_controllers_cmd.go
@@ -25,6 +25,7 @@ func newControllerList(parent *rootOpts) *controllerListOpts {
 func (opts *controllerListOpts) Command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "list-controllers",
+		Aliases: []string{"list-workloads"},
 		Short:   "List controllers currently running in the cluster.",
 		Example: makeExample("fluxctl list-controllers"),
 		RunE:    opts.RunE,


### PR DESCRIPTION
This fixes #1423 , as controllers is here for historical reasons.
<!--

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the

- DCO
- contribution workflow and
- how to get your fix accepted

are important.

# News

Please consider adding an entry for either the

 - regular changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG.md or
 - helm operator changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG-helmop.md

In your PR, just add a short description of your change with a link to the
relevant discussion. (You can find CHANGELOG.md and CHANGELOG-helmop.md in the
top-level directory.)

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

-->