### PR TITLE
Fix ineffective break statement

### DIFF
--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -96,9 +96,9 @@ func New(logger log.Logger, polling Polling, clients Clients, release *release.R
 	}
 }
 
-//  Run creates a syncing loop monitoring repo chart changes. It is
-//  assumed that the *git.Repo given to the config is ready to use
-//  before this is invoked.
+// Run creates a syncing loop monitoring repo chart changes. It is
+// assumed that the *git.Repo given to the config is ready to use
+// before this is invoked.
 //
 // The behaviour if the git mirror becomes unavailable while it's
 // running is not defined (this could be tightened up).
@@ -174,7 +174,7 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 
 			case <-stopCh:
 				chs.logger.Log("stopping", "true")
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
This break breaks the inner select only, to break for loop we can use return from the function since there is nothing after for loop here.

<!--

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the

- DCO
- contribution workflow and
- how to get your fix accepted

are important.

# News

Please consider adding an entry for either the

 - regular changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG.md or
 - helm operator changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG-helmop.md

In your PR, just add a short description of your change with a link to the
relevant discussion. (You can find CHANGELOG.md and CHANGELOG-helmop.md in the
top-level directory.)

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

-->