### PR TITLE
TLS verification Helm operator

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,22 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:aec6720081aad903219cf427bb9acdefc9c440743add4d02df38ff387c69886a"
+  name = "github.com/Masterminds/sprig"
+  packages = ["."]
+  pruneopts = ""
+  revision = "15f9564e7e9cf0da02a48e0d25f12a7b83559aa6"
+  version = "v2.16.0"
+
+[[projects]]
+  digest = "1:24cff84fefa06791f78f9bc6e05c2a3a90710c81ae6b76225280daf33b267d36"
+  name = "github.com/aokoli/goutils"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3391d3790d23d03408670993e957e8f408993c34"
+  version = "v1.0.1"
+
+[[projects]]
   branch = "master"
   digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
@@ -257,6 +273,14 @@
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
+  digest = "1:5247b135b5492aa232a731acdcb52b08f32b874cb398f21ab460396eadbe866b"
+  name = "github.com/google/uuid"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
+  version = "v1.0.0"
+
+[[projects]]
   digest = "1:2a131706ff80636629ab6373f2944569b8252ecc018cda8040931b05d32e3c16"
   name = "github.com/googleapis/gnostic"
   packages = [
@@ -337,6 +361,14 @@
   ]
   pruneopts = ""
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
+
+[[projects]]
+  digest = "1:35979179658d20a73693589e67bdc3baf4dc0ef9f524b1dfd3cc55fb5f6ae384"
+  name = "github.com/huandu/xstrings"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f02667b379e2fb5916c3cda2cf31e0eb885d79f8"
+  version = "v1.2.0"
 
 [[projects]]
   digest = "1:23bc0b496ba341c6e3ba24d6358ff4a40a704d9eb5f9a3bd8e8fbd57ad869013"
@@ -701,6 +733,7 @@
     "encoding/proto",
     "grpclb/grpc_lb_v1/messages",
     "grpclog",
+    "health/grpc_health_v1",
     "internal",
     "keepalive",
     "metadata",
@@ -965,23 +998,29 @@
   revision = "b58fc7edb82e0c6ffc9b8aef61813c7261b785d4"
 
 [[projects]]
-  digest = "1:0bb3ef18f8f199bf341cab6b7de16b4b132cca2cfcbf498228a37e4c6a4a732e"
+  digest = "1:3836fc3b7c902b550b5e523ac479e957e15f6c367e3706a651e77f0d8ebefa8d"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
+    "pkg/engine",
     "pkg/helm",
     "pkg/ignore",
+    "pkg/manifest",
     "pkg/proto/hapi/chart",
     "pkg/proto/hapi/release",
     "pkg/proto/hapi/services",
     "pkg/proto/hapi/version",
+    "pkg/releaseutil",
+    "pkg/renderutil",
+    "pkg/storage/errors",
     "pkg/sympath",
     "pkg/tlsutil",
+    "pkg/urlutil",
     "pkg/version",
   ]
   pruneopts = ""
-  revision = "6af75a8fd72e2aa18a2b278cfe5c7a1c5feca7f2"
-  version = "v2.8.1"
+  revision = "2e55dbe1fdb5fdb96b75ff144a339489417b146b"
+  version = "v2.11.0"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,22 +41,6 @@
   version = "v1.4.0"
 
 [[projects]]
-  digest = "1:aec6720081aad903219cf427bb9acdefc9c440743add4d02df38ff387c69886a"
-  name = "github.com/Masterminds/sprig"
-  packages = ["."]
-  pruneopts = ""
-  revision = "15f9564e7e9cf0da02a48e0d25f12a7b83559aa6"
-  version = "v2.16.0"
-
-[[projects]]
-  digest = "1:24cff84fefa06791f78f9bc6e05c2a3a90710c81ae6b76225280daf33b267d36"
-  name = "github.com/aokoli/goutils"
-  packages = ["."]
-  pruneopts = ""
-  revision = "3391d3790d23d03408670993e957e8f408993c34"
-  version = "v1.0.1"
-
-[[projects]]
   branch = "master"
   digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
