### PR TITLE
Improve commit message for containers releases

### DIFF
--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -871,7 +871,7 @@ func Test_UpdateContainers(t *testing.T) {
 							Target:    newSidecarRef,
 						}},
 					},
-					Commit: "Release containers\n\ndefault:deployment/helloworld\n- quay.io/weaveworks/helloworld:master-a000002\n- weaveworks/sidecar:master-a000002\n",
+					Commit: "Update image refs in default:deployment/helloworld\n\ndefault:deployment/helloworld\n- quay.io/weaveworks/helloworld:master-a000002\n- weaveworks/sidecar:master-a000002\n",
 				},
 				false: {
 					Result: update.ControllerResult{
@@ -886,7 +886,7 @@ func Test_UpdateContainers(t *testing.T) {
 							Target:    newSidecarRef,
 						}},
 					},
-					Commit: "Release containers\n\ndefault:deployment/helloworld\n- quay.io/weaveworks/helloworld:master-a000002\n- weaveworks/sidecar:master-a000002\n",
+					Commit: "Update image refs in default:deployment/helloworld\n\ndefault:deployment/helloworld\n- quay.io/weaveworks/helloworld:master-a000002\n- weaveworks/sidecar:master-a000002\n",
 				},
 			},
 		},
@@ -918,7 +918,7 @@ func Test_UpdateContainers(t *testing.T) {
 							},
 						},
 					},
-					Commit: "Release containers\n\ndefault:deployment/helloworld\n- weaveworks/sidecar:master-a000002\n",
+					Commit: "Update image refs in default:deployment/helloworld\n\ndefault:deployment/helloworld\n- weaveworks/sidecar:master-a000002\n",
 				},
 				false: {Err: errors.New("cannot satisfy specs")},
 			},
@@ -996,7 +996,7 @@ func Test_UpdateContainers(t *testing.T) {
 							},
 						},
 					},
-					Commit: "Release containers\n\ndefault:deployment/locked-service\n- quay.io/weaveworks/locked-service:2\n",
+					Commit: "Update image refs in default:deployment/locked-service\n\ndefault:deployment/locked-service\n- quay.io/weaveworks/locked-service:2\n",
 				},
 				false: {
 					Result: update.ControllerResult{
@@ -1009,7 +1009,7 @@ func Test_UpdateContainers(t *testing.T) {
 							},
 						},
 					},
-					Commit: "Release containers\n\ndefault:deployment/locked-service\n- quay.io/weaveworks/locked-service:2\n",
+					Commit: "Update image refs in default:deployment/locked-service\n\ndefault:deployment/locked-service\n- quay.io/weaveworks/locked-service:2\n",
 				},
 			},
 		},

--- a/update/containers.go
+++ b/update/containers.go
@@ -166,17 +166,18 @@ func (s ContainerSpecs) ReleaseType() ReleaseType {
 }
 
 func (s ContainerSpecs) CommitMessage(result Result) string {
-	buf := &bytes.Buffer{}
-	fmt.Fprintln(buf, "Release containers")
+	var workloads []string
+	body := &bytes.Buffer{}
 	for _, res := range result.AffectedResources() {
-		fmt.Fprintf(buf, "\n%s", res)
+		workloads = append(workloads, res.String())
+		fmt.Fprintf(body, "\n%s", res)
 		for _, upd := range result[res].PerContainer {
-			fmt.Fprintf(buf, "\n- %s", upd.Target)
+			fmt.Fprintf(body, "\n- %s", upd.Target)
 		}
-		fmt.Fprintln(buf)
+		fmt.Fprintln(body)
 	}
 	if err := result.Error(); err != "" {
-		fmt.Fprintf(buf, "\n%s", result.Error())
+		fmt.Fprintf(body, "\n%s", result.Error())
 	}
-	return buf.String()
+	return fmt.Sprintf("Update image refs in %s\n%s", strings.Join(workloads, ", "), body.String())
 }


### PR DESCRIPTION
Changes the Git commit message for containers release from

```
Release containers

default:deployment/foo
- quay.io/bar/nginx:master-d9500ad8
- quay.io/bar/logger:master-d9500ad8

default:deployment/moo
- quay.io/bar/nginx:master-d9500ad8
```

to

```
Update image refs in default:deployment/foo, default:deployment/moo

default:deployment/foo
- quay.io/bar/nginx:master-d9500ad8
- quay.io/bar/logger:master-d9500ad8

default:deployment/moo
- quay.io/bar/nginx:master-d9500ad8
```

Closes #1478