### PR TITLE
Set flux and helm-op versions in the upgrade doc

### DIFF
--- a/site/helm-upgrading-to-beta.md
+++ b/site/helm-upgrading-to-beta.md
@@ -42,7 +42,11 @@ correct arguments to the operator; to upgrade, do
 
 ```sh
 helm repo update
-helm upgrade flux --reuse-values --namespace=flux weaveworks/flux --version 0.5.1
+
+helm upgrade flux --reuse-values \
+--set helmOperator.tag=0.5.1 \
+--namespace=flux \
+weaveworks/flux --version 0.5.1
 ```
 
 The chart will leave the old custom resource definition and custom

--- a/site/helm-upgrading-to-beta.md
+++ b/site/helm-upgrading-to-beta.md
@@ -44,6 +44,7 @@ correct arguments to the operator; to upgrade, do
 helm repo update
 
 helm upgrade flux --reuse-values \
+--set image.tag=1.8.1 \
 --set helmOperator.tag=0.5.1 \
 --namespace=flux \
 weaveworks/flux --version 0.5.1


### PR DESCRIPTION
Helm upgrade with reuse values flag will prevent flux and helm-op images from being updated, this PR adds the two image tags to the upgrade command.