@@ -273,14 +257,6 @@
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
 
 [[projects]]
-  digest = "1:5247b135b5492aa232a731acdcb52b08f32b874cb398f21ab460396eadbe866b"
-  name = "github.com/google/uuid"
-  packages = ["."]
-  pruneopts = ""
-  revision = "d460ce9f8df2e77fb1ba55ca87fafed96c607494"
-  version = "v1.0.0"
-
-[[projects]]
   digest = "1:2a131706ff80636629ab6373f2944569b8252ecc018cda8040931b05d32e3c16"
   name = "github.com/googleapis/gnostic"
   packages = [
@@ -361,14 +337,6 @@
   ]
   pruneopts = ""
   revision = "0fb14efe8c47ae851c0034ed7a448854d3d34cf3"
-
-[[projects]]
-  digest = "1:35979179658d20a73693589e67bdc3baf4dc0ef9f524b1dfd3cc55fb5f6ae384"
-  name = "github.com/huandu/xstrings"
-  packages = ["."]
-  pruneopts = ""
-  revision = "f02667b379e2fb5916c3cda2cf31e0eb885d79f8"
-  version = "v1.2.0"
 
 [[projects]]
   digest = "1:23bc0b496ba341c6e3ba24d6358ff4a40a704d9eb5f9a3bd8e8fbd57ad869013"
@@ -806,6 +774,14 @@
   version = "kubernetes-1.11.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:0a865e7f317907161f1c2df5f270595b9d7ba09850b7eb39a2b11cc8f9a50d28"
