### PR TITLE
Use flux-get-started repository everywhere.

### DIFF
--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -92,7 +92,7 @@ tolerations: []
 affinity: {}
 
 git:
-  # URL of git repo with Kubernetes manifests; e.g. git.url=ssh://git@github.com/weaveworks/flux-example
+  # URL of git repo with Kubernetes manifests; e.g. git.url=ssh://git@github.com/weaveworks/flux-get-started
   url: ""
   # Branch of git repo to use for Kubernetes manifests
   branch: "master"

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -79,7 +79,7 @@ func main() {
 		kubernetesKubectl = fs.String("kubernetes-kubectl", "", "Optional, explicit path to kubectl tool")
 		versionFlag       = fs.Bool("version", false, "Get version number")
 		// Git repo & key etc.
-		gitURL       = fs.String("git-url", "", "URL of git repo with Kubernetes manifests; e.g., git@github.com:weaveworks/flux-example")
+		gitURL       = fs.String("git-url", "", "URL of git repo with Kubernetes manifests; e.g., git@github.com:weaveworks/flux-get-started")
 		gitBranch    = fs.String("git-branch", "master", "branch of git repo to use for Kubernetes manifests")
 		gitPath      = fs.StringSlice("git-path", []string{}, "relative paths within the git repo to locate Kubernetes manifests")
 		gitUser      = fs.String("git-user", "Weave Flux", "username to use as git committer")

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -96,7 +96,7 @@ spec:
         - --ssh-keygen-dir=/var/fluxd/keygen
 
         # replace or remove the following URL
-        - --git-url=git@github.com:weaveworks/flux-example
+        - --git-url=git@github.com:weaveworks/flux-get-started
         - --git-branch=master
 
         # include these next two to connect to an "upstream" service

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -44,7 +44,7 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--kubernetes-kubectl    |                               | optional, explicit path to kubectl tool|
 |--version               | false                         | output the version number and exit |
 |**Git repo & key etc.** |                              ||
-|--git-url               |                               | URL of git repo with Kubernetes manifests; e.g., `git@github.com:weaveworks/flux-example`|
+|--git-url               |                               | URL of git repo with Kubernetes manifests; e.g., `git@github.com:weaveworks/flux-get-started`|
 |--git-branch            | `master`                        | branch of git repo to use for Kubernetes manifests|
 |--git-ci-skip           | false   | when set, fluxd will append `\n\n[ci skip]` to its commit messages |
 |--git-ci-skip-message   | `""`    | if provided, fluxd will append this to commit messages (overrides --git-ci-skip`) |


### PR DESCRIPTION
As a followup to #1527, I thought it'd be good to generally stop referring to `flux-example` and go with `flux-get-started` everywhere.