### PR TITLE
Minor updates to fluxctl docs

### DIFF
--- a/site/faq.md
+++ b/site/faq.md
@@ -105,7 +105,7 @@ For example, if you use the following `fluxctl` command:
 
 The image tag will be updated in the git repository upon applying the command.
 
-For more information about Flux commands see [the fluxctl docs](./using.md).
+For more information about Flux commands see [the fluxctl docs](./fluxctl.md).
 
 ### Does Flux automatically sync changes back to git?
 

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -9,12 +9,11 @@ All of the features of Flux are accessible from within
 However, `fluxctl` provides an equivalent API that can be used from
 the command line.
 
-Download the latest version of the fluxctl client
-[from github](https://github.com/weaveworks/flux/releases).
-
 The `--help` for `fluxctl` is described below.
 
 # Installing fluxctl
+
+## Mac OS
 
 If you are using a Mac and use Homebrew, you can simply run:
 
@@ -22,8 +21,24 @@ If you are using a Mac and use Homebrew, you can simply run:
 brew install fluxctl
 ```
 
-Everybody else can download the `fluxctl` binaries (Mac, Linux, Windows) from
-the [Flux release page](https://github.com/weaveworks/flux/releases).
+## Linux
+
+### Arch Linux
+
+Install the `fluxctl-bin` package [from the
+AUR](https://aur.archlinux.org/packages/fluxctl-bin/):
+
+```sh
+git clone https://aur.archlinux.org/fluxctl-bin.git
+cd fluxctl-bin
+makepkg -si
+```
+
+## Binary releases
+
+With every release of Flux, we release binaries of `fluxctl` for Mac, Linux
+and Windows. Download them from the [Flux release
+page](https://github.com/weaveworks/flux/releases).
 
 # Connecting fluxctl to the daemon
 

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -89,7 +89,7 @@ the SSH public key with:
 kubectl logs deployment/flux | grep identity.pub | cut -d '"' -f2
 ```
 
-*Note:* If you have downloaded [fluxctl](./using.md) already, you can use
+*Note:* If you have downloaded [fluxctl](./fluxctl.md) already, you can use
 `fluxctl identity` as well.
 
 In order to sync your cluster state with git you need to copy the

--- a/site/standalone-setup.md
+++ b/site/standalone-setup.md
@@ -51,7 +51,11 @@ You have two options:
 ### 1. Allow Flux to generate a key for you.
 
 If you don't specify a key to use, Flux will create one for you. Obtain
-the public key through fluxctl:
+the public key through `fluxctl`:
+
+```sh
+fluxctl identity
+```
 
 ### 2. Specify a key to use
 


### PR DESCRIPTION
 - Improve instructions on how to install `fluxctl`, add Arch Linux instructions
 - fix links in two places
 - add missing piece of text on how to get public key from `fluxctl`