### PR TITLE
Add buffer to channel for Notify

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -332,7 +332,7 @@ func main() {
 	shutdownWg := &sync.WaitGroup{}
 
 	go func() {
-		c := make(chan os.Signal)
+		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 		errc <- fmt.Errorf("%s", <-c)
 	}()

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -139,7 +139,7 @@ func main() {
 	shutdownWg := &sync.WaitGroup{}
 
 	go func() {
-		c := make(chan os.Signal)
+		c := make(chan os.Signal, 1)
 		signal.Notify(c, syscall.SIGINT, syscall.SIGTERM)
 		errc <- fmt.Errorf("%s", <-c)
 	}()


### PR DESCRIPTION
Package signal will not block sending to c: the caller must ensure that c has sufficient buffer space to keep up with the expected signal rate.
See https://golang.org/pkg/os/signal/#Notify

<!--

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the

- DCO
- contribution workflow and
- how to get your fix accepted

are important.

# News

Please consider adding an entry for either the

 - regular changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG.md or
 - helm operator changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG-helmop.md

In your PR, just add a short description of your change with a link to the
relevant discussion. (You can find CHANGELOG.md and CHANGELOG-helmop.md in the
top-level directory.)

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

-->