### PR TITLE
Add 'extraEnvs' values to Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -205,6 +205,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.pullPolicy` | Helm operator image pull policy | `IfNotPresent`
 | `helmOperator.chartsSyncInterval` | Interval at which to check for changed charts | `3m`
 | `helmOperator.chartsSyncTimeout` | Timeout when checking for changed charts | `1m`
+| `helmOperator.extraEnvs` | Extra environment variables for the Helm operator pod | `[]`
 | `helmOperator.git.url` | URL of git repo with Helm charts | `git.url`
 | `helmOperator.git.branch` | Branch of git repo to use for Helm charts | `master`
 | `helmOperator.git.chartsPath` | Path within git repo to locate Helm charts (relative path) | `charts`
@@ -220,6 +221,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.tls.certFile` | Name of the certificate file within the k8s secret | `tls.crt`
 | `helmOperator.tls.caContent` | Certificate Authority content used to validate the Tiller server certificate | None
 | `token` | Weave Cloud service token | None
+| `extraEnvs` | Extra environment variables for the Flux pod | `[]`
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -63,6 +63,9 @@ spec:
           env:
           - name: KUBECONFIG
             value: /root/.kubectl/config
+          {{- if .Values.extraEnvs }}
+{{ toYaml .Values.extraEnvs | indent 10 }}
+          {{- end }}
           args:
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --k8s-secret-name={{ template "flux.fullname" . }}-git-deploy

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -95,4 +95,8 @@ spec:
         - --tiller-tls-ca-cert-path=/etc/fluxd/helm-ca/ca.crt
         {{- end }}
         {{- end }}
+      {{- if .Values.helmOperator.extraEnvs }}
+        env:
+{{ toYaml .Values.helmOperator.extraEnvs | indent 8 }}
+      {{- end }}
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -48,6 +48,11 @@ helmOperator:
     # add ./identity.pub as a read-only deployment key in your GitHub repo where the charts are
     # set the secret name (helm-ssh) below
     secretName: ""
+  # Additional environment variables to set
+  extraEnvs: []
+  # extraEnvs:
+  #   - name: FOO
+  #     value: bar
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -144,3 +149,9 @@ kube:
 #for https://github.com/justinbarrick/fluxcloud/
 #additionalArgs:
 # - --connect=ws://fluxcloud
+
+# Additional environment variables to set
+extraEnvs: []
+# extraEnvs:
+#   - name: FOO
+#     value: bar


### PR DESCRIPTION
If users of the Helm chart need to provide additional environment variables to the pod, they can be added to the 'extraEnvs' or 'helmOperator.extraEnvs' arrays in values.yaml, respectively.

[Relevant discussion in Slack](https://weave-community.slack.com/archives/C4U5ATZ9S/p1539609056000100).
