### PR TITLE
Add `--watch` option to release command

### DIFF
--- a/cmd/fluxctl/release_cmd.go
+++ b/cmd/fluxctl/release_cmd.go
@@ -234,16 +234,16 @@ func writeRolloutStatus(service v6.ControllerStatus, verbosity int) {
 		c := service.Containers[0]
 		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%d/%d", service.ID, c.Name, c.Current.ID, service.Status, service.Rollout.Updated, service.Rollout.Desired)
 		if verbosity > 0 {
-			fmt.Fprintf(w, " (%d outdated, %d updated)", service.Rollout.Outdated, service.Rollout.Updated)
+			fmt.Fprintf(w, " (%d outdated, %d ready)", service.Rollout.Outdated, service.Rollout.Ready)
 		}
 		fmt.Fprintf(w, "\n")
 		for _, c := range service.Containers[1:] {
 			fmt.Fprintf(w, "\t%s\t%s\t\t\n", c.Name, c.Current.ID)
 		}
 	} else {
-		fmt.Fprintf(w, "%s\t\t\t%s\t%d/%d", service.ID, service.Status, service.Rollout.Ready, service.Rollout.Desired)
+		fmt.Fprintf(w, "%s\t\t\t%s\t%d/%d", service.ID, service.Status, service.Rollout.Updated, service.Rollout.Desired)
 		if verbosity > 0 {
-			fmt.Fprintf(w, " (%d outdated, %d updated)", service.Rollout.Outdated, service.Rollout.Updated)
+			fmt.Fprintf(w, " (%d outdated, %d ready)", service.Rollout.Outdated, service.Rollout.Ready)
 		}
 		fmt.Fprintf(w, "\n")
 	}


### PR DESCRIPTION
Adds a flag to `fluxctl release` to observe rollout progress during the release. Shows the numbers of pods desired, up-to-date, available, and outdated.

Note: I wasn't sure if it made sense to add a case somewhere in `release_cmd_test` for this flag, since there's no change to the release spec. Happy to add one if desired! 

Addresses #1424 
