### PR TITLE
Rename standalone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Get started by browsing through the documentation below:
   - [Considerations regarding installing Flux](/site/installing.md)
   - [Flux <-> Helm integration](/site/helm-integration.md)
 - Get Started with Flux
-  - [Standalone Flux](/site/standalone/installing.md)
+  - [Standalone Flux](/site/get-started.md)
   - [Flux using Helm](/site/helm-get-started.md)
 - Operating Flux
   - [Using Flux](/site/using.md)

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -35,7 +35,7 @@ spec:
       # file, which you will need to do if you host your own git
       # repo rather than using github or the like. You'll also need to
       # mount it into the container, below. See
-      # https://github.com/weaveworks/flux/blob/master/site/standalone/setup.md#using-a-private-git-host
+      # https://github.com/weaveworks/flux/blob/master/site/standalone-setup.md#using-a-private-git-host
       # - name: ssh-config
       #   configMap:
       #     name: flux-ssh-config

--- a/site/faq.md
+++ b/site/faq.md
@@ -270,7 +270,7 @@ service, or running your own git host, you need to supply your own
 host key(s).
 
 How to do this is documented in
-[setup.md](/site/standalone/setup.md#using-a-private-git-host).
+[standalone-setup.md](/site/standalone-setup.md#using-a-private-git-host).
 
 ### Will Flux delete resources that are no longer in the git repository?
 

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -11,7 +11,7 @@ have Flux running in your cluster and it will be deploying any
 code changes for you.
 
 _Note:_ If you would like to install Flux using Helm, refer to the
-[Helm section](../helm-get-started.md).
+[Helm section](./helm-get-started.md).
 
 ## Prerequisites
 
@@ -89,7 +89,7 @@ the SSH public key with:
 kubectl logs deployment/flux | grep identity.pub | cut -d '"' -f2
 ```
 
-*Note:* If you have downloaded [fluxctl](../using.md) already, you can use
+*Note:* If you have downloaded [fluxctl](./using.md) already, you can use
 `fluxctl identity` as well.
 
 In order to sync your cluster state with git you need to copy the
@@ -142,5 +142,5 @@ deployed, give Flux access to it and see modifications land are
 very straight-forward and are a quite natural work-flow.
 
 As a next step, you might want to dive deeper into [how to control
-Flux](../using.md) or check out [more sophisticated
-setups](./setup.md).
+Flux](./using.md) or check out [more sophisticated
+setups](./standalone-setup.md).

--- a/site/installing.md
+++ b/site/installing.md
@@ -13,7 +13,7 @@ should run in the cluster. Flux imposes
 # Installing Weave Flux
 
 Here are the instructions to [install Flux on your own
-cluster](./standalone/installing.md).
+cluster](./get-started.md).
 
 If you are using Helm, we have a [separate section about
 this](./helm-get-started.md).

--- a/site/standalone-setup.md
+++ b/site/standalone-setup.md
@@ -15,7 +15,7 @@ the directory with the examples configuration.
 First, you need to connect Flux to the repository with Kubernetes
 manifests. This is achieved by setting the `--git-url` and
 `--git-branch` arguments in the
-[`flux-deployment.yaml`](../../deploy/flux-deployment.yaml) manifest.
+[`flux-deployment.yaml`](../deploy/flux-deployment.yaml) manifest.
 
 ## Memcache
 
@@ -62,7 +62,7 @@ kubectl create secret generic flux-git-deploy --from-file=identity=/path/to/priv
 ```
 
 The Kubernetes deployment configuration file
-[flux-deployment.yaml](../../deploy/flux-deployment.yaml) runs the
+[flux-deployment.yaml](../deploy/flux-deployment.yaml) runs the
 Flux daemon, but you'll need to edit it first, at least to supply your
 own configuration repo (the `--git-repo` argument).
 
@@ -76,7 +76,7 @@ kubectl create -f flux-deployment.yaml
 You will need to provide fluxd with a service account which can access
 the namespaces you want to use Flux with. To do this, consult the
 example service account given in
-[flux-account.yaml](../../deploy/flux-account.yaml) (which
+[flux-account.yaml](../deploy/flux-account.yaml) (which
 puts essentially no constraints on the account) and the
 [RBAC documentation](https://kubernetes.io/docs/admin/authorization/rbac/),
 and create a service account in whichever namespace you put fluxd

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -51,7 +51,7 @@ This means Flux can't read from and write to the git repo. Check that
    _image_ with host keys for `github.com`, `gitlab.com` and
    `bitbucket.org`, but if you're using your own git server, you'll
    need to add its host key. See
-   [./standalone/setup.md](./standalone/setup.md#using-a-private-git-host).
+   [./standalone-setup.md](./standalone-setup.md#using-a-private-git-host).
 
 ### "The request failed authentication"
 
@@ -61,10 +61,10 @@ from the settings in Weave Cloud; set the environment variable
 `FLUX_TOKEN` to the token.
 
 If you have set Flux up standalone (as in the instructions in
-[./standalone/installing.md](./standalone/installing.md)), this
+[./get-started.md](./get-started.md)), this
 probably means Flux is defaulting to using Weave Cloud because you've
 not set the environment variable `FLUX_URL` to point at the
-daemon. See [./standalone/setup.md](./standalone/setup.md).
+daemon. See [./standalone-setup.md](./standalone-setup.md).
 
 ### I'm using GCR/GKE and I keep seeing "Quota exceeded" in logs
 


### PR DESCRIPTION
As one of the remaining items on #1178, rename the standalone docs, and have a flat hierarchy of docs.
