### PR TITLE
Move controller Status* consts to cluster package

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -8,6 +8,17 @@ import (
 	"github.com/weaveworks/flux/ssh"
 )
 
+// Constants for workload ready status. These are defined here so that
+// no-one has to drag in Kubernetes dependencies to be able to use
+// them.
+const (
+	StatusUnknown  = "unknown"
+	StatusError    = "error"
+	StatusReady    = "ready"
+	StatusUpdating = "updating"
+	StatusStarted  = "started"
+)
+
 // The things we can get from the running cluster. These used to form
 // the remote.Platform interface; but now we do more in the daemon so they
 // are distinct interfaces.

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -21,14 +21,6 @@ import (
 	"github.com/weaveworks/flux/ssh"
 )
 
-const (
-	StatusUnknown  = "unknown"
-	StatusError    = "error"
-	StatusReady    = "ready"
-	StatusUpdating = "updating"
-	StatusStarted  = "started"
-)
-
 type coreClient k8sclient.Interface
 type fluxHelmClient fhrclient.Interface
 

--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -139,7 +139,7 @@ func makeDeploymentPodController(deployment *apiapps.Deployment) podController {
 	var status string
 	objectMeta, deploymentStatus := deployment.ObjectMeta, deployment.Status
 
-	status = StatusStarted
+	status = cluster.StatusStarted
 	rollout := cluster.RolloutStatus{
 		Desired:   *deployment.Spec.Replicas,
 		Updated:   deploymentStatus.UpdatedReplicas,
@@ -151,12 +151,12 @@ func makeDeploymentPodController(deployment *apiapps.Deployment) podController {
 
 	if deploymentStatus.ObservedGeneration >= objectMeta.Generation {
 		// the definition has been updated; now let's see about the replicas
-		status = StatusUpdating
+		status = cluster.StatusUpdating
 		if rollout.Updated == rollout.Desired && rollout.Available == rollout.Desired && rollout.Outdated == 0 {
-			status = StatusReady
+			status = cluster.StatusReady
 		}
 		if len(rollout.Messages) != 0 {
-			status = StatusError
+			status = cluster.StatusError
 		}
 	}
 
@@ -202,7 +202,7 @@ func makeDaemonSetPodController(daemonSet *apiapps.DaemonSet) podController {
 	var status string
 	objectMeta, daemonSetStatus := daemonSet.ObjectMeta, daemonSet.Status
 
-	status = StatusStarted
+	status = cluster.StatusStarted
 	rollout := cluster.RolloutStatus{
 		Desired:   daemonSetStatus.DesiredNumberScheduled,
 		Updated:   daemonSetStatus.UpdatedNumberScheduled,
@@ -215,9 +215,9 @@ func makeDaemonSetPodController(daemonSet *apiapps.DaemonSet) podController {
 
 	if daemonSetStatus.ObservedGeneration >= objectMeta.Generation {
 		// the definition has been updated; now let's see about the replicas
-		status = StatusUpdating
+		status = cluster.StatusUpdating
 		if rollout.Updated == rollout.Desired && rollout.Available == rollout.Desired && rollout.Outdated == 0 {
-			status = StatusReady
+			status = cluster.StatusReady
 		}
 	}
 
@@ -263,7 +263,7 @@ func makeStatefulSetPodController(statefulSet *apiapps.StatefulSet) podControlle
 	var status string
 	objectMeta, statefulSetStatus := statefulSet.ObjectMeta, statefulSet.Status
 
-	status = StatusStarted
+	status = cluster.StatusStarted
 	rollout := cluster.RolloutStatus{
 		Ready: statefulSetStatus.ReadyReplicas,
 		// There is no Available parameter for statefulset, so use Ready instead
@@ -304,13 +304,13 @@ func makeStatefulSetPodController(statefulSet *apiapps.StatefulSet) podControlle
 
 	if statefulSetStatus.ObservedGeneration >= objectMeta.Generation {
 		// the definition has been updated; now let's see about the replicas
-		status = StatusUpdating
+		status = cluster.StatusUpdating
 		// for partition rolling update rollout.Ready might be >= rollout.Desired
 		// because of rollout.Ready references to all ready pods (updated and outdated ones)
 		// and rollout.Desired references to only desired pods for current partition
 		// we check that all pods (updated and outdated ones) are ready
 		if rollout.Updated == rollout.Desired && rollout.Ready == specDesired && rollout.Outdated == 0 {
-			status = StatusReady
+			status = cluster.StatusReady
 		}
 	}
 
@@ -357,7 +357,7 @@ func makeCronJobPodController(cronJob *apibatch.CronJob) podController {
 		apiVersion:  "batch/v1beta1",
 		kind:        "CronJob",
 		name:        cronJob.ObjectMeta.Name,
-		status:      StatusReady,
+		status:      cluster.StatusReady,
 		podTemplate: cronJob.Spec.JobTemplate.Spec.Template,
 		k8sObject:   cronJob}
 }

--- a/remote/rpc/compat.go
+++ b/remote/rpc/compat.go
@@ -9,7 +9,7 @@ import (
 	"github.com/weaveworks/flux/api/v10"
 	"github.com/weaveworks/flux/api/v11"
 	"github.com/weaveworks/flux/api/v6"
-	"github.com/weaveworks/flux/cluster/kubernetes"
+	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/remote"
 	"github.com/weaveworks/flux/update"
@@ -86,7 +86,7 @@ func listServicesRolloutStatus(ss []v6.ControllerStatus) {
 			// and 'updated' all to the same count.
 			ss[i].Rollout.Ready = ss[i].Rollout.Updated
 			ss[i].Rollout.Available = ss[i].Rollout.Updated
-			ss[i].Status = kubernetes.StatusUpdating
+			ss[i].Status = cluster.StatusUpdating
 		}
 	}
 }


### PR DESCRIPTION
Previously these were defined in cluster/kubernetes, and used in
remote/rpc, meaning anything that used RPC also dragged in all of the
Kubernetes depdendencies.

This commit avoids that dependency by putting the consts in cluster
instead.
