### PR TITLE
Fix typo in helm-get-started.md

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -159,7 +159,7 @@ kubectl -n flux logs deployment/flux -f
 
 The default sync frequency for Flux using the Helm chart is
 30 seconds. This can be tweaked easily. By observing the logs
-you can see when the change landed in in the cluster.
+you can see when the change landed in the cluster.
 
 ## Confirm the change landed
 


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

There was a double 'in' in the text, which I fixed.
