### PR TITLE
Add some values to the Helm chart for other components of Flux

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -176,6 +176,8 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `image.tag` | Image tag | `<VERSION>`
 | `image.pullPolicy` | Image pull policy | `IfNotPresent`
 | `resources` | CPU/memory resource requests/limits for Flux | None
+| `token` | Weave Cloud service token | None
+| `extraEnvs` | Extra environment variables for the Flux pod | `[]`
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used | `flux`
@@ -199,6 +201,9 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `registry.burst` | Maximum number of warmer connections to remote and memcache | `125`
 | `registry.trace` |  Output trace of image registry requests to log | `false`
 | `registry.insecureHosts` | Use HTTP rather than HTTPS for these image registry domains | None
+| `memcached.verbose` | Enable request logging in memcached | `false`
+| `memcached.maxItemSize` | Maximum size for one item | `1m`
+| `memcached.maxMemory` | Maximum memory to use, in megabytes | `64`
 | `memcached.resources` | CPU/memory resource requests/limits for memcached | None
 | `helmOperator.create` | If `true`, install the Helm operator | `false`
 | `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator`
@@ -221,8 +226,6 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.tls.keyFile` | Name of the key file within the k8s secret | `tls.key`
 | `helmOperator.tls.certFile` | Name of the certificate file within the k8s secret | `tls.crt`
 | `helmOperator.tls.caContent` | Certificate Authority content used to validate the Tiller server certificate | None
-| `token` | Weave Cloud service token | None
-| `extraEnvs` | Extra environment variables for the Flux pod | `[]`
 | `helmOperator.resources` | CPU/memory resource requests/limits for Helm operator | None
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -175,7 +175,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `image.repository` | Image repository | `quay.io/weaveworks/flux`
 | `image.tag` | Image tag | `<VERSION>`
 | `image.pullPolicy` | Image pull policy | `IfNotPresent`
-| `resources` | CPU/memory resource requests/limits | None
+| `resources` | CPU/memory resource requests/limits for Flux | None
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`
 | `serviceAccount.name` | Service account to be used | `flux`
@@ -199,6 +199,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `registry.burst` | Maximum number of warmer connections to remote and memcache | `125`
 | `registry.trace` |  Output trace of image registry requests to log | `false`
 | `registry.insecureHosts` | Use HTTP rather than HTTPS for these image registry domains | None
+| `memcached.resources` | CPU/memory resource requests/limits for memcached | None
 | `helmOperator.create` | If `true`, install the Helm operator | `false`
 | `helmOperator.repository` | Helm operator image repository | `quay.io/weaveworks/helm-operator`
 | `helmOperator.tag` | Helm operator image tag | `<VERSION>`
@@ -222,6 +223,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.tls.caContent` | Certificate Authority content used to validate the Tiller server certificate | None
 | `token` | Weave Cloud service token | None
 | `extraEnvs` | Extra environment variables for the Flux pod | `[]`
+| `helmOperator.resources` | CPU/memory resource requests/limits for Helm operator | None
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -103,4 +103,18 @@ spec:
         env:
 {{ toYaml .Values.helmOperator.extraEnvs | indent 8 }}
       {{- end }}
+        resources:
+{{ toYaml .Values.helmOperator.resources | indent 10 }}
+      {{- with .Values.helmOperator.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.helmOperator.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+      {{- end }}
+      {{- with .Values.helmOperator.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+      {{- end }}
 {{- end -}}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -35,6 +35,20 @@ spec:
         ports:
         - name: memcached
           containerPort: 11211
+        resources:
+{{ toYaml .Values.memcached.resources | indent 10 }}
+    {{- with .Values.memcached.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.memcached.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.memcached.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -81,11 +81,11 @@ resources: {}
   # If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   # limits:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #  cpu: 250m
+  #  memory: 300Mi
   # requests:
-  #  cpu: 100m
-  #  memory: 128Mi
+  #  cpu: 150m
+  #  memory: 250Mi
 
 nodeSelector: {}
 

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -53,6 +53,18 @@ helmOperator:
   # extraEnvs:
   #   - name: FOO
   #     value: bar
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  resources: {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 50m
+    #  memory: 150Mi
+    # requests:
+    #  cpu: 20m
+    #  memory: 100Mi
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -127,6 +139,18 @@ memcached:
   verbose: false
   maxItemSize: 1m
   maxMemory: 64
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  resources: {}
+    # If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #  cpu: 100m
+    #  memory: 70Mi
+    # requests:
+    #  cpu: 50m
+    #  memory: 64Mi
 
 ssh:
   # Overrides for git over SSH. If you use your own git server, you


### PR DESCRIPTION
We're setting up a cluster with mixed Windows/Linux nodes, and the Helm chart is missing `nodeSelector` values for the helm operator and memcached deployments. I added tolerations/affinity/resources values for those components too, because why not.