### PR TITLE
Docs: added note about ignore annotation to fluxctl docs

### DIFF
--- a/site/using.md
+++ b/site/using.md
@@ -525,3 +525,6 @@ filtering annotations take the form
 `filter-type` can be [`glob`](#glob), [`semver`](#semver), and
 [`regexp`](#regexp). Filter values use the same syntax as when the filter is
 configured using fluxctl.
+
+Annotations can also be used to tell Flux to temporary ignore certain manifests
+using `flux.weave.works/ignore: "true"`. Read more about this in the [FAQ](faq.md#can-i-temporarily-make-flux-ignore-a-deployment).

--- a/site/using.md
+++ b/site/using.md
@@ -526,5 +526,5 @@ filtering annotations take the form
 [`regexp`](#regexp). Filter values use the same syntax as when the filter is
 configured using fluxctl.
 
-Annotations can also be used to tell Flux to temporary ignore certain manifests
+Annotations can also be used to tell Flux to temporarily ignore certain manifests
 using `flux.weave.works/ignore: "true"`. Read more about this in the [FAQ](faq.md#can-i-temporarily-make-flux-ignore-a-deployment).


### PR DESCRIPTION
User on Slack:

> jonaz [3:33 PM]
Just to confirm, the only way for the Flux Helm Operator to avoid setting up a `FluxHelmRelease` is to use the following annotation
```flux.weave.works/ignore: "true"``` 
It is not enough to avoid adding any annotation?
Never mind, I found https://github.com/weaveworks/flux/blob/master/site/faq.md#can-i-temporarily-make-flux-ignore-a-deployment (edited)
I was looking in https://github.com/weaveworks/flux/blob/master/site/using.md#using-annotations

This adds a note to the annotations section to guide future readers.