### PR TITLE
Helm chart: change kubectl config mount path

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
             protocol: TCP
           volumeMounts:
           - name: kubedir
-            mountPath: /root/.kube
+            mountPath: /root/.kubectl
           - name: sshdir
             mountPath: /root/.ssh
             readOnly: true
@@ -60,6 +60,9 @@ spec:
             readOnly: true
           - name: git-keygen
             mountPath: /var/fluxd/keygen
+          env:
+          - name: KUBECONFIG
+            value: /root/.kubectl/config
           args:
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --k8s-secret-name={{ template "flux.fullname" . }}-git-deploy

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -127,7 +127,7 @@ ssh:
   known_hosts: ""
 
 kube:
-  # Override for ./kube/config
+  # Override for kubectl default config
   config: |
     apiVersion: v1
     clusters: []


### PR DESCRIPTION
- mount kubectl config to `/root/.kubectl`
- set config path using `KUBECONFIG` env var
- enable kubectl caching by mounting the config to a different dir than `$HOME/.kube/`

Fix: #1422
