### PR TITLE
Configurable maximum item size for memcache

### DIFF
--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -26,8 +26,9 @@ spec:
         image: memcached:1.4.25
         imagePullPolicy: IfNotPresent
         args:
-        - -m 64    # Maximum memory to use, in megabytes. 64MB is default.
+        - -m {{ .Values.memcached.max_memory }}    # Maximum memory to use, in megabytes. 64MB is default.
         - -p 11211    # Default port, but being explicit is nice.
+        - -I {{ .Values.memcached.max_item_size }} #  Maximum size for one item
         {{- if .Values.memcached.verbose }}
         - -vv    # This gets us to the level of request logs.
         {{- end }}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -26,9 +26,9 @@ spec:
         image: memcached:1.4.25
         imagePullPolicy: IfNotPresent
         args:
-        - -m {{ .Values.memcached.max_memory }}    # Maximum memory to use, in megabytes. 64MB is default.
+        - -m {{ .Values.memcached.maxMemory }}    # Maximum memory to use, in megabytes. 64MB is default.
         - -p 11211    # Default port, but being explicit is nice.
-        - -I {{ .Values.memcached.max_item_size }} #  Maximum size for one item
+        - -I {{ .Values.memcached.maxItemSize }} #  Maximum size for one item
         {{- if .Values.memcached.verbose }}
         - -vv    # This gets us to the level of request logs.
         {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -125,6 +125,8 @@ registry:
  
 memcached:
   verbose: false
+  max_item_size: 1m
+  max_memory: 64
 
 ssh:
   # Overrides for git over SSH. If you use your own git server, you

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -125,8 +125,8 @@ registry:
  
 memcached:
   verbose: false
-  max_item_size: 1m
-  max_memory: 64
+  maxItemSize: 1m
+  maxMemory: 64
 
 ssh:
   # Overrides for git over SSH. If you use your own git server, you


### PR DESCRIPTION
Setting `max_item_size` to `5m` fixes `SERVER_ERROR object too large for cache`  errors on large deployments
