### PR TITLE
Fixing link to chart's README

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -11,7 +11,7 @@ any code changes for you.
 
 If you are looking for more generic notes for how to install Flux
 using Helm, we collected them [in the chart's
-README](../../chart/flux/README.md).
+README](../chart/flux/README.md).
 
 ## Prerequisites
 


### PR DESCRIPTION
Fixed the link. I do not think this worth a Changelog entry, but I'm happy to add one, if you insist.