### PR TITLE
Fix panic because of a typo

### DIFF
--- a/event/event.go
+++ b/event/event.go
@@ -266,7 +266,7 @@ func (s ReleaseSpec) IsKindExecute() (bool, error) {
 			return true, nil
 		}
 	case ReleaseContainersSpecType:
-		if s.ReleaseContainersSpec != nil && s.ReleaseImageSpec.Kind == update.ReleaseKindExecute {
+		if s.ReleaseContainersSpec != nil && s.ReleaseContainersSpec.Kind == update.ReleaseKindExecute {
 			return true, nil
 		}
 


### PR DESCRIPTION
Should be `ReleaseContainersSpec` instead of `ReleaseImageSpec`.
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
