### PR TITLE
Document how to get fluxctl through homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Get started by browsing through the documentation below:
   - [Standalone Flux](/site/get-started.md)
   - [Flux using Helm](/site/helm-get-started.md)
 - Operating Flux
-  - [Using Flux](/site/using.md)
+  - [Using fluxctl to control Flux](/site/fluxctl.md)
   - [Helm Operator](/site/helm-operator.md)
   - [Troubleshooting](/site/troubleshooting.md)
   - [Frequently encountered issues](https://github.com/weaveworks/flux/labels/FAQ)

--- a/git/errors.go
+++ b/git/errors.go
@@ -16,7 +16,7 @@ We need to clone a git repo to proceed, and you haven't supplied
 one. Please upload a config file, including a git repository URL, as
 described in
 
-    https://github.com/weaveworks/flux/blob/master/site/using.md
+    https://github.com/weaveworks/flux/blob/master/site/fluxctl.md
 
 `,
 }

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -14,20 +14,31 @@ Download the latest version of the fluxctl client
 
 The `--help` for `fluxctl` is described below.
 
+# Installing fluxctl
+
+If you are using a Mac and use Homebrew, you can simply run:
+
+```sh
+brew install fluxctl
+```
+
+Everybody else can download the `fluxctl` binaries (Mac, Linux, Windows) from
+the [Flux release page](https://github.com/weaveworks/flux/releases).
+
 # Connecting fluxctl to the daemon
 
 By default, fluxctl will attempt to port-forward to your Flux
 instance, assuming it runs in the `"default"` namespace. You can
 specify a different namespace with the `--k8s-fwd-ns` flag:
 
-```
+```sh
 fluxctl --k8s-fwd-ns=weave list-controllers
 ```
 
 The namespace can also be given in the environment variable
 `FLUX_FORWARD_NAMESPACE`:
 
-```
+```sh
 export FLUX_FORWARD_NAMESPACE=weave
 fluxctl list-controllers
 ```
@@ -41,7 +52,7 @@ authentication.**
 Once that is set up, you can specify an API URL with `--url` or the
 environment variable `FLUX_URL`:
 
-```
+```sh
 fluxctl --url http://127.0.0.1:3030/api/flux list-controllers
 ```
 
@@ -58,7 +69,7 @@ fluxctl list-controllers --all-namespaces
 Flux connects to the repository using an SSH key. You have two
 options:
 
-### 1. Allow flux to generate a key for you.
+### 1. Allow flux to generate a key for you
 
 If you don't specify a key to use, Flux will create one for you. Obtain
 the public key through fluxctl:
@@ -165,7 +176,7 @@ Flags:
 Use "fluxctl [command] --help" for more information about a command.
 ```
 
-# What is a Controller?
+# What is a Controller
 
 This term refers to any cluster resource responsible for the creation of
 containers from versioned images - in Kubernetes these are workloads such as
@@ -337,7 +348,8 @@ default:deployment/helloworld  success
 It may be desirable to release an image to a locked controller while
 maintaining the lock afterwards. In order to not having to modify the
 lock policy (which includes author and reason), one may use `--force`:
-```
+
+```sh
 fluxctl release --controller=default:deployment/helloworld --update-all-images --force
 ```
 
@@ -390,30 +402,34 @@ So for example, if you want to only update the "helloworld" image
 to tags that were built against the "prod" branch then you could
 do the following:
 
-```
+```sh
 fluxctl policy --controller=default:deployment/helloworld --tag-all='prod-*'
 ```
 
 If your pod contains multiple containers then you tag each container
 individually:
 
-```
+```sh
 fluxctl policy --controller=default:deployment/helloworld --tag='helloworld=prod-*' --tag='sidecar=prod-*'
 ```
 
 Manual releases without explicit mention of the target image will
 also adhere to tag filters.
 This will only release the newest image matching the tag filter:
-```
+
+```sh
 fluxctl release --controller=default:deployment/helloworld --update-all-images
 ```
 
 To release an image outside of tag filters, either specify the image:
-```
+
+```sh
 fluxctl release --controller=default:deployment/helloworld --update-image=helloworld:dev-abc123
 ```
+
 or use `--force`:
-```
+
+```sh
 fluxctl release --controller=default:deployment/helloworld --update-all-images --force
 ```
 
@@ -427,7 +443,8 @@ Flux currently offers support for `glob`, `semver` and `regexp` based filtering.
 
 The glob (`*`) filter is the simplest filter Flux supports, a filter can contain
 multiple globs:
-```
+
+```sh
 fluxctl policy --controller=default:deployment/helloworld --tag-all='glob:master-v1.*.*'
 ```
 
@@ -435,12 +452,14 @@ fluxctl policy --controller=default:deployment/helloworld --tag-all='glob:master
 
 If your images use [semantic versioning](https://semver.org) you can filter by image tags
 that adhere to certain constraints:
-```
+
+```sh
 fluxctl policy --controller=default:deployment/helloworld --tag-all='semver:~1'
 ```
 
 or only release images that have a stable semantic version tag (X.Y.Z):
-```
+
+```sh
 fluxctl policy --controller=default:deployment/helloworld --tag-all='semver:*'
 ```
 
@@ -450,7 +469,8 @@ that the higher versions will be considered newer.
 ### Regexp
 
 If your images have complex tags you can filter by regular expression:
-```
+
+```sh
 fluxctl policy --controller=default:deployment/helloworld --tag-all='regexp:^([a-zA-Z]+)$'
 ```
 
@@ -511,8 +531,10 @@ Commit customization
 In case of no prior commit by the specified author, an error will be reported
 for b) and c):
 
+```sh
 git commit: fatal: --author 'unknown' is not 'Name <email>' and matches
 no existing author
+```
 
 # Using Annotations
 

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -142,5 +142,5 @@ deployed, give Flux access to it and see modifications land are
 very straight-forward and are a quite natural work-flow.
 
 As a next step, you might want to dive deeper into [how to control
-Flux](./using.md) or check out [more sophisticated
+Flux](./fluxctl.md) or check out [more sophisticated
 setups](./standalone-setup.md).

--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -182,7 +182,7 @@ very straight-forward and are a quite natural work-flow.
 # Next
 
 As a next step, you might want to dive deeper into [how to control
-Flux](using.md).
+Flux](fluxctl.md).
 
 For a more advanced Helm setup, take a look at the [gitops-helm
 repository](https://github.com/stefanprodan/gitops-helm).

--- a/site/installing.md
+++ b/site/installing.md
@@ -20,7 +20,7 @@ this](./helm-get-started.md).
 
 # Next
 
-[Setup fluxctl and run the daemon](./using.md)
+[Setup fluxctl and run the daemon](./fluxctl.md)
 
 ----
 [k8s-manifests]: https://kubernetes.io/docs/concepts/configuration/overview/


### PR DESCRIPTION
- Document how to get fluxctl through homebrew.
- Rename `using.md` to `fluxctl.md`.
- Make markdownlint happier.