+  name = "k8s.io/apiextensions-apiserver"
+  packages = ["pkg/features"]
+  pruneopts = ""
+  revision = "84f7c7786e298ad1479d00ff314a2cfa0006cd0c"
+
+[[projects]]
   digest = "1:b6b2fb7b4da1ac973b64534ace2299a02504f16bc7820cb48edb8ca4077183e1"
   name = "k8s.io/apimachinery"
   packages = [
@@ -857,6 +833,17 @@
   pruneopts = ""
   revision = "103fd098999dc9c0c88536f5c9ad2e5da39373ae"
   version = "kubernetes-1.11.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:307114f0d43e1f0b8ce6fba0ca3369b7270504e99fd9125a698b4ef0b6f686c6"
+  name = "k8s.io/apiserver"
+  packages = [
+    "pkg/features",
+    "pkg/util/feature",
+  ]
+  pruneopts = ""
+  revision = "f2e7e4864e403362f09eded9fb122b0f0b622c7c"
 
 [[projects]]
   digest = "1:d04779a8de7d5465e0463bd986506348de5e89677c74777f695d3145a7a8d15e"
@@ -998,29 +985,25 @@
   revision = "b58fc7edb82e0c6ffc9b8aef61813c7261b785d4"
 
 [[projects]]
-  digest = "1:3836fc3b7c902b550b5e523ac479e957e15f6c367e3706a651e77f0d8ebefa8d"
+  digest = "1:ec6534bd79f79351514d62ff48f4f547aeb53ea0c9ee45ca5594fbdfbd2fc258"
   name = "k8s.io/helm"
   packages = [
     "pkg/chartutil",
-    "pkg/engine",
     "pkg/helm",
     "pkg/ignore",
-    "pkg/manifest",
     "pkg/proto/hapi/chart",
     "pkg/proto/hapi/release",
     "pkg/proto/hapi/services",
     "pkg/proto/hapi/version",
-    "pkg/releaseutil",
-    "pkg/renderutil",
-    "pkg/storage/errors",
+    "pkg/storage/driver",
     "pkg/sympath",
     "pkg/tlsutil",
     "pkg/urlutil",
     "pkg/version",
   ]
   pruneopts = ""
-  revision = "2e55dbe1fdb5fdb96b75ff144a339489417b146b"
-  version = "v2.11.0"
+  revision = "9ad53aac42165a5fadc6c87be0dea6b115f93090"
+  version = "v2.10.0"
 
 [[projects]]
   branch = "master"
@@ -1029,6 +1012,88 @@
   packages = ["pkg/util/proto"]
   pruneopts = ""
   revision = "50ae88d24ede7b8bad68e23c805b5d3da5c8abaf"
+
+[[projects]]
+  digest = "1:89eef4670d767c8f3e520d71509f40e77698b4bc898305b6ee0220300840b788"
+  name = "k8s.io/kubernetes"
+  packages = [
+    "pkg/api/legacyscheme",
+    "pkg/api/ref",
+    "pkg/apis/admissionregistration",
+    "pkg/apis/admissionregistration/install",
+    "pkg/apis/admissionregistration/v1alpha1",
+    "pkg/apis/admissionregistration/v1beta1",
+    "pkg/apis/apps",
+    "pkg/apis/apps/install",
+    "pkg/apis/apps/v1",
+    "pkg/apis/apps/v1beta1",
+    "pkg/apis/apps/v1beta2",
+    "pkg/apis/authentication",
+    "pkg/apis/authentication/install",
+    "pkg/apis/authentication/v1",
+    "pkg/apis/authentication/v1beta1",
+    "pkg/apis/authorization",
+    "pkg/apis/authorization/install",
+    "pkg/apis/authorization/v1",
+    "pkg/apis/authorization/v1beta1",
+    "pkg/apis/autoscaling",
+    "pkg/apis/autoscaling/install",
+    "pkg/apis/autoscaling/v1",
+    "pkg/apis/autoscaling/v2beta1",
+    "pkg/apis/batch",
+    "pkg/apis/batch/install",
+    "pkg/apis/batch/v1",
+    "pkg/apis/batch/v1beta1",
+    "pkg/apis/batch/v2alpha1",
+    "pkg/apis/certificates",
+    "pkg/apis/certificates/install",
+    "pkg/apis/certificates/v1beta1",
+    "pkg/apis/componentconfig",
+    "pkg/apis/componentconfig/install",
+    "pkg/apis/componentconfig/v1alpha1",
+    "pkg/apis/core",
+    "pkg/apis/core/install",
+    "pkg/apis/core/v1",
+    "pkg/apis/events",
+    "pkg/apis/events/install",
+    "pkg/apis/events/v1beta1",
+    "pkg/apis/extensions",
+    "pkg/apis/extensions/install",
+    "pkg/apis/extensions/v1beta1",
+    "pkg/apis/networking",
+    "pkg/apis/networking/install",
+    "pkg/apis/networking/v1",
+    "pkg/apis/policy",
+    "pkg/apis/policy/install",
+    "pkg/apis/policy/v1beta1",
+    "pkg/apis/rbac",
+    "pkg/apis/rbac/install",
+    "pkg/apis/rbac/v1",
+    "pkg/apis/rbac/v1alpha1",
+    "pkg/apis/rbac/v1beta1",
+    "pkg/apis/scheduling",
+    "pkg/apis/scheduling/install",
+    "pkg/apis/scheduling/v1alpha1",
+    "pkg/apis/scheduling/v1beta1",
+    "pkg/apis/settings",
+    "pkg/apis/settings/install",
+    "pkg/apis/settings/v1alpha1",
+    "pkg/apis/storage",
+    "pkg/apis/storage/install",
+    "pkg/apis/storage/v1",
+    "pkg/apis/storage/v1alpha1",
+    "pkg/apis/storage/v1beta1",
+    "pkg/client/clientset_generated/internalclientset/scheme",
+    "pkg/client/clientset_generated/internalclientset/typed/core/internalversion",
+    "pkg/features",
+    "pkg/kubelet/apis",
+    "pkg/master/ports",
+    "pkg/util/parsers",
+    "pkg/util/pointer",
+  ]
+  pruneopts = ""
+  revision = "bf9a868e8ea3d3a8fa53cbb22f566771b3f8068b"
+  version = "v1.11.4"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "v2.11.0"
+  version = "~v2.10.0"
 
 [[constraint]]
 	name = "github.com/justinbarrick/go-k8s-portforward"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "k8s.io/helm"
-  version = "v2.8.1"
+  version = "v2.11.0"
 
 [[constraint]]
 	name = "github.com/justinbarrick/go-k8s-portforward"

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -99,7 +99,7 @@ spec:
         - --tiller-tls-verify={{ .Values.helmOperator.tls.verify }}
         - --tiller-tls-ca-cert-path=/etc/fluxd/helm-ca/ca.crt
         {{- if .Values.helmOperator.tls.hostname }}
-        - --tiler-tls-hostname={{ .Values.helmOperator.tls.hostname }}
+        - --tiller-tls-hostname={{ .Values.helmOperator.tls.hostname }}
         {{- end }}
         {{- end }}
         {{- end }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -98,6 +98,9 @@ spec:
         {{- if .Values.helmOperator.tls.verify }}
         - --tiller-tls-verify={{ .Values.helmOperator.tls.verify }}
         - --tiller-tls-ca-cert-path=/etc/fluxd/helm-ca/ca.crt
+        {{- if .Values.helmOperator.tls.hostname }}
+        - --tiler-tls-hostname={{ .Values.helmOperator.tls.hostname }}
+        {{- end }}
         {{- end }}
         {{- end }}
       {{- if .Values.helmOperator.extraEnvs }}

--- a/chart/flux/templates/helm-tls.yaml
+++ b/chart/flux/templates/helm-tls.yaml
@@ -6,6 +6,6 @@ metadata:
   name: {{ template "flux.fullname" . }}-helm-tls-ca-config
 data:
   ca.crt: |
-    {{ .Values.helmOperator.tls.caContent | indent 4 }}
+{{ .Values.helmOperator.tls.caContent | indent 4 }}
 {{- end -}}
 {{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -37,6 +37,7 @@ helmOperator:
     keyFile: "tls.key"
     certFile: "tls.crt"
     caContent: ""
+    hostname: ""
   # Override Flux git settings
   git:
     url: ""

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -177,7 +177,7 @@ func main() {
 
 	// HELM ---------------------------------------------------------------------------------
 	helmClient := fluxhelm.ClientSetup(log.With(logger, "component", "helm"), kubeClient, fluxhelm.TillerOptions{
-		IP:        *tillerIP,
+		Host:      *tillerIP,
 		Port:      *tillerPort,
 		Namespace: *tillerNamespace,
 		TLSVerify: *tillerTLSVerify,

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -42,11 +42,12 @@ var (
 	tillerPort      *string
 	tillerNamespace *string
 
-	tillerTLSVerify *bool
-	tillerTLSEnable *bool
-	tillerTLSKey    *string
-	tillerTLSCert   *string
-	tillerTLSCACert *string
+	tillerTLSVerify   *bool
+	tillerTLSEnable   *bool
+	tillerTLSKey      *string
+	tillerTLSCert     *string
+	tillerTLSCACert   *string
+	tillerTLSHostname *string
 
 	chartsSyncInterval *time.Duration
 	chartsSyncTimeout  *time.Duration
@@ -100,6 +101,7 @@ func init() {
 	tillerTLSKey = fs.String("tiller-tls-key-path", "/etc/fluxd/helm/tls.key", "Path to private key file used to communicate with the Tiller server.")
 	tillerTLSCert = fs.String("tiller-tls-cert-path", "/etc/fluxd/helm/tls.crt", "Path to certificate file used to communicate with the Tiller server.")
 	tillerTLSCACert = fs.String("tiller-tls-ca-cert-path", "", "Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled.")
+	tillerTLSHostname = fs.String("tiller-tls-hostname", "", "The server name used to verify the hostname on the returned certificates from the server.")
 
 	chartsSyncInterval = fs.Duration("charts-sync-interval", 3*time.Minute, "Interval at which to check for changed charts")
 	chartsSyncTimeout = fs.Duration("charts-sync-timeout", 1*time.Minute, "Timeout when checking for changed charts")
@@ -177,14 +179,15 @@ func main() {
 
 	// HELM ---------------------------------------------------------------------------------
 	helmClient := fluxhelm.ClientSetup(log.With(logger, "component", "helm"), kubeClient, fluxhelm.TillerOptions{
-		Host:      *tillerIP,
-		Port:      *tillerPort,
-		Namespace: *tillerNamespace,
-		TLSVerify: *tillerTLSVerify,
-		TLSEnable: *tillerTLSEnable,
-		TLSKey:    *tillerTLSKey,
-		TLSCert:   *tillerTLSCert,
-		TLSCACert: *tillerTLSCACert,
+		Host:        *tillerIP,
+		Port:        *tillerPort,
+		Namespace:   *tillerNamespace,
+		TLSVerify:   *tillerTLSVerify,
+		TLSEnable:   *tillerTLSEnable,
+		TLSKey:      *tillerTLSKey,
+		TLSCert:     *tillerTLSCert,
+		TLSCACert:   *tillerTLSCACert,
+		TLSHostname: *tillerTLSHostname,
 	})
 
 	// The status updater, to keep track the release status for each

--- a/integrations/helm/helm.go
+++ b/integrations/helm/helm.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	k8shelm "k8s.io/helm/pkg/helm"
@@ -26,7 +25,7 @@ type RepoConfig struct {
 }
 
 type TillerOptions struct {
-	IP        string
+	Host      string
 	Port      string
 	Namespace string
 	TLSVerify bool
@@ -98,26 +97,13 @@ func GetTillerVersion(cl k8shelm.Client, h string) (string, error) {
 
 // TODO ... set up based on the tiller existing in the cluster, if no ops given
 func tillerHost(kubeClient *kubernetes.Clientset, opts TillerOptions) (string, error) {
-	var ts *corev1.Service
-	var err error
-	var ip string
-	var port string
-
-	if opts.IP == "" {
-		ts, err = kubeClient.CoreV1().Services(opts.Namespace).Get("tiller-deploy", metav1.GetOptions{})
+	if opts.Host == "" || opts.Port == "" {
+		ts, err := kubeClient.CoreV1().Services(opts.Namespace).Get("tiller-deploy", metav1.GetOptions{})
 		if err != nil {
 			return "", err
 		}
-		ip = ts.Spec.ClusterIP
-		port = fmt.Sprintf("%v", ts.Spec.Ports[0].Port)
+		return fmt.Sprintf("%s.%s:%v", ts.Name, ts.Namespace, ts.Spec.Ports[0].Port), nil
 	}
 
-	if opts.IP != "" {
-		ip = opts.IP
-	}
-	if opts.Port != "" {
-		port = fmt.Sprintf("%v", opts.Port)
-	}
-
-	return fmt.Sprintf("%s:%s", ip, port), nil
+	return fmt.Sprintf("%s:%s", opts.Host, opts.Port), nil
 }

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -23,7 +23,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--tiller-tls-tls-key-path     |`/etc/fluxd/helm/tls.key`      | Path to private key file used to communicate with the Tiller server. |
 |--tiller-tls-tls-cert-path    |`/etc/fluxd/helm/tls.crt`      | Path to certificate file used to communicate with the Tiller server. |
 |--tiller-tls-tls-ca-cert-path |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled. |
-|--tiler-tls-hostname          |                               | The server name used to verify the hostname on the returned certificates from the server. |
+|--tiller-tls-hostname         |                               | The server name used to verify the hostname on the returned certificates from the Tiller server. |
 |                              |                               | **Git repo & key etc.**|
 |--git-url                     |                               | URL of git repo with Helm Charts; e.g., `ssh://git@github.com/weaveworks/flux-example`|
 |--git-branch                  | `master`                      | Branch of git repo to use for Kubernetes manifests|

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -23,6 +23,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--tiller-tls-tls-key-path     |`/etc/fluxd/helm/tls.key`      | Path to private key file used to communicate with the Tiller server. |
 |--tiller-tls-tls-cert-path    |`/etc/fluxd/helm/tls.crt`      | Path to certificate file used to communicate with the Tiller server. |
 |--tiller-tls-tls-ca-cert-path |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled. |
+|--tiler-tls-hostname          |                               | The server name used to verify the hostname on the returned certificates from the server. |
 |                              |                               | **Git repo & key etc.**|
 |--git-url                     |                               | URL of git repo with Helm Charts; e.g., `ssh://git@github.com/weaveworks/flux-example`|
 |--git-branch                  | `master`                      | Branch of git repo to use for Kubernetes manifests|

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -41,12 +41,15 @@ helm-operator requires setup and offers customization though a multitude of flag
 
 ### Installing Helm / Tiller
 
-Generate certificates for Tiller and Flux. This will provide a CA, servercerts for tiller and client certs for helm / weave flux.
+Generate certificates for Tiller and Flux. This will provide a CA, servercerts for Tiller and client certs for Helm / Weave Flux.
+
+> **Note**: When creating the certificate for Tiller the Common Name should match the hostname you are connecting to from the Helm operator.
 
 The following script can be used for that (requires [cfssl](https://github.com/cloudflare/cfssl)):
 
 ```bash
-export TILLER_HOSTNAME=tiller-server
+# TILLER_HOSTNAME=<service>.<namespace>
+export TILLER_HOSTNAME=tiller-deploy.kube-system
 export TILLER_SERVER=server
 export USER_NAME=flux-helm-operator
 
@@ -163,10 +166,11 @@ Error: transport is closing
 When providing the certificates, it should work correctly:
 
 ```bash
-helm --tls \
+helm --tls --tls-verify \
   --tls-ca-cert ./tls/ca.pem \
   --tls-cert ./tls/flux-helm-operator.pem \
   --tls-key ././tls/flux-helm-operator-key.pem \
+  --tls-hostname tiller-deploy.kube-system \
   ls
 ```
 


### PR DESCRIPTION
First off: this bug wasn't completely our fault.

The Helm docs on this subject are giving you the idea that everything is configured as it should be but are actually ignoring the TLS CA verification.

[Their example](https://docs.helm.sh/using_helm/#configuring-the-helm-client) tells you to run:

```console
$ helm ls --tls --tls-ca-cert ca.cert.pem --tls-cert helm.cert.pem --tls-key helm.key.pem
```

> This configuration sends our client-side certificate to establish identity, uses the client key for encryption, and uses the CA certificate to validate the remote Tiller's identity.

The latter is not true, to actually validate the CA provided you have to add an additional configuration flag `--tls-verify`.

If you run the command with the `--tls-verify` flag you will get an error back:

```console
# helm --tls --tls-verify --tls-ca-cert=/etc/fluxd/helm-ca/ca.crt --tls-cert=/etc/fluxd/helm/tls.crt --tls-key=/etc/fluxd/helm/tls.key ls
Error: x509: cannot validate certificate for 10.110.56.228 because it doesn't contain any IP SANs
```

This error brings you to the [troubleshooting section](https://docs.helm.sh/using_helm/#troubleshooting) on the same page:

> **If I use `--tls-verify` on the client, I get `Error: x509: cannot validate certificate for 127.0.0.1 because it doesn't contain any IP SANs`**
>
> During the TLS handshake, a target, usually provided as a hostname (e.g. example.com), is checked against the subject and subject alternative names of the certificate (i.e. hostname verficiation). However, because of the tunnel, the target is an IP address. Therefore, to validate the certificate, the IP address 127.0.0.1 must be listed as an IP subject alternative name (IP SAN) in the Tiller certificate.

The solution would be to add the cluster IP of the `tiller-deploy` service to the Tiller certificate. This quite inconvenient for our users as they don't know the cluster IP beforehand and it's likely to change over time.

**Alternative solution:**

- connections to Tiller are now made to the hostname instead of the cluster IP (`<service>.<namespace>`)
- added notes to Helm operator docs about the required Common Name configuration for the Tiller cert
- integrated `--tls-hostname` Helm client flag so user has full control over verification process

**Bonus:**

- fixed the CA cert in the Helm template

---

**Image available for testing:** `hiddeco/helm-operator:1465-tiller-tls`

---

Fixes #1465 #1475 