### PR TITLE
Default to fluxctl use for getting git deploy key

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -154,10 +154,11 @@ The [configuration](#configuration) section lists all the parameters that can be
 #### Setup Git deploy
 
 At startup Flux generates a SSH key and logs the public key.
-Find the SSH public key with:
+Find the SSH public key by installing [fluxctl](../../site/fluxctl.md) and
+running:
 
 ```sh
-kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2
+fluxctl identity
 ```
 
 In order to sync your cluster state with GitHub you need to copy the public key and

--- a/chart/flux/templates/NOTES.txt
+++ b/chart/flux/templates/NOTES.txt
@@ -1,20 +1,10 @@
-1. Get the application URL by running these commands:
-{{- if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "flux.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-  echo http://$NODE_IP:$NODE_PORT
-{{- else if contains "LoadBalancer" .Values.service.type }}
-     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get svc -w {{ template "flux.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "flux.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-  echo http://$SERVICE_IP:{{ .Values.service.port }}
-{{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:3030 &
-{{- end }}
+Get the Git deploy key by either (a) running
 
-2. Get the Git deploy key by installing fluxctl
-   https://github.com/weaveworks/flux/blob/master/site/fluxctl.md#installing-fluxctl
-   and running:
+  kubectl -n {{ .Release.Namespace }} logs deployment/{{ .Release.Name }} | grep identity.pub | cut -d '"' -f2
+
+or by (b) installing fluxctl through
+https://github.com/weaveworks/flux/blob/master/site/fluxctl.md#installing-fluxctl
+and running:
+
   fluxctl identity
 

--- a/chart/flux/templates/NOTES.txt
+++ b/chart/flux/templates/NOTES.txt
@@ -13,7 +13,8 @@
   kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME 8080:3030 &
 {{- end }}
 
-2. Get the Git deploy key by running these commands:
-  export FLUX_POD=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "flux.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
-  kubectl -n {{ .Release.Namespace }} logs $FLUX_POD | grep identity.pub | cut -d '"' -f2
+2. Get the Git deploy key by installing fluxctl
+   https://github.com/weaveworks/flux/blob/master/site/fluxctl.md#installing-fluxctl
+   and running:
+  fluxctl identity
 

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -74,14 +74,12 @@ watch kubectl get pods --all-namespaces
 ## Giving write access
 
 At startup Flux generates a SSH key and logs the public key. Find
-the SSH public key with:
+the SSH public key by installing [fluxctl](./fluxctl.md) and
+runnning:
 
 ```sh
-kubectl logs deployment/flux | grep identity.pub | cut -d '"' -f2
+fluxctl identity
 ```
-
-*Note:* If you have downloaded [fluxctl](./fluxctl.md) already, you can use
-`fluxctl identity` as well.
 
 In order to sync your cluster state with git you need to copy the
 public key and create a deploy key with write access on your GitHub

--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -108,10 +108,11 @@ that you will need to add a deploy key to your fork of the
 repository.
 
 This is pretty straight-forward as Flux generates a SSH key and
-logs the public key at startup. Find the SSH public key with:
+logs the public key at startup. Find the SSH public key by
+installing [fluxctl](./fluxctl.md) and running:
 
 ```sh
-kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2
+fluxctl identity
 ```
 
 In order to sync your cluster state with git you need to copy the


### PR DESCRIPTION
For a while we gave people a set of commands to extract the git deploy key from flux logs. Now that it's gotten easier to install fluxctl (and there's lots of benefits to using it anyway), let's default to using

  "fluxctl identity"

  Closes: #1179