### PR TITLE
Include proxy env variables in git operations if set

### DIFF
--- a/git/operations.go
+++ b/git/operations.go
@@ -20,7 +20,7 @@ import (
 const trace = false
 
 // Env vars that are allowed to be inherited from the os
-var allowedEnvVars = []string{"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY"}
+var allowedEnvVars = []string{"http_proxy", "https_proxy", "no_proxy"}
 
 func config(ctx context.Context, workingDir, user, email string) error {
 	for k, v := range map[string]string{

--- a/git/operations.go
+++ b/git/operations.go
@@ -297,11 +297,9 @@ func env() []string {
 
 	// include allowed env vars from os
 	for _, k := range allowedEnvVars {
-		v, ex := os.LookupEnv(k)
-		if ex == false {
-			continue
+		if v, ok := os.LookupEnv(k); ok {
+			env = append(env, k+"="+v)
 		}
-		env = append(env, k+"="+v)
 	}
 
 	return env


### PR DESCRIPTION
Fixes #1535.

Includes proxy env variables (`http_proxy`, `https_proxy` and `no_proxy`) in Git operations if they are set.