### PR TITLE
Fix chart version in upgrade guide

### DIFF
--- a/site/helm-upgrading-to-beta.md
+++ b/site/helm-upgrading-to-beta.md
@@ -37,10 +37,13 @@ since the new operator will ignore them.
 
 ### Using the flux chart
 
-The chart (from v0.5.0-beta, or from this git repo) provides the
+The chart (from v0.5.0, or from this git repo) provides the
 correct arguments to the operator; to upgrade, do
 
-   helm upgrade flux --reuse-values weaveworks/flux --version 0.5.0-beta
+```bash
+helm repo update
+helm upgrade flux --reuse-values weaveworks/flux --version 0.5.0
+```
 
 The chart will leave the old custom resource definition and custom
 resources in place. You will need to replace the individual resources,

--- a/site/helm-upgrading-to-beta.md
+++ b/site/helm-upgrading-to-beta.md
@@ -40,7 +40,7 @@ since the new operator will ignore them.
 The chart (from v0.5.0, or from this git repo) provides the
 correct arguments to the operator; to upgrade, do
 
-```bash
+```sh
 helm repo update
 helm upgrade flux --reuse-values weaveworks/flux --version 0.5.0
 ```


### PR DESCRIPTION
I've changed the version to match our Helm repo and I've added the update command.
