### PR TITLE
Add prometheus annotation to Helm chart

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -15,8 +15,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- if .Values.prometheus.enabled }}
       annotations:
         prometheus.io.scrape: "true"
+      {{- end }}
       labels:
         app: {{ template "flux.name" . }}
         release: {{ .Release.Name }}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -15,6 +15,8 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        prometheus.io.scrape: "true"
       labels:
         app: {{ template "flux.name" . }}
         release: {{ .Release.Name }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -20,6 +20,10 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      {{- if .Values.prometheus.enabled }}
+      annotations:
+        prometheus.io.scrape: "true"
+      {{- end }}
       labels:
         app: {{ template "flux.name" . }}-helm-operator
         release: {{ .Release.Name }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -157,3 +157,6 @@ extraEnvs: []
 # extraEnvs:
 #   - name: FOO
 #     value: bar
+
+prometheus:
+  enabled: false


### PR DESCRIPTION
This change adds the `prometheus.io.scrape: "true"` annotation in order for prometheus to start collecting metrics from Flux.

This fixes #1461.