### PR TITLE
Soften the changelog requirement for PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,24 +1,17 @@
 <!--
-
 # General contribution criteria
 
 Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
 Particularly the sections about the:
-- DCO
-- contribution workflow and
-- how to get your fix accepted
 
+ - DCO;
+ - contribution workflow; and
+ - how to get your fix accepted
 
-# News
-
-Please consider adding an entry for either the
-
- - regular changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG.md or
- - helm operator changelog: https://github.com/weaveworks/flux/blob/master/CHANGELOG-helmop.md
-
-In your PR, just add a short description of your change with a link to the
-relevant discussion. (You can find CHANGELOG.md and CHANGELOG-helmop.md in the
-top-level directory.)
+To help the maintainers out when they're writing release notes, please
+try to include a sentence or two here describing your change for end
+users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
+top-level directory for examples.
 
 Particularly for ground-breaking changes and new features, it's important to
 make users and developers aware of what's changing and where those changes
@@ -27,5 +20,4 @@ were documented or discussed.
 Even for smaller changes it's useful to see things documented as well, as it
 gives everybody a chance to see at a glance what's coming up in the next
 release. It makes the life of the project maintainer a lot easier as well.
-
 -->


### PR DESCRIPTION
I'd rather people wrote their suggestion for the changelog in the PR
description, rather than including it in the commits. I end up
looking through the PRs anyway, and this way we don't have to keep a
"staging area" for the next release in the changelog.