### PR TITLE
Actually return the SyncError for controllers

### DIFF
--- a/api/v6/api.go
+++ b/api/v6/api.go
@@ -36,6 +36,7 @@ type ControllerStatus struct {
 	ReadOnly   ReadOnlyReason
 	Status     string
 	Rollout    cluster.RolloutStatus
+	SyncError  string
 	Antecedent flux.ResourceID
 	Labels     map[string]string
 	Automated  bool

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -136,12 +136,17 @@ func (d *Daemon) ListServicesWithOptions(ctx context.Context, opts v11.ListServi
 		case service.IsSystem:
 			readOnly = v6.ReadOnlySystem
 		}
+		var syncError string
+		if service.SyncError != nil {
+			syncError = service.SyncError.Error()
+		}
 		res = append(res, v6.ControllerStatus{
 			ID:         service.ID,
 			Containers: containers2containers(service.ContainersOrNil()),
 			ReadOnly:   readOnly,
 			Status:     service.Status,
 			Rollout:    service.Rollout,
+			SyncError:  syncError,
 			Antecedent: service.Antecedent,
 			Labels:     service.Labels,
 			Automated:  policies.Has(policy.Automated),


### PR DESCRIPTION
So far we only collected it but didn't pass it on in our response for
`ListServices{,WithOptions}()`.

Follow-up to #1410