### PR TITLE
Git timeout Helm operator

### DIFF
--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -56,6 +56,8 @@ spec:
                     type: string
                   ref:
                     type: string
+                  timeout:
+                    type: int
               - required: ['repository', 'name', 'version']
                 properties:
                   repository:

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -1,5 +1,3 @@
-{{- $gitPollInterval := default .Values.git.pollInterval .Values.helmOperator.git.pollInterval }}
-{{- $gitTimeout := default .Values.git.timeout .Values.helmOperator.git.timeout }}
 {{- if .Values.helmOperator.create -}}
 apiVersion: apps/v1beta2
 kind: Deployment
@@ -83,8 +81,6 @@ spec:
         {{- end }}
         {{- end }}
         args:
-        - --git-poll-interval={{ $gitPollInterval }}
-        - --git-timeout={{ $gitTimeout }}
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}
         - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -49,9 +49,6 @@ var (
 	logReleaseDiffs    *bool
 	updateDependencies *bool
 
-	gitPollInterval *time.Duration
-	gitTimeout      *time.Duration
-
 	listenAddr *string
 )
 
@@ -92,9 +89,6 @@ func init() {
 	chartsSyncInterval = fs.Duration("charts-sync-interval", 3*time.Minute, "period on which to reconcile the Helm releases with HelmRelease resources")
 	logReleaseDiffs = fs.Bool("log-release-diffs", false, "log the diff when a chart release diverges; potentially insecure")
 	updateDependencies = fs.Bool("update-chart-deps", true, "Update chart dependencies before installing/upgrading a release")
-
-	gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period on which to poll for changes to the git repo")
-	gitTimeout = fs.Duration("git-timeout", 20*time.Second, "duration after which git operations time out")
 }
 
 func main() {

--- a/deploy-helm/flux-helm-release-crd.yaml
+++ b/deploy-helm/flux-helm-release-crd.yaml
@@ -47,6 +47,8 @@ spec:
                     type: string
                   ref:
                     type: string
+                  timeout:
+                    type: int
               - required: ['repository', 'name', 'version']
                 properties:
                   repository:

--- a/integrations/apis/flux.weave.works/v1beta1/types.go
+++ b/integrations/apis/flux.weave.works/v1beta1/types.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"time"
+
 	"github.com/ghodss/yaml"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -38,19 +40,30 @@ type ChartSource struct {
 }
 
 type GitChartSource struct {
-	GitURL string `json:"git"`
-	Ref    string `json:"ref"`
-	Path   string `json:"path"`
+	GitURL  string        `json:"git"`
+	Ref     string        `json:"ref"`
+	Path    string        `json:"path"`
+	Timeout time.Duration `json:"timeout"`
 }
 
 // DefaultGitRef is the ref assumed if the Ref field is not given in a GitChartSource
 const DefaultGitRef = "master"
+
+// DefaultGitTimeout is the timeout asssumed if the Timeout field is not given in a GitChartSource
+const DefaultGitTimeout = 20
 
 func (s GitChartSource) RefOrDefault() string {
 	if s.Ref == "" {
 		return DefaultGitRef
 	}
 	return s.Ref
+}
+
+func (s GitChartSource) TimeoutOrDefault() time.Duration {
+	if s.Timeout == 0 {
+		return DefaultGitTimeout
+	}
+	return s.Timeout
 }
 
 type RepoChartSource struct {

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -264,7 +264,7 @@ func mirrorName(chartSource *fluxv1beta1.GitChartSource) string {
 func (chs *ChartChangeSync) maybeMirror(fhr fluxv1beta1.HelmRelease) {
 	chartSource := fhr.Spec.ChartSource.GitChartSource
 	if chartSource != nil {
-		if ok := chs.mirrors.Mirror(mirrorName(chartSource), git.Remote{chartSource.GitURL}, git.ReadOnly); !ok {
+		if ok := chs.mirrors.Mirror(mirrorName(chartSource), git.Remote{chartSource.GitURL}, git.Timeout(chartSource.TimeoutOrDefault()*time.Second), git.ReadOnly); !ok {
 			chs.logger.Log("info", "started mirroring repo", "repo", chartSource.GitURL)
 		}
 	}

--- a/site/helm-integration.md
+++ b/site/helm-integration.md
@@ -68,12 +68,17 @@ spec:
     git: git@github.com:weaveworks/flux-get-started
     ref: master
     path: charts/ghost
+    timeout: 20
 ```
 
 In this case, the git repo will be cloned, and the chart will be
 released from the ref given (which defaults to `master`, if not
 supplied). Commits to the git repo may result in releases, if they
 update the chart at the path given.
+
+For larger git repositories you may want to increase the timeout (which
+defaults to `20` seconds when omitted) as the cloning process will take
+more time.
 
 Note that you will usually need to provide an SSH key to grant access
 to the git repository. The example deployment shows how to mount a

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -24,8 +24,6 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--tiller-tls-tls-ca-cert-path |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled. |
 |--tiller-tls-hostname         |                               | The server name used to verify the hostname on the returned certificates from the Tiller server. |
 |                              |                               | **repo chart changes** (none of these need overriding, usually) |
-|--git-timeout                 | `20 seconds`                  | duration after which git operations time out |
-|--git-poll-interval           | `5 minutes`                   | period at which to poll git repo for new commits|
 |--chartsSyncInterval          | 3*time.Minute                 | Interval at which to check for changed charts.|
 |                              |                               | **k8s-secret backed ssh keyring configuration**|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`       | Mount location of the k8s secret storing the private SSH key|


### PR DESCRIPTION
Fixes #1551 -- adds a `Timeout` field to the `HelmRelease` CRD and uses the value (default `20`) while setting up the Git mirror.

Image for testing available as `hiddeco/helm-operator:1551-git-timeout-fix`.