### PR TITLE
 Prevent CRD deletion on helm delete

### DIFF
--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.8.1"
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control
 name: flux
-version: 0.5.1
+version: 0.5.2
 home: https://weave.works
 sources:
 - https://github.com/weaveworks/flux

--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -10,6 +10,8 @@ metadata:
     chart: {{ template "flux.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: flux.weave.works
   names:
@@ -78,6 +80,8 @@ metadata:
     chart: {{ template "flux.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   group: helm.integrations.flux.weave.works
   names:


### PR DESCRIPTION
Hello,

If CRD were created by helm, once you delete flux, it would delete the CRD, this would cause flux to try to delete the charts while it's been terminated.

This PR makes helm do not remove CRD.

```
$ helm delete --purge flux
These resources were kept due to the resource policy:
[CustomResourceDefinition] fluxhelmreleases.helm.integrations.flux.weave.works
[CustomResourceDefinition] helmreleases.flux.weave.works

release "flux" deleted
```

I've also bumped the chart.