### PR TITLE
Add HelmRelease to the kinds supported in RPC

### DIFF
--- a/remote/rpc/clientV8.go
+++ b/remote/rpc/clientV8.go
@@ -27,7 +27,7 @@ type clientV8 interface {
 
 var _ clientV8 = &RPCClientV8{}
 
-var supportedKindsV8 = []string{"deployment", "daemonset", "statefulset", "cronjob", "fluxhelmrelease"}
+var supportedKindsV8 = []string{"deployment", "daemonset", "statefulset", "cronjob", "fluxhelmrelease", "helmrelease"}
 
 // NewClient creates a new rpc-backed implementation of the server.
 func NewClientV8(conn io.ReadWriteCloser) *RPCClientV8 {


### PR DESCRIPTION
The RPC client has its own explicit list of resource kinds it's happy
to deal with. This commit adds `helmrelease` (HelmRelease) to the
list, so that custom resources for the new helm operator will be
represented in API calls forwarded over RPC.
