### PR TITLE
Add events for container release

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -137,7 +137,7 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 	}
 
 	ctx := context.Background()
-	spec := update.ReleaseSpec{
+	spec := update.ReleaseImageSpec{
 		ServiceSpecs: controllers,
 		ImageSpec:    image,
 		Kind:         kind,
@@ -182,10 +182,10 @@ func (opts *controllerReleaseOpts) RunE(cmd *cobra.Command, args []string) error
 	return await(ctx, cmd.OutOrStdout(), cmd.OutOrStderr(), opts.API, jobID, !opts.dryRun, opts.verbosity)
 }
 
-func promptSpec(out io.Writer, result job.Result, verbosity int) (update.ContainerSpecs, error) {
+func promptSpec(out io.Writer, result job.Result, verbosity int) (update.ReleaseContainersSpec, error) {
 	menu := update.NewMenu(out, result.Result, verbosity)
 	containerSpecs, err := menu.Run()
-	return update.ContainerSpecs{
+	return update.ReleaseContainersSpec{
 		Kind:           update.ReleaseKindExecute,
 		ContainerSpecs: containerSpecs,
 		SkipMismatches: false,

--- a/cmd/fluxctl/release_cmd_test.go
+++ b/cmd/fluxctl/release_cmd_test.go
@@ -12,29 +12,29 @@ import (
 func TestReleaseCommand_CLIConversion(t *testing.T) {
 	for _, v := range []struct {
 		args         []string
-		expectedSpec update.ReleaseSpec
+		expectedSpec update.ReleaseImageSpec
 	}{
-		{[]string{"--update-all-images", "--all"}, update.ReleaseSpec{
+		{[]string{"--update-all-images", "--all"}, update.ReleaseImageSpec{
 			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 			ImageSpec:    update.ImageSpecLatest,
 			Kind:         update.ReleaseKindExecute,
 		}},
-		{[]string{"--update-all-images", "--all", "--dry-run"}, update.ReleaseSpec{
+		{[]string{"--update-all-images", "--all", "--dry-run"}, update.ReleaseImageSpec{
 			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 			ImageSpec:    update.ImageSpecLatest,
 			Kind:         update.ReleaseKindPlan,
 		}},
-		{[]string{"--update-image=alpine:latest", "--all"}, update.ReleaseSpec{
+		{[]string{"--update-image=alpine:latest", "--all"}, update.ReleaseImageSpec{
 			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 			ImageSpec:    "alpine:latest",
 			Kind:         update.ReleaseKindExecute,
 		}},
-		{[]string{"--update-all-images", "--controller=deployment/flux"}, update.ReleaseSpec{
+		{[]string{"--update-all-images", "--controller=deployment/flux"}, update.ReleaseImageSpec{
 			ServiceSpecs: []update.ResourceSpec{"default:deployment/flux"},
 			ImageSpec:    update.ImageSpecLatest,
 			Kind:         update.ReleaseKindExecute,
 		}},
-		{[]string{"--update-all-images", "--all", "--exclude=deployment/test,deployment/yeah"}, update.ReleaseSpec{
+		{[]string{"--update-all-images", "--all", "--exclude=deployment/test,deployment/yeah"}, update.ReleaseImageSpec{
 			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 			ImageSpec:    update.ImageSpecLatest,
 			Kind:         update.ReleaseKindExecute,

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -144,7 +144,7 @@ func TestDaemon_ListServicesWithOptions(t *testing.T) {
 
 	ctx := context.Background()
 
-	t.Run("no filter", func (t *testing.T) {
+	t.Run("no filter", func(t *testing.T) {
 		s, err := d.ListServicesWithOptions(ctx, v11.ListServicesOptions{})
 		if err != nil {
 			t.Fatalf("Error: %s", err.Error())
@@ -153,7 +153,7 @@ func TestDaemon_ListServicesWithOptions(t *testing.T) {
 			t.Fatalf("Expected %v but got %v", 2, len(s))
 		}
 	})
-	t.Run("filter id", func (t *testing.T) {
+	t.Run("filter id", func(t *testing.T) {
 		s, err := d.ListServicesWithOptions(ctx, v11.ListServicesOptions{
 			Namespace: "",
 			Services:  []flux.ResourceID{flux.MustParseResourceID(svc)}})
@@ -165,7 +165,7 @@ func TestDaemon_ListServicesWithOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("filter id and namespace", func (t *testing.T) {
+	t.Run("filter id and namespace", func(t *testing.T) {
 		_, err := d.ListServicesWithOptions(ctx, v11.ListServicesOptions{
 			Namespace: "foo",
 			Services:  []flux.ResourceID{flux.MustParseResourceID(svc)}})
@@ -174,7 +174,7 @@ func TestDaemon_ListServicesWithOptions(t *testing.T) {
 		}
 	})
 
-	t.Run("filter unsupported id kind", func (t *testing.T) {
+	t.Run("filter unsupported id kind", func(t *testing.T) {
 		_, err := d.ListServicesWithOptions(ctx, v11.ListServicesOptions{
 			Namespace: "foo",
 			Services:  []flux.ResourceID{flux.MustParseResourceID("default:unsupportedkind/goodbyeworld")}})
@@ -183,7 +183,6 @@ func TestDaemon_ListServicesWithOptions(t *testing.T) {
 		}
 	})
 }
-
 
 // When I call list images for a service, it should return images
 func TestDaemon_ListImagesWithOptions(t *testing.T) {
@@ -848,7 +847,7 @@ func (w *wait) ForImageTag(t *testing.T, d *Daemon, service, container, tag stri
 func updateImage(ctx context.Context, d *Daemon, t *testing.T) job.ID {
 	return updateManifest(ctx, t, d, update.Spec{
 		Type: update.Images,
-		Spec: update.ReleaseSpec{
+		Spec: update.ReleaseImageSpec{
 			Kind:         update.ReleaseKindExecute,
 			ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 			ImageSpec:    newHelloImage,

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -306,8 +306,8 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 
 			// Interpret some notes as events to send to the upstream
 			switch n.Spec.Type {
-			case update.Images:
-				spec := n.Spec.Spec.(update.ReleaseSpec)
+			case update.Containers:
+				spec := n.Spec.Spec.(update.ReleaseContainersSpec)
 				noteEvents = append(noteEvents, event.Event{
 					ServiceIDs: n.Result.AffectedResources(),
 					Type:       event.EventRelease,
@@ -320,7 +320,32 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 							Result:   n.Result,
 							Error:    n.Result.Error(),
 						},
-						Spec:  spec,
+						Spec: event.ReleaseSpec{
+							Type:                 event.ReleaseContainerSpecType,
+							ReleaseContainerSpec: &spec,
+						},
+						Cause: n.Spec.Cause,
+					},
+				})
+				includes[event.EventRelease] = true
+			case update.Images:
+				spec := n.Spec.Spec.(update.ReleaseImageSpec)
+				noteEvents = append(noteEvents, event.Event{
+					ServiceIDs: n.Result.AffectedResources(),
+					Type:       event.EventRelease,
+					StartedAt:  started,
+					EndedAt:    time.Now().UTC(),
+					LogLevel:   event.LogLevelInfo,
+					Metadata: &event.ReleaseEventMetadata{
+						ReleaseEventCommon: event.ReleaseEventCommon{
+							Revision: commits[i].Revision,
+							Result:   n.Result,
+							Error:    n.Result.Error(),
+						},
+						Spec: event.ReleaseSpec{
+							Type:             event.ReleaseImageSpecType,
+							ReleaseImageSpec: &spec,
+						},
 						Cause: n.Spec.Cause,
 					},
 				})

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -321,8 +321,8 @@ func (d *Daemon) doSync(logger log.Logger) (retErr error) {
 							Error:    n.Result.Error(),
 						},
 						Spec: event.ReleaseSpec{
-							Type:                 event.ReleaseContainerSpecType,
-							ReleaseContainerSpec: &spec,
+							Type: event.ReleaseContainersSpecType,
+							ReleaseContainersSpec: &spec,
 						},
 						Cause: n.Spec.Cause,
 					},

--- a/event/event.go
+++ b/event/event.go
@@ -95,10 +95,12 @@ func (e Event) String() string {
 		if len(strImageIDs) == 0 {
 			strImageIDs = []string{"no image changes"}
 		}
-		for _, spec := range metadata.Spec.ServiceSpecs {
-			if spec == update.ResourceSpecAll {
-				strServiceIDs = []string{"all services"}
-				break
+		if metadata.Spec.Type == ReleaseImageSpecType {
+			for _, spec := range metadata.Spec.ReleaseImageSpec.ServiceSpecs {
+				if spec == update.ResourceSpecAll {
+					strServiceIDs = []string{"all services"}
+					break
+				}
 			}
 		}
 		if len(strServiceIDs) == 0 {
@@ -239,11 +241,27 @@ type ReleaseEventCommon struct {
 	Error string `json:"error,omitempty"`
 }
 
+const (
+	// ReleaseImageSpecType is a type of release spec when there are update.Images
+	ReleaseImageSpecType = "releaseImageSpecType"
+	// ReleaseContainerSpecType is a type of release spec when there are update.Containers
+	ReleaseContainerSpecType = "releaseContainerSpecType"
+)
+
+// ReleaseSpec is a spec for images and containers release
+type ReleaseSpec struct {
+	// Type is ReleaseImagesSpecType or ReleaseContainersSpecType
+	// if empty (for previous version), then use ReleaseImagesSpecType
+	Type                 string
+	ReleaseImageSpec     *update.ReleaseImageSpec
+	ReleaseContainerSpec *update.ReleaseContainersSpec
+}
+
 // ReleaseEventMetadata is the metadata for when service(s) are released
 type ReleaseEventMetadata struct {
 	ReleaseEventCommon
-	Spec  update.ReleaseSpec `json:"spec"`
-	Cause update.Cause       `json:"cause"`
+	Spec  ReleaseSpec  `json:"spec"`
+	Cause update.Cause `json:"cause"`
 }
 
 // AutoReleaseEventMetadata is for when service(s) are released

--- a/event/event.go
+++ b/event/event.go
@@ -95,7 +95,7 @@ func (e Event) String() string {
 		if len(strImageIDs) == 0 {
 			strImageIDs = []string{"no image changes"}
 		}
-		if metadata.Spec.Type == ReleaseImageSpecType {
+		if metadata.Spec.Type == "" || metadata.Spec.Type == ReleaseImageSpecType {
 			for _, spec := range metadata.Spec.ReleaseImageSpec.ServiceSpecs {
 				if spec == update.ResourceSpecAll {
 					strServiceIDs = []string{"all services"}
@@ -244,17 +244,17 @@ type ReleaseEventCommon struct {
 const (
 	// ReleaseImageSpecType is a type of release spec when there are update.Images
 	ReleaseImageSpecType = "releaseImageSpecType"
-	// ReleaseContainerSpecType is a type of release spec when there are update.Containers
-	ReleaseContainerSpecType = "releaseContainerSpecType"
+	// ReleaseContainersSpecType is a type of release spec when there are update.Containers
+	ReleaseContainersSpecType = "releaseContainersSpecType"
 )
 
 // ReleaseSpec is a spec for images and containers release
 type ReleaseSpec struct {
-	// Type is ReleaseImagesSpecType or ReleaseContainersSpecType
-	// if empty (for previous version), then use ReleaseImagesSpecType
-	Type                 string
-	ReleaseImageSpec     *update.ReleaseImageSpec
-	ReleaseContainerSpec *update.ReleaseContainersSpec
+	// Type is ReleaseImageSpecType or ReleaseContainersSpecType
+	// if empty (for previous version), then use ReleaseImageSpecType
+	Type                  string
+	ReleaseImageSpec      *update.ReleaseImageSpec
+	ReleaseContainersSpec *update.ReleaseContainersSpec
 }
 
 // ReleaseEventMetadata is the metadata for when service(s) are released

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	spec = update.ReleaseSpec{
+	spec = update.ReleaseImageSpec{
 		ImageSpec: update.ImageSpecLatest,
 	}
 	cause = update.Cause{
@@ -22,7 +22,10 @@ func TestEvent_ParseReleaseMetaData(t *testing.T) {
 		Type: EventRelease,
 		Metadata: &ReleaseEventMetadata{
 			Cause: cause,
-			Spec:  spec,
+			Spec: ReleaseSpec{
+				Type:             ReleaseImageSpecType,
+				ReleaseImageSpec: &spec,
+			},
 		},
 	}
 
@@ -35,7 +38,7 @@ func TestEvent_ParseReleaseMetaData(t *testing.T) {
 	}
 	switch r := e.Metadata.(type) {
 	case *ReleaseEventMetadata:
-		if r.Spec.ImageSpec != spec.ImageSpec ||
+		if r.Spec.ReleaseImageSpec.ImageSpec != spec.ImageSpec ||
 			r.Cause != cause {
 			t.Fatal("Release event wasn't marshalled/unmarshalled")
 		}

--- a/event/event_test.go
+++ b/event/event_test.go
@@ -63,3 +63,35 @@ func TestEvent_ParseNoMetadata(t *testing.T) {
 		t.Fatal("Hasn't been unmarshalled properly")
 	}
 }
+
+// TestEvent_ParseOldReleaseMetaData makes sure the parsing code can
+// handle the older format events recorded against commits.
+func TestEvent_ParseOldReleaseMetaData(t *testing.T) {
+	// A minimal example of an old-style ReleaseEventMetadata. NB it
+	// must have at least an entry for "spec", since otherwise the
+	// JSON unmarshaller will not attempt to unparse the spec and
+	// thereby invoke the specialised UnmarshalJSON.
+	oldData := `
+{
+  "spec": {
+    "serviceSpecs": ["<all>"]
+  }
+}
+`
+	var eventData ReleaseEventMetadata
+	if err := json.Unmarshal([]byte(oldData), &eventData); err != nil {
+		t.Fatal(err)
+	}
+	if eventData.Spec.Type != ReleaseImageSpecType {
+		t.Error("did not set spec type to ReleaseImageSpecType")
+	}
+	if eventData.Spec.ReleaseImageSpec == nil {
+		t.Error("did not set .ReleaseImageSpec as expected")
+	}
+	if eventData.Spec.ReleaseContainersSpec != nil {
+		t.Error("unexpectedly set .ReleaseContainersSpec")
+	}
+	if len(eventData.Spec.ReleaseImageSpec.ServiceSpecs) != 1 {
+		t.Error("expected service specs of len 1")
+	}
+}

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -227,7 +227,7 @@ func (s HTTPServer) UpdateImages(w http.ResponseWriter, r *http.Request) {
 		excludes = append(excludes, s)
 	}
 
-	spec := update.ReleaseSpec{
+	spec := update.ReleaseImageSpec{
 		ServiceSpecs: serviceSpecs,
 		ImageSpec:    imageSpec,
 		Kind:         releaseKind,

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -243,7 +243,7 @@ func Test_InitContainer(t *testing.T) {
 	}
 
 	initSpec, _ := update.ParseResourceSpec(initWorkloadID.String())
-	spec := update.ReleaseSpec{
+	spec := update.ReleaseImageSpec{
 		ServiceSpecs: []update.ResourceSpec{initSpec},
 		ImageSpec:    update.ImageSpecLatest,
 		Kind:         update.ReleaseKindExecute,
@@ -268,13 +268,13 @@ func Test_FilterLogic(t *testing.T) {
 	notInRepoSpec, _ := update.ParseResourceSpec(notInRepoService)
 	for _, tst := range []struct {
 		Name     string
-		Spec     update.ReleaseSpec
+		Spec     update.ReleaseImageSpec
 		Expected expected
 	}{
 		// ignored if: excluded OR not included OR not correct image.
 		{
 			Name: "include specific service",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{hwSvcSpec},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -302,7 +302,7 @@ func Test_FilterLogic(t *testing.T) {
 			},
 		}, {
 			Name: "exclude specific service",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -334,7 +334,7 @@ func Test_FilterLogic(t *testing.T) {
 			},
 		}, {
 			Name: "update specific image",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecFromRef(newHwRef),
 				Kind:         update.ReleaseKindExecute,
@@ -363,7 +363,7 @@ func Test_FilterLogic(t *testing.T) {
 			// skipped if: not ignored AND (locked or not found in cluster)
 			// else: service is pending.
 			Name: "skipped & service is pending",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -395,7 +395,7 @@ func Test_FilterLogic(t *testing.T) {
 			},
 		}, {
 			Name: "all overrides spec",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{hwSvcSpec, update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -427,7 +427,7 @@ func Test_FilterLogic(t *testing.T) {
 			},
 		}, {
 			Name: "service not in repo",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{notInRepoSpec},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -468,12 +468,12 @@ func Test_Force_lockedController(t *testing.T) {
 	}
 	for _, tst := range []struct {
 		Name     string
-		Spec     update.ReleaseSpec
+		Spec     update.ReleaseImageSpec
 		Expected expected
 	}{
 		{
 			Name: "force ignores service lock (--controller --update-image)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{lockedSvcSpec},
 				ImageSpec:    update.ImageSpecFromRef(newLockedRef),
 				Kind:         update.ReleaseKindExecute,
@@ -488,7 +488,7 @@ func Test_Force_lockedController(t *testing.T) {
 			},
 		}, {
 			Name: "force does not ignore lock if updating all controllers (--all --update-image)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecFromRef(newLockedRef),
 				Kind:         update.ReleaseKindExecute,
@@ -504,7 +504,7 @@ func Test_Force_lockedController(t *testing.T) {
 		},
 		{
 			Name: "force ignores service lock (--controller --update-all-images)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{lockedSvcSpec},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -519,7 +519,7 @@ func Test_Force_lockedController(t *testing.T) {
 			},
 		}, {
 			Name: "force does not ignore lock if updating all controllers (--all --update-all-images)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -571,12 +571,12 @@ func Test_Force_filteredContainer(t *testing.T) {
 	}
 	for _, tst := range []struct {
 		Name     string
-		Spec     update.ReleaseSpec
+		Spec     update.ReleaseImageSpec
 		Expected expected
 	}{
 		{
 			Name: "force ignores container tag pattern (--controller --update-image)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{semverSvcSpec},
 				ImageSpec:    update.ImageSpecFromRef(newHwRef), // does not match filter
 				Kind:         update.ReleaseKindExecute,
@@ -592,7 +592,7 @@ func Test_Force_filteredContainer(t *testing.T) {
 		},
 		{
 			Name: "force ignores container tag pattern (--all --update-image)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecFromRef(newHwRef), // does not match filter
 				Kind:         update.ReleaseKindExecute,
@@ -608,7 +608,7 @@ func Test_Force_filteredContainer(t *testing.T) {
 		},
 		{
 			Name: "force complies with semver when updating all images (--controller --update-all-image)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{semverSvcSpec},
 				ImageSpec:    update.ImageSpecLatest, // will filter images by semver and pick newest version
 				Kind:         update.ReleaseKindExecute,
@@ -624,7 +624,7 @@ func Test_Force_filteredContainer(t *testing.T) {
 		},
 		{
 			Name: "force complies with semver when updating all images (--all --update-all-image)",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -670,12 +670,12 @@ func Test_ImageStatus(t *testing.T) {
 	testSvcSpec, _ := update.ParseResourceSpec(testSvc.ID.String())
 	for _, tst := range []struct {
 		Name     string
-		Spec     update.ReleaseSpec
+		Spec     update.ReleaseImageSpec
 		Expected expected
 	}{
 		{
 			Name: "image not found",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{testSvcSpec},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -692,7 +692,7 @@ func Test_ImageStatus(t *testing.T) {
 			},
 		}, {
 			Name: "image up to date",
-			Spec: update.ReleaseSpec{
+			Spec: update.ReleaseImageSpec{
 				ServiceSpecs: []update.ResourceSpec{hwSvcSpec},
 				ImageSpec:    update.ImageSpecLatest,
 				Kind:         update.ReleaseKindExecute,
@@ -746,7 +746,7 @@ func Test_UpdateMultidoc(t *testing.T) {
 		repo:      checkout,
 		registry:  mockRegistry,
 	}
-	spec := update.ReleaseSpec{
+	spec := update.ReleaseImageSpec{
 		ServiceSpecs: []update.ResourceSpec{"default:deployment/multi-deploy"},
 		ImageSpec:    update.ImageSpecLatest,
 		Kind:         update.ReleaseKindExecute,
@@ -794,7 +794,7 @@ func Test_UpdateList(t *testing.T) {
 		repo:      checkout,
 		registry:  mockRegistry,
 	}
-	spec := update.ReleaseSpec{
+	spec := update.ReleaseImageSpec{
 		ServiceSpecs: []update.ResourceSpec{"default:deployment/list-deploy"},
 		ImageSpec:    update.ImageSpecLatest,
 		Kind:         update.ReleaseKindExecute,
@@ -1014,7 +1014,7 @@ func Test_UpdateContainers(t *testing.T) {
 			},
 		},
 	} {
-		specs := update.ContainerSpecs{
+		specs := update.ReleaseContainersSpec{
 			ContainerSpecs: map[flux.ResourceID][]update.ContainerUpdate{tst.WorkloadID: tst.Spec},
 			Kind:           update.ReleaseKindExecute,
 		}
@@ -1040,7 +1040,7 @@ func Test_UpdateContainers(t *testing.T) {
 	}
 }
 
-func testRelease(t *testing.T, ctx *ReleaseContext, spec update.ReleaseSpec, expected update.Result) {
+func testRelease(t *testing.T, ctx *ReleaseContext, spec update.ReleaseImageSpec, expected update.Result) {
 	results, err := Release(ctx, spec, log.NewNopLogger())
 	assert.NoError(t, err)
 	assert.Equal(t, expected, results)
@@ -1059,7 +1059,7 @@ func (m *badManifests) UpdateImage(def []byte, resourceID flux.ResourceID, conta
 
 func Test_BadRelease(t *testing.T) {
 	cluster := mockCluster(hwSvc)
-	spec := update.ReleaseSpec{
+	spec := update.ReleaseImageSpec{
 		ServiceSpecs: []update.ResourceSpec{update.ResourceSpecAll},
 		ImageSpec:    update.ImageSpecFromRef(newHwRef),
 		Kind:         update.ReleaseKindExecute,

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -160,7 +160,7 @@ func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.Upst
 
 	updateSpec := update.Spec{
 		Type: update.Images,
-		Spec: update.ReleaseSpec{
+		Spec: update.ReleaseImageSpec{
 			ServiceSpecs: []update.ResourceSpec{
 				update.ResourceSpecAll,
 			},

--- a/remote/rpc/compat.go
+++ b/remote/rpc/compat.go
@@ -47,7 +47,7 @@ func requireSpecKinds(s update.Spec, kinds []string) error {
 				return fmt.Errorf("Unsupported resource kind: %s", kind)
 			}
 		}
-	case update.ReleaseSpec:
+	case update.ReleaseImageSpec:
 		for _, ss := range s.ServiceSpecs {
 			if err := requireServiceSpecKinds(ss, kinds); err != nil {
 				return err

--- a/update/release_containers.go
+++ b/update/release_containers.go
@@ -15,8 +15,8 @@ import (
 
 var zeroImageRef = image.Ref{}
 
-// ContainerSpecs defines the spec for a `containers` manifest update.
-type ContainerSpecs struct {
+// ReleaseContainersSpec defines the spec for a `containers` manifest update.
+type ReleaseContainersSpec struct {
 	Kind           ReleaseKind
 	ContainerSpecs map[flux.ResourceID][]ContainerUpdate
 	SkipMismatches bool
@@ -25,7 +25,7 @@ type ContainerSpecs struct {
 
 // CalculateRelease computes required controller updates to satisfy this specification.
 // It returns an error if any spec calculation fails unless `SkipMismatches` is true.
-func (s ContainerSpecs) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*ControllerUpdate, Result, error) {
+func (s ReleaseContainersSpec) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*ControllerUpdate, Result, error) {
 	results := Result{}
 	prefilter, postfilter := s.filters()
 	all, err := rc.SelectServices(results, prefilter, postfilter)
@@ -36,7 +36,7 @@ func (s ContainerSpecs) CalculateRelease(rc ReleaseContext, logger log.Logger) (
 	return updates, results, s.resultsError(results)
 }
 
-func (s ContainerSpecs) resultsError(results Result) error {
+func (s ReleaseContainersSpec) resultsError(results Result) error {
 	failures := 0
 	successes := 0
 	for _, res := range results {
@@ -56,7 +56,7 @@ func (s ContainerSpecs) resultsError(results Result) error {
 	return nil
 }
 
-func (s ContainerSpecs) filters() ([]ControllerFilter, []ControllerFilter) {
+func (s ReleaseContainersSpec) filters() ([]ControllerFilter, []ControllerFilter) {
 	var rids []flux.ResourceID
 	for rid := range s.ContainerSpecs {
 		rids = append(rids, rid)
@@ -69,7 +69,7 @@ func (s ContainerSpecs) filters() ([]ControllerFilter, []ControllerFilter) {
 	return pre, []ControllerFilter{}
 }
 
-func (s ContainerSpecs) controllerUpdates(results Result, all []*ControllerUpdate) []*ControllerUpdate {
+func (s ReleaseContainersSpec) controllerUpdates(results Result, all []*ControllerUpdate) []*ControllerUpdate {
 	var updates []*ControllerUpdate
 	for _, u := range all {
 		cs, err := u.Controller.ContainersOrError()
@@ -157,15 +157,15 @@ func (s ContainerSpecs) controllerUpdates(results Result, all []*ControllerUpdat
 	return updates
 }
 
-func (s ContainerSpecs) ReleaseKind() ReleaseKind {
+func (s ReleaseContainersSpec) ReleaseKind() ReleaseKind {
 	return s.Kind
 }
 
-func (s ContainerSpecs) ReleaseType() ReleaseType {
+func (s ReleaseContainersSpec) ReleaseType() ReleaseType {
 	return "containers"
 }
 
-func (s ContainerSpecs) CommitMessage(result Result) string {
+func (s ReleaseContainersSpec) CommitMessage(result Result) string {
 	var workloads []string
 	body := &bytes.Buffer{}
 	for _, res := range result.AffectedResources() {

--- a/update/spec.go
+++ b/update/spec.go
@@ -49,7 +49,7 @@ func (spec *Spec) UnmarshalJSON(in []byte) error {
 		}
 		spec.Spec = update
 	case Images:
-		var update ReleaseSpec
+		var update ReleaseImageSpec
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err
 		}
@@ -67,7 +67,7 @@ func (spec *Spec) UnmarshalJSON(in []byte) error {
 		}
 		spec.Spec = update
 	case Containers:
-		var update ContainerSpecs
+		var update ReleaseContainersSpec
 		if err := json.Unmarshal(wire.SpecBytes, &update); err != nil {
 			return err
 		}


### PR DESCRIPTION
For `ReleaseEventMetadata` use spec with both types: `ReleaseImageSpec` and `ReleaseContainersSpec`.

Need this for https://github.com/weaveworks/service/issues/2277

<!--

# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the

- DCO
- contribution workflow and
- how to get your fix accepted

are important.

# News

Please consider adding an entry for either the

 - regular changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG.md or
 - helm operator changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG-helmop.md

In your PR, just add a short description of your change with a link to the
relevant discussion. (You can find CHANGELOG.md and CHANGELOG-helmop.md in the
top-level directory.)

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.

-->