### PR TITLE
Deal with case of no service request arguments

### DIFF
--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -144,13 +144,15 @@ func (s HTTPServer) ListServicesWithOptions(w http.ResponseWriter, r *http.Reque
 	var opts v11.ListServicesOptions
 	opts.Namespace = r.URL.Query().Get("namespace")
 	services := r.URL.Query().Get("services")
-	for _, svc := range strings.Split(services, ",") {
-		id, err := flux.ParseResourceID(svc)
-		if err != nil {
-			transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", svc))
-			return
+	if services != "" {
+		for _, svc := range strings.Split(services, ",") {
+			id, err := flux.ParseResourceID(svc)
+			if err != nil {
+				transport.WriteError(w, r, http.StatusBadRequest, errors.Wrapf(err, "parsing service spec %q", svc))
+				return
+			}
+			opts.Services = append(opts.Services, id)
 		}
-		opts.Services = append(opts.Services, id)
 	}
 
 	res, err := s.server.ListServicesWithOptions(r.Context(), opts)


### PR DESCRIPTION
It's possible to send a request to ListServicesWithOptions that doesn't specify the services of interest.

    fluxctl list-controllers

will do exactly that -- and currently, it gets a 400 Bad Request.