### PR TITLE
Helm chart: Make SSH know hosts volume optional

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -30,10 +30,12 @@ spec:
       - name: kubedir
         configMap:
           name: {{ template "flux.fullname" . }}-kube-config
+      {{- if .Values.ssh.known_hosts }}
       - name: sshdir
         configMap:
           name: {{ template "flux.fullname" . }}-ssh-config
           defaultMode: 0600
+      {{- end }}
       - name: git-key
         secret:
           {{- if .Values.git.secretName }}
@@ -56,9 +58,11 @@ spec:
           volumeMounts:
           - name: kubedir
             mountPath: /root/.kubectl
+          {{- if .Values.ssh.known_hosts }}
           - name: sshdir
             mountPath: /root/.ssh
             readOnly: true
+          {{- end }}
           - name: git-key
             mountPath: /etc/fluxd/ssh
             readOnly: true

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -30,10 +30,12 @@ spec:
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
       {{- end }}
       volumes:
+      {{- if .Values.ssh.known_hosts }}
       - name: sshdir
         configMap:
           name: {{ template "flux.fullname" . }}-ssh-config
           defaultMode: 0600
+      {{- end }}
       - name: git-key
         secret:
           {{- if .Values.helmOperator.git.secretName }}
@@ -61,10 +63,12 @@ spec:
         image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
         imagePullPolicy: {{ .Values.helmOperator.pullPolicy }}
         volumeMounts:
+        {{- if .Values.ssh.known_hosts }}
         - name: sshdir
           mountPath: /root/.ssh/known_hosts
           subPath: known_hosts
           readOnly: true
+        {{- end }}
         - name: git-key
           mountPath: /etc/fluxd/ssh
           readOnly: true

--- a/chart/flux/templates/ssh.yaml
+++ b/chart/flux/templates/ssh.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ssh.known_hosts -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,3 +14,4 @@ data:
         {{ .Values.ssh.known_hosts }}
       {{- end }}
     {{- end }}
+{{- end -}}


### PR DESCRIPTION
If no know hosts are specified don't create the ConfigMap and the readonly volumes in Flux and helm-op ref #1542 