### PR TITLE
add `globsemver:` pattern

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ operator is in [./CHANGELOG-helmop.md](./CHANGELOG-helmop.md).
 
 ### Improvements
 
-- ..
+- Add `globsemver:` filter which is useful when you want to do glob matching and semantic versioning for image tags simultaneously.
 
 ## 1.7.1 (2018-09-26)
 
@@ -478,4 +478,3 @@ Initial semver release.
 -   Refactored registry code and improved coverage
 
 See https://github.com/weaveworks/flux/milestone/7?closed=1 for full details.
-

--- a/policy/pattern.go
+++ b/policy/pattern.go
@@ -1,17 +1,20 @@
 package policy
 
 import (
+	"errors"
+	"regexp"
+	"strings"
+
 	"github.com/Masterminds/semver"
 	"github.com/ryanuber/go-glob"
 	"github.com/weaveworks/flux/image"
-	"strings"
-	"regexp"
 )
 
 const (
-	globPrefix   = "glob:"
-	semverPrefix = "semver:"
-	regexpPrefix = "regexp:"
+	globPrefix       = "glob:"
+	semverPrefix     = "semver:"
+	globSemverPrefix = "globsemver:"
+	regexpPrefix     = "regexp:"
 )
 
 var (
@@ -43,13 +46,41 @@ type SemverPattern struct {
 
 // RegexpPattern matches by regular expression.
 type RegexpPattern struct {
-	pattern	string // pattern without prefix
-	regexp	*regexp.Regexp
+	pattern string // pattern without prefix
+	regexp  *regexp.Regexp
+}
+
+// GlobSemverPattern matches by glob and respects semantic versioning.
+type GlobSemverPattern struct {
+	pattern     string // pattern without prefix
+	prefix      string
+	ver         string
+	suffix      string
+	extractErr  error
+	constraints *semver.Constraints
+}
+
+// splits "v{1.2.3}-dev" into  "v", "1.2.3" and "-dev"
+func splitSemVer(pattern string) (string, string, string, error) {
+	x := strings.Split(pattern, "{")
+	if len(x) != 2 {
+		return "", "", "", errors.New("invalid format for GlobSemver tag")
+	}
+	prefix, remaining := x[0], x[1]
+	y := strings.Split(remaining, "}")
+	if len(y) != 2 {
+		return "", "", "", errors.New("invalid format for GlobSemver tag")
+	}
+	ver, suffix := y[0], y[1]
+	if len(ver) == 0 {
+		return "", "", "", errors.New("invalid format for GlobSemver tag, empty semver pattern")
+	}
+	return prefix, ver, suffix, nil
 }
 
 // NewPattern instantiates a Pattern according to the prefix
 // it finds. The prefix can be either `glob:` (default if omitted),
-// `semver:` or `regexp:`.
+// `semver:`, `globsemver:` or `regexp:`.
 func NewPattern(pattern string) Pattern {
 	switch {
 	case strings.HasPrefix(pattern, semverPrefix):
@@ -60,9 +91,52 @@ func NewPattern(pattern string) Pattern {
 		pattern = strings.TrimPrefix(pattern, regexpPrefix)
 		r, _ := regexp.Compile(pattern)
 		return RegexpPattern{pattern, r}
+	case strings.HasPrefix(pattern, globSemverPrefix):
+		pattern = strings.TrimPrefix(pattern, globSemverPrefix)
+		prefix, ver, suffix, err := splitSemVer(pattern)
+		c, _ := semver.NewConstraint(ver)
+		return GlobSemverPattern{pattern, prefix, ver, suffix, err, c}
 	default:
 		return GlobPattern(strings.TrimPrefix(pattern, globPrefix))
 	}
+}
+
+func (gs GlobSemverPattern) ExtractSemver(tag string) string {
+	tagSemver := strings.TrimSuffix(tag, gs.suffix)
+	return strings.TrimPrefix(tagSemver, gs.prefix)
+}
+
+func (gs GlobSemverPattern) Matches(tag string) bool {
+	v, err := semver.NewVersion(gs.ExtractSemver(tag))
+	if err != nil {
+		return false
+	}
+	var semverMatch bool
+	if gs.constraints == nil {
+		// Invalid constraints match anything
+		semverMatch = true
+	} else {
+		semverMatch = gs.constraints.Check(v)
+	}
+	globPattern := gs.prefix + "*" + gs.suffix
+	g := glob.Glob(globPattern, tag)
+	return g && semverMatch
+}
+
+func (gs GlobSemverPattern) Newer(a, b *image.Info) bool {
+	oldATag, oldBTag := a.ID.Tag, b.ID.Tag
+	a.ID.Tag, b.ID.Tag = gs.ExtractSemver(a.ID.Tag), gs.ExtractSemver(b.ID.Tag)
+	isNever := image.NewerBySemver(a, b)
+	a.ID.Tag, b.ID.Tag = oldATag, oldBTag
+	return isNever
+}
+
+func (gs GlobSemverPattern) String() string {
+	return globSemverPrefix + gs.pattern
+}
+
+func (gs GlobSemverPattern) Valid() bool {
+	return gs.constraints != nil && gs.extractErr == nil
 }
 
 func (g GlobPattern) Matches(tag string) bool {

--- a/policy/pattern_test.go
+++ b/policy/pattern_test.go
@@ -122,7 +122,7 @@ func TestRegexpPattern_Matches(t *testing.T) {
 	}
 }
 
-func Test_extractGlob(t *testing.T) {
+func Test_splitSemVer(t *testing.T) {
 	tests := []struct {
 		name    string
 		pattern string

--- a/site/using.md
+++ b/site/using.md
@@ -447,6 +447,18 @@ fluxctl policy --controller=default:deployment/helloworld --tag-all='semver:*'
 Using a semver filter will also affect how flux sorts images, so
 that the higher versions will be considered newer.
 
+### GlobSemver
+GlobSemver filter is a combination of Glob and Semver filters.
+This filter is useful when you want to do glob matching and semantic versioning simultaneously.
+Semver part of the filter expects constraints inside curly braces, while Glob part treats curly braces and their contents as a `*`.
+
+For example, if you want to deploy `1.x.x-rc` tags and you want tags to be sorted according to [semantic versioning](https://semver.org),
+use the following filter:
+```
+fluxctl policy --controller=default:deployment/helloworld --tag-all='globsemver:{~1}-rc'
+```
+This will apply semantic versioning according to `~1` pattern and do glob matching according to `*-rc` pattern
+
 ### Regexp
 
 If your images have complex tags you can filter by regular expression:

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
 )
@@ -76,6 +75,16 @@ func TestImageInfos_Filter_semver(t *testing.T) {
 	ii := ImageInfos{latest, semver0, semver1}
 	assert.Equal(t, SortedImageInfos{semver1, semver0}, ii.FilterAndSort(policy.NewPattern("semver:*")))
 	assert.Equal(t, SortedImageInfos{semver1}, ii.FilterAndSort(policy.NewPattern("semver:~1")))
+}
+
+func TestImageInfos_Filter_globsemver(t *testing.T) {
+	globsemver0 := image.Info{ID: image.Ref{Name: image.Name{Image: "flux"}, Tag: "v1.2.3-dev"}}
+	globsemver1 := image.Info{ID: image.Ref{Name: image.Name{Image: "moon"}, Tag: "v1.0.1-dev"}}
+	globsemver2 := image.Info{ID: image.Ref{Name: image.Name{Image: "earth"}, Tag: "v1.2.3"}}
+
+	ii := ImageInfos{globsemver0, globsemver1, globsemver2}
+	assert.Equal(t, SortedImageInfos{globsemver0, globsemver1}, ii.FilterAndSort(policy.NewPattern("globsemver:v{~1}-dev")))
+	assert.Equal(t, SortedImageInfos{globsemver0}, ii.FilterAndSort(policy.NewPattern("globsemver:v{~1.2}-dev")))
 }
 
 func TestAvail(t *testing.T) {


### PR DESCRIPTION
GlobSemver filter is a combination of Glob and Semver filters.
This filter is useful when you want to do glob matching and semantic versioning simultaneously.

For example, one of our development teams pushes several deployments a day, each deployment has to go through multiple CI stages before it finally gets to k8s cluster.
This sometimes triggers race condition -- for example, developer pushes `v1.2.5-rc` tag to CI, then he realizes he had made a logical mistake, fixes it and pushes `v1.2.6-rc` tag.
He expects that soon he will see `v1.2.6-rc` at k8s-staging cluster.
But because the CI node which was testing `v1.2.6-rc` was slower then the one which was testing  `v1.2.5-rc` -- Flux deploys `v1.2.6-rc` first, and then replaces it with `v1.2.5-rc` if we are using `glob:*-rc` filter

globSemver filter  `globsemver:v{1.x.x}-rc` could prevent such an issue