### PR TITLE
Remove CRD hook from chart and update helm-op to v0.5.1

### DIFF
--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.8.1"
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control
 name: flux
-version: 0.5.0
+version: 0.5.1
 home: https://weave.works
 sources:
 - https://github.com/weaveworks/flux

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -73,10 +73,19 @@ weaveworks/flux
 
 #### To install Flux with the Helm operator:
 
+Apply the Helm Release CRD:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/weaveworks/flux/master/deploy-helm/flux-helm-release-crd.yaml
+```
+
+Install Flux with Helm:
+
 ```sh
 $ helm install --name flux \
 --set git.url=git@github.com:weaveworks/flux-get-started \
 --set helmOperator.create=true \
+--set helmOperator.createCRD=false \
 --namespace flux \
 weaveworks/flux
 ```
@@ -115,6 +124,7 @@ using an alternate mechanism.
     helm install \
     --name flux \
     --set helmOperator.create=true \
+    --set helmOperator.createCRD=false \
     --set git.url="git@${YOUR_GIT_HOST}:${YOUR_GIT_USER}/flux-get-started" \
     --set-string ssh.known_hosts="${KNOWN_HOSTS}" \
     --namespace flux \
@@ -132,6 +142,7 @@ using an alternate mechanism.
     helm install \
     --name flux \
     --set helmOperator.create=true \
+    --set helmOperator.createCRD=false \
     --set git.url="git@${YOUR_GIT_HOST}:${YOUR_GIT_USER}/flux-get-started" \
     --set-file ssh.known_hosts=/tmp/flux_known_hosts \
     --namespace flux \

--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -10,8 +10,6 @@ metadata:
     chart: {{ template "flux.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: flux.weave.works
   names:
@@ -80,8 +78,6 @@ metadata:
     chart: {{ template "flux.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-  annotations:
-    "helm.sh/hook": crd-install
 spec:
   group: helm.integrations.flux.weave.works
   names:

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -18,7 +18,7 @@ helmOperator:
   create: false
   createCRD: true
   repository: quay.io/weaveworks/helm-operator
-  tag: 0.5.0
+  tag: 0.5.1
   pullPolicy: IfNotPresent
   # Update dependencies for charts
   updateChartDeps: true

--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -55,6 +55,12 @@ Add the Flux repository of Weaveworks:
 helm repo add weaveworks https://weaveworks.github.io/flux
 ```
 
+Apply the Helm Release CRD:
+
+```sh
+kubectl apply -f https://raw.githubusercontent.com/weaveworks/flux/master/deploy-helm/flux-helm-release-crd.yaml
+```
+
 In this next step you install Weave Flux using `helm`. Simply
 
  1. Fork [flux-get-started](https://github.com/weaveworks/flux-get-started)
@@ -70,6 +76,7 @@ In this next step you install Weave Flux using `helm`. Simply
       ```sh
       helm upgrade -i flux \
       --set helmOperator.create=true \
+      --set helmOperator.createCRD=false \
       --set git.url=git@github.com:YOURUSER/flux-get-started \
       --namespace flux \
       weaveworks/flux

--- a/site/helm-upgrading-to-beta.md
+++ b/site/helm-upgrading-to-beta.md
@@ -42,7 +42,7 @@ correct arguments to the operator; to upgrade, do
 
 ```sh
 helm repo update
-helm upgrade flux --reuse-values weaveworks/flux --version 0.5.0
+helm upgrade flux --reuse-values --namespace=flux weaveworks/flux --version 0.5.1
 ```
 
 The chart will leave the old custom resource definition and custom


### PR DESCRIPTION
- remove the crd-install hook
- add CRD kubectl apply to install docs 

I would wait for a new helm-op release before merging this. Once this is merged and published to our Helm repo I will delete the faulty `0.5.0` release.