### PR TITLE
[WIP] Add the ability to support authentication to AWS ECR 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,47 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:eedc89853af7761550e4dbe0627858d8e3c5daf9e702a755cd8edc264fc3b1cf"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ecr",
+    "service/ecr/ecriface",
+    "service/sts",
+  ]
+  pruneopts = ""
+  revision = "c0037b52736b07cea4e0cb6521f7995adef833bc"
+  version = "v1.15.59"
+
+[[projects]]
   branch = "master"
   digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
@@ -353,6 +394,13 @@
   pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  digest = "1:6f49eae0c1e5dab1dafafee34b207aeb7a42303105960944828c2079b92fc88e"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = ""
+  revision = "0b12d6b5"
 
 [[projects]]
   digest = "1:31c6f3c4f1e15fcc24fcfc9f5f24603ff3963c56d6fa162116493b4025fb6acc"
@@ -996,6 +1044,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/semver",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/ecr",
+    "github.com/aws/aws-sdk-go/service/ecr/ecriface",
     "github.com/bradfitz/gomemcache/memcache",
     "github.com/docker/distribution",
     "github.com/docker/distribution/manifest/manifestlist",

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.7.1"
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control
 name: flux
-version: 0.3.4
+version: 0.3.5
 home: https://weave.works
 sources:
 - https://github.com/weaveworks/flux

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -222,6 +222,15 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.tls.caContent` | Certificate Authority content used to validate the Tiller server certificate | None
 | `token` | Weave Cloud service token | None
 | `extraEnvs` | Extra environment variables for the Flux pod | `[]`
+| `podAnnotations` | Extra pod annotations for the Flux pod | `[]`
+| `sidecar.aws.enabled` | Deploy AWS ECR repository authenticator as a sidecar to flux |`false`
+| `sidecar.aws.registryIds` | The AWS Account IDs of ECR repositories that needs authentication. This is a comma separated value. E.g `1234567890,0987654321` | None
+| `sidecar.aws.region` | The AWS Region of the ECR repositories that needs authentication   | `us-east-1`
+| `sidecar.aws.fetchInterval` | The period at which to fetch for a new token from the AWS Account IDs | `1h`
+| `sidecar.aws.image.repository` | ECR sidecar image repository | `quay.io/weaveworks/ecr-sidecar`
+| `sidecar.aws.image.tag` | ECR sidecar image tag | `latest`
+| `sidecar.aws.image.pullPolicy` | ECR sidecar image pull policy | `IfNotPresent`
+
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
       labels:
         app: {{ template "flux.name" . }}
         release: {{ .Release.Name }}
+    {{- if .Values.podAnnotations }}
+      annotations:
+    {{ toYaml .Values.podAnnotations | indent 8 }}
+    {{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
@@ -42,6 +46,19 @@ spec:
         emptyDir:
           medium: Memory
       containers:
+        {{- if .Values.sidecar.aws.enabled }}
+        - name: aws
+          image: "{{ .Values.sidecar.aws.image.repository }}:{{ .Values.sidecar.aws.image.tag }}"
+          imagePullPolicy: {{ .Values.sidecar.aws.image.pullPolicy }}
+          args:
+          - --registry-ids={{ .Values.sidecar.aws.registryIds }}
+          - --region={{ .Values.sidecar.aws.region }}
+          - --fetch-interval={{ .Values.sidecar.aws.fetchInterval }}
+          ports:
+          - name: http
+            containerPort: 3031
+            protocol: TCP
+        {{- end }}
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -5,6 +5,8 @@ token: ""
 
 replicaCount: 1
 
+podAnnotations: {}
+
 image:
   repository: quay.io/weaveworks/flux
   tag: 1.7.1
@@ -80,6 +82,17 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+sidecar:
+  aws:
+    enabled: false
+    image:
+      repository: quay.io/weaveworks/ecr-sidecar
+      tag: latest
+      pullPolicy: IfNotPresent
+    registryIds: ""
+    region: us-east-1
+    fetchInterval: 1h
 
 git:
   # URL of git repo with Kubernetes manifests; e.g. git.url=ssh://git@github.com/weaveworks/flux-example

--- a/docker/Dockerfile.ecr-sidecar
+++ b/docker/Dockerfile.ecr-sidecar
@@ -1,0 +1,16 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache ca-certificates tini
+
+COPY ./ecr-sidecar /usr/local/bin
+
+ENTRYPOINT [ "/sbin/tini", "--", "ecr-sidecar" ]
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+# These will change for every build
+LABEL org.opencontainers.image.revision="$VCS_REF" \
+      org.opencontainers.image.created="$BUILD_DATE" \
+      org.label-schema.vcs-ref="$VCS_REF" \
+      org.label-schema.build-date="$BUILD_DATE"

--- a/registry/aws.go
+++ b/registry/aws.go
@@ -1,0 +1,46 @@
+package registry
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/weaveworks/flux/sidecar/aws/ecr"
+)
+
+// GetECRRegistryCredential is used by the Flux daemon to communicate to the AWS sidecar url
+// to GET the appropriate ECR repository's docker username and password. If the input
+// host was not found from the sidecar's JSON response, an empty credential will be returned.
+func GetECRRegistryCredential(host, sidecarURL string) (credential, error) {
+	res, err := http.Get(sidecarURL)
+	if err != nil {
+		return credential{}, nil
+	}
+	defer res.Body.Close()
+	cred := &ecr.DockerCredential{}
+	if err := json.NewDecoder(res.Body).Decode(&cred); err != nil {
+		return credential{}, nil
+	}
+	for auth, entry := range cred.Auths {
+		hostRegistryID := strings.Split(host, ".")[0]
+		authHost := strings.TrimPrefix(auth, "https://")
+		authRegistryID := strings.Split(authHost, ".")[0]
+		if hostRegistryID == authRegistryID {
+			decodedAuth, err := base64.StdEncoding.DecodeString(entry.Auth)
+			if err != nil {
+				return credential{}, err
+			}
+			authParts := strings.SplitN(string(decodedAuth), ":", 2)
+			return credential{
+				registry:   host,
+				provenance: ecr.SidecarAWSURL,
+				username:   authParts[0],
+				password:   strings.TrimSpace(authParts[1]),
+			}, nil
+		}
+	}
+	return credential{},
+		fmt.Errorf("%s: unable to find auth for host %s", ecr.SidecarAWSURL, host)
+}

--- a/registry/aws_test.go
+++ b/registry/aws_test.go
@@ -1,0 +1,71 @@
+package registry
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const (
+	credentialJSONResponse = `{
+"auths": {
+	"https://12345.dkr.ecr-use-east-1.amazonaws.com": {
+		"auth": "QVdTOmVjcnBhc3N3b3JkCg=="
+	},
+	"https://602401143452.dkr.ecr.us-east-1.amazonaws.com": {
+		"auth": "QVdTOnh4eHh4Cg=="
+	}
+}}`
+	awsUser                    = "AWS"
+	credentialHost1            = "12345.dkr.ecr-use-east-1.amazonaws.com"
+	credentialDecodedPassword1 = "ecrpassword"
+	credentialHost2            = "602401143452.dkr.ecr.us-east-1.amazonaws.com"
+	credentialDecodedPassword2 = "xxxxx"
+)
+
+func TestGetECRRegistryCredential(t *testing.T) {
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(credentialJSONResponse))
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(handler))
+	defer ts.Close()
+
+	tt := []struct {
+		pass             bool
+		expectedUser     string
+		expectedPassword string
+		registryHost     string
+	}{
+		{true, awsUser, credentialDecodedPassword1, credentialHost1},
+		{true, awsUser, credentialDecodedPassword2, credentialHost2},
+		{false, awsUser, "qweqwewq", "unknownprofile.dkr.ecr.us-east-1.amazonaws.com"},
+	}
+
+	for _, tc := range tt {
+		if tc.pass {
+			t.Run("known registry host must pass", func(t *testing.T) {
+				creds, err := GetECRRegistryCredential(tc.registryHost, ts.URL)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if creds.username != tc.expectedUser {
+					t.Fatalf("incorrect decoded username: got %s, want %s!", creds.username, tc.expectedUser)
+				}
+				if creds.password != tc.expectedPassword {
+					t.Fatalf("incorrect decoded password. got %s, want %s!", creds.password, tc.expectedPassword)
+				}
+				fmt.Println("--- INFO: got ", creds)
+			})
+		} else {
+			t.Run("unknown registry host must fail", func(t *testing.T) {
+				_, err := GetECRRegistryCredential(tc.registryHost, ts.URL)
+				if err == nil {
+					t.Fatalf("expected to fail test when fetching a non existent host %s but it went ok!", tc.registryHost)
+				}
+			})
+		}
+	}
+}

--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -118,7 +118,7 @@ func (f *RemoteClientFactory) Succeed(repo image.CanonicalName) {
 // store adapts a set of pre-selected creds to be an
 // auth.CredentialsStore
 type store struct {
-	auth creds
+	auth credential
 }
 
 func (s *store) Basic(url *url.URL) (string, string) {

--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -98,6 +98,8 @@ func ParseCredentials(from string, b []byte) (Credentials, error) {
 	return Credentials{m: m}, nil
 }
 
+// ImageCredsWithDefaults designates the appropriate credential to use for a repository
+// using a docker configuration file supplied by the caller.
 func ImageCredsWithDefaults(lookup func() ImageCreds, configPath string) (func() ImageCreds, error) {
 	// pre-flight check
 	bs, err := ioutil.ReadFile(configPath)

--- a/registry/gcp.go
+++ b/registry/gcp.go
@@ -16,10 +16,10 @@ type gceToken struct {
 	TokenType   string `json:"token_type"`
 }
 
-func GetGCPOauthToken(host string) (creds, error) {
+func GetGCPOauthToken(host string) (credential, error) {
 	request, err := http.NewRequest("GET", gcpDefaultTokenURL, nil)
 	if err != nil {
-		return creds{}, err
+		return credential{}, err
 	}
 
 	request.Header.Add("Metadata-Flavor", "Google")
@@ -27,24 +27,24 @@ func GetGCPOauthToken(host string) (creds, error) {
 	client := &http.Client{}
 	response, err := client.Do(request)
 	if err != nil {
-		return creds{}, err
+		return credential{}, err
 	}
 
 	if response.StatusCode != http.StatusOK {
-		return creds{}, fmt.Errorf("unexpected status from metadata service: %s", response.Status)
+		return credential{}, fmt.Errorf("unexpected status from metadata service: %s", response.Status)
 	}
 
 	var token gceToken
 	decoder := json.NewDecoder(response.Body)
 	if err := decoder.Decode(&token); err != nil {
-		return creds{}, err
+		return credential{}, err
 	}
 
 	if err := response.Body.Close(); err != nil {
-		return creds{}, err
+		return credential{}, err
 	}
 
-	return creds{
+	return credential{
 		registry:   host,
 		provenance: "",
 		username:   "oauth2accesstoken",

--- a/sidecar/aws/cmd/main.go
+++ b/sidecar/aws/cmd/main.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/go-kit/kit/log"
+	"github.com/spf13/pflag"
+	fluxecr "github.com/weaveworks/flux/sidecar/aws/ecr"
+)
+
+func main() {
+	// Flag domain.
+	fs := pflag.NewFlagSet("default", pflag.ContinueOnError)
+	var (
+		awsRegistryIDs = fs.StringSlice("registry-ids", []string{}, "list of AWS ECR account IDs to authenticate")
+		awsRegion      = fs.String("region", "us-east-1", "AWS Region to authenticate to")
+		fetchInterval  = fs.Duration("fetch-interval", 1*time.Hour, "period at which to fetch for a new authentication token. Authorization tokens are valid for 12 hours")
+	)
+	fs.Parse(os.Args[1:])
+
+	var logger log.Logger
+	{
+		logger = log.NewLogfmtLogger(os.Stderr)
+		logger = log.With(logger, "ts", log.DefaultTimestampUTC)
+		logger = log.With(logger, "caller", log.DefaultCaller)
+	}
+	logger.Log("sidecar_type", "aws")
+	logger.Log("registry_ids", fmt.Sprintf("%s", *awsRegistryIDs), "region", *awsRegion, "fetch_interval", fmt.Sprintf("%dm", *fetchInterval/time.Minute))
+	logger.Log("sidecar_uri", "http://localhost:"+fluxecr.SidecarAWSPort+fluxecr.SidecarAWSPath)
+
+	var ecrCredentials []byte
+	go func() {
+		for {
+			sess := session.Must(session.NewSession(&aws.Config{Region: awsRegion}))
+			ecrSvc := ecr.New(sess)
+			cred, err := fluxecr.GetAmazonECRToken(ecrSvc, *awsRegistryIDs)
+			if err != nil {
+				logger.Log("error", err)
+				os.Exit(1)
+			}
+			logger.Log("info", "successfully fetched ECR credentials")
+			ecrCredentials = []byte(cred.String())
+			logger.Log("info", "ECR credentials are updated in memory")
+			time.Sleep(*fetchInterval)
+		}
+	}()
+
+	mux := http.NewServeMux()
+	mux.HandleFunc(fluxecr.SidecarAWSPath, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write(ecrCredentials); err != nil {
+			logger.Log("err", err)
+		}
+	})
+	if err := http.ListenAndServe(":"+fluxecr.SidecarAWSPort, mux); err != nil {
+		logger.Log("err", err)
+		os.Exit(1)
+	}
+}

--- a/sidecar/aws/ecr/ecr.go
+++ b/sidecar/aws/ecr/ecr.go
@@ -1,0 +1,52 @@
+package ecr
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
+)
+
+// DockerCredential is used to decode the output of ecr.GetAuthorizationToken
+// to a docker config JSON credential string.
+//  {
+//   "auths": {
+//     "{{ registry endpoint }}": {
+//        "auth": "{{ authentication token }}"
+//     }
+//    }
+//  }
+type DockerCredential struct {
+	Auths map[string]Auth `json:"auths"`
+}
+
+// Auth contains the ECR base64 encoded username:password.
+type Auth struct {
+	Auth string `json:"auth"`
+}
+
+// GetAmazonECRToken fetches ECR Docker credentials of the given AWS Accounts or ECR Registry IDs.
+func GetAmazonECRToken(svc ecriface.ECRAPI, registryIDs []string) (*DockerCredential, error) {
+	ecrToken, err := svc.GetAuthorizationToken(
+		&ecr.GetAuthorizationTokenInput{
+			RegistryIds: aws.StringSlice(registryIDs),
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	auths := make(map[string]Auth)
+	for _, v := range ecrToken.AuthorizationData {
+		// Remove the https prefix
+		host := strings.TrimPrefix(*v.ProxyEndpoint, "https://")
+		auths[host] = Auth{*v.AuthorizationToken}
+	}
+	return &DockerCredential{auths}, nil
+}
+
+func (cred *DockerCredential) String() string {
+	bs, _ := json.Marshal(cred)
+	return string(bs)
+}

--- a/sidecar/aws/ecr/ecr_test.go
+++ b/sidecar/aws/ecr/ecr_test.go
@@ -1,0 +1,52 @@
+package ecr
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/aws/aws-sdk-go/service/ecr/ecriface"
+)
+
+type mockECRClient struct {
+	ecriface.ECRAPI
+	resp ecr.GetAuthorizationTokenOutput
+}
+
+// Mock the response
+func (m *mockECRClient) GetAuthorizationToken(input *ecr.GetAuthorizationTokenInput) (*ecr.GetAuthorizationTokenOutput, error) {
+	return &m.resp, nil
+}
+
+func TestGetAmazonECRToken(t *testing.T) {
+	tc := struct {
+		resp               ecr.GetAuthorizationTokenOutput
+		expectedHost       string
+		expectedCredential string
+	}{
+		// Mock the response
+		resp: ecr.GetAuthorizationTokenOutput{
+			AuthorizationData: []*ecr.AuthorizationData{
+				{
+					ProxyEndpoint:      aws.String("https://12345.dkr.ecr-use-east-1.amazonaws.com"),
+					AuthorizationToken: aws.String("QVdTOmVjcnBhc3N3b3JkCg=="),
+				},
+			},
+		},
+		expectedHost:       "12345.dkr.ecr-use-east-1.amazonaws.com",
+		expectedCredential: "QVdTOmVjcnBhc3N3b3JkCg==",
+	}
+	mockSvc := &mockECRClient{resp: tc.resp}
+	cred, err := GetAmazonECRToken(mockSvc, []string{"12345", "6024011343452"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, found := cred.Auths[tc.expectedHost]; !found {
+		t.Fatalf("expecting to see %s based from the mocked response", tc.expectedHost)
+	}
+	if cred.Auths[tc.expectedHost].Auth != tc.expectedCredential {
+		t.Fatalf("expecting to see %s credential based from the mocked response", tc.expectedCredential)
+	}
+	fmt.Println("--- INFO: got ", cred)
+}

--- a/sidecar/aws/ecr/types.go
+++ b/sidecar/aws/ecr/types.go
@@ -1,0 +1,8 @@
+package ecr
+
+// Contants that will be used by the ecr sidecar and flux daemon.
+const (
+	SidecarAWSPort = "3031"
+	SidecarAWSPath = "/awsauth"
+	SidecarAWSURL  = "http://localhost:" + SidecarAWSPort + SidecarAWSPath
+)


### PR DESCRIPTION
This fixes #539. In order for this to work, the **fluxd** container must have the credentials
to access AWS API via API Keys or IAM roles.

**Sidecar integration approach:**

* Run the **ecr-sidecar** container alongside the **fluxd** container (flux Pod).. 
* The **ecr-sidecar**  must use `registry-ids` and `region` flag values which are required when invoking the get token request. 
* The **ecr-sidecar** container fetches the docker login token using [AWS ECR SDK](https://docs.aws.amazon.com/sdk-for-go/api/service/ecr/#ECR.GetAuthorizationTokenRequest) with a configurable interval using `fetch-interval` flag and save it in memory.
* The **ecr-sidecar** container exposes a `/awsauth` endpoint which returns the authentication in JSON format.
  ```json
  {
    "auths": {
      "https://12345.dkr.ecr-use-east-1.amazonaws.com": {
        "auth": "QVdTOmVjcnBhc3N3b3JkCg=="
      },
      "https://602401143452.dkr.ecr.us-east-1.amazonaws.com": {
        "auth": "QVdTOnh4eHh4Cg=="
      }
    }
  }
   ```
* **WIP**: Now, when **fluxd** invoke the [credsFor](https://github.com/weaveworks/flux/blob/fd1cddced210acb94a0a005fcf0d75adc3c674ae/registry/credentials.go#L130) function we can add a new condition for AWS related docker repos:

  ```go
  if strings.HasSuffix(host, "amazonaws.com") {
    sidecar := newAWSSidecar()
    if cred, err := sidecar.GetAWSLoginCreds(host); err == nil {
      return cred
    }
  }
  ```
  
  This is not tested yet..

**Considerations:**

Initially, I thought it would be nicer if **GetAWSLoginCreds** function can be executed as a new goroutine during the **fluxd** runtime. But it was taking so much effort for me to understand the end to end flow of this demon. In my opinion, adding a sidecar made it much simpler for me to integrate this feature. We may be able to do the same for Azure authentication in the future.

**References:**

* https://docs.aws.amazon.com/cli/latest/reference/ecr/get-authorization-token.html
* https://docs.aws.amazon.com/sdk-for-go/api/service/ecr/#ECR.GetAuthorizationTokenRequest
* https://github.com/bzon/ecr-k8s-secret-creator