### PR TITLE
Remove note about --bootstrapper=kubeadm.

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -19,9 +19,6 @@ You will need to have Kubernetes set up. To get up and running fast,
 you might want to use `minikube` or `kubeadm`. Any other Kubernetes
 setup will work as well though.
 
-*Note:* If you are using `minikube`, be sure to start the
-cluster with `--bootstrapper=kubeadm` so you are using RBAC.
-
 Download Helm:
 
 - On MacOS:


### PR DESCRIPTION
Apparently `kubeadm` is the default bootstrapper in `minikube` forabout 11 months now, let's remove the note:

  https://github.com/kubernetes/minikube/blame/ae9f4b20c7fcb7a89fc65e6eab0fb716f4d1a4ed/pkg/minikube/constants/constants.go#L119
