### PR TITLE
Reduce spam log generated by registry cache warmer

### DIFF
--- a/registry/cache/warming.go
+++ b/registry/cache/warming.go
@@ -280,7 +280,7 @@ func (w *Warmer) warm(ctx context.Context, now time.Time, logger log.Logger, id 
 	updates:
 		for _, up := range toUpdate {
 			select {
-			case <-ctxc.Done():
+			case <-ctx.Done():
 				break updates
 			case fetchers <- struct{}{}:
 			}
@@ -306,8 +306,8 @@ func (w *Warmer) warm(ctx context.Context, now time.Time, logger log.Logger, id 
 					if strings.Contains(err.Error(), "429") {
 						once.Do(func() {
 							errorLogger.Log("warn", "aborting image tag fetching due to rate limiting, will try again later")
+							cancel()
 						})
-						cancel()
 					} else {
 						errorLogger.Log("err", err, "ref", imageID)
 					}

--- a/registry/cache/warming.go
+++ b/registry/cache/warming.go
@@ -271,7 +271,6 @@ func (w *Warmer) warm(ctx context.Context, now time.Time, logger log.Logger, id 
 		// w.Burst, so limit the number of fetching goroutines to that.
 		fetchers := make(chan struct{}, w.burst)
 		awaitFetchers := &sync.WaitGroup{}
-		awaitFetchers.Add(len(toUpdate))
 
 		ctxc, cancel := context.WithCancel(ctx)
 		var once sync.Once
@@ -280,10 +279,12 @@ func (w *Warmer) warm(ctx context.Context, now time.Time, logger log.Logger, id 
 	updates:
 		for _, up := range toUpdate {
 			select {
-			case <-ctx.Done():
+			case <-ctxc.Done():
 				break updates
 			case fetchers <- struct{}{}:
 			}
+
+			awaitFetchers.Add(1)
 
 			go func(update update) {
 				defer func() { awaitFetchers.Done(); <-fetchers }()


### PR DESCRIPTION
- abort image tags fetching on HTTP 429 errors
- log the rate limit error once per image repository

Fix #1529 