### PR TITLE
Add container resources requests for Flux and helm-op

### DIFF
--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -54,15 +54,10 @@ helmOperator:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  resources: {}
-    # If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    # limits:
-    #  cpu: 50m
-    #  memory: 150Mi
-    # requests:
-    #  cpu: 20m
-    #  memory: 100Mi
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
 
 rbac:
   # Specifies whether RBAC resources should be created
@@ -75,15 +70,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
-resources: {}
-  # If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #  cpu: 250m
-  #  memory: 300Mi
-  # requests:
-  #  cpu: 150m
-  #  memory: 250Mi
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
 
 nodeSelector: {}
 

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -62,6 +62,10 @@ spec:
         # and replace the tag here.
         image: quay.io/weaveworks/helm-operator:0.5.1
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
         volumeMounts:
         # Include this if you need to mount a customised known_hosts or ssh_config
         # file; you'll also need the volume declared above.

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -56,6 +56,10 @@ spec:
         # and replace the tag here.
         image: quay.io/weaveworks/flux:1.8.1
         imagePullPolicy: IfNotPresent
+        resources:
+          requests:
+            cpu: 50m
+            memory: 64Mi
         ports:
         - containerPort: 3030 # informational
         volumeMounts:


### PR DESCRIPTION
Set requests to 50m CPU and 64Mi memory to prevent Flux containers from being scheduled on exhausted nodes
