### PR TITLE
Reimplement Git timeout Helm operator

### DIFF
--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -1,4 +1,3 @@
-{{- $gitPollInterval := default .Values.git.pollInterval .Values.helmOperator.git.pollInterval }}
 {{- $gitTimeout := default .Values.git.timeout .Values.helmOperator.git.timeout }}
 {{- if .Values.helmOperator.create -}}
 apiVersion: apps/v1beta2
@@ -83,7 +82,6 @@ spec:
         {{- end }}
         {{- end }}
         args:
-        - --git-poll-interval={{ $gitPollInterval }}
         - --git-timeout={{ $gitTimeout }}
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -49,8 +49,7 @@ var (
 	logReleaseDiffs    *bool
 	updateDependencies *bool
 
-	gitPollInterval *time.Duration
-	gitTimeout      *time.Duration
+	gitTimeout *time.Duration
 
 	listenAddr *string
 )
@@ -93,8 +92,10 @@ func init() {
 	logReleaseDiffs = fs.Bool("log-release-diffs", false, "log the diff when a chart release diverges; potentially insecure")
 	updateDependencies = fs.Bool("update-chart-deps", true, "Update chart dependencies before installing/upgrading a release")
 
-	gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period on which to poll for changes to the git repo")
+	_ = fs.Duration("git-poll-interval", 0, "")
 	gitTimeout = fs.Duration("git-timeout", 20*time.Second, "duration after which git operations time out")
+
+	fs.MarkDeprecated("git-poll-interval", "no longer used; has been replaced by charts-sync-interval")
 }
 
 func main() {

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -181,7 +181,7 @@ func main() {
 	chartSync := chartsync.New(log.With(logger, "component", "chartsync"),
 		chartsync.Polling{Interval: *chartsSyncInterval},
 		chartsync.Clients{KubeClient: *kubeClient, IfClient: *ifClient},
-		rel, chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies})
+		rel, chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, GitTimeout: *gitTimeout})
 	chartSync.Run(shutdown, errc, shutdownWg)
 
 	// OPERATOR - CUSTOM RESOURCE CHANGE SYNC -----------------------------------------------

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -88,6 +88,7 @@ type Config struct {
 	ChartCache string
 	LogDiffs   bool
 	UpdateDeps bool
+	GitTimeout time.Duration
 }
 
 func (c Config) WithDefaults() Config {
@@ -264,7 +265,7 @@ func mirrorName(chartSource *fluxv1beta1.GitChartSource) string {
 func (chs *ChartChangeSync) maybeMirror(fhr fluxv1beta1.HelmRelease) {
 	chartSource := fhr.Spec.ChartSource.GitChartSource
 	if chartSource != nil {
-		if ok := chs.mirrors.Mirror(mirrorName(chartSource), git.Remote{chartSource.GitURL}, git.ReadOnly); !ok {
+		if ok := chs.mirrors.Mirror(mirrorName(chartSource), git.Remote{chartSource.GitURL}, git.Timeout(chs.config.GitTimeout), git.ReadOnly); !ok {
 			chs.logger.Log("info", "started mirroring repo", "repo", chartSource.GitURL)
 		}
 	}

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -60,16 +60,16 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--git-label             |                               | label to keep track of sync progress; overrides both --git-sync-tag and --git-notes-ref|
 |--git-sync-tag          | `flux-sync`             | tag to use to mark sync progress for this cluster (old config, still used if --git-label is not supplied)|
 |--git-notes-ref         | `flux`            | ref to use for keeping commit annotations in git notes|
-|--git-poll-interval     | `5 minutes`                 | period at which to fetch any new commits from the git repo |
-|--git-timeout           | `20 seconds`                | duration after which git operations time out |
+|--git-poll-interval     | `5m`                 | period at which to fetch any new commits from the git repo |
+|--git-timeout           | `20s`                | duration after which git operations time out |
 |**syncing**             |                             | control over how config is applied to the cluster |
-|--sync-interval         | `5 minutes`                 | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs |
+|--sync-interval         | `5m`                 | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs |
 |**registry cache**      |                               | (none of these need overriding, usually) |
 |--memcached-hostname    | `memcached` | hostname for memcached service to use for caching image metadata|
-|--memcached-timeout     | `1 second`                   | maximum time to wait before giving up on memcached requests|
+|--memcached-timeout     | `1s`                   | maximum time to wait before giving up on memcached requests|
 |--memcached-service     | `memcached`                     | SRV service used to discover memcache servers|
-|--registry-cache-expiry | `1 hour`                  | Duration to keep cached registry tag info. Must be < 1 month.|
-|--registry-poll-interval| `5 minutes`                   | period at which to poll registry for new images|
+|--registry-cache-expiry | `1h`                  | Duration to keep cached registry tag info. Must be < 1 month.|
+|--registry-poll-interval| `5m`                   | period at which to poll registry for new images|
 |--registry-rps          | `200`                           | maximum registry requests per second per host|
 |--registry-burst        | `125`      | maximum number of warmer connections to remote and memcache|
 |--registry-insecure-host| []         | registry hosts to use HTTP for (instead of HTTPS) |

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -25,7 +25,6 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--tiller-tls-hostname         |                               | The server name used to verify the hostname on the returned certificates from the Tiller server. |
 |                              |                               | **repo chart changes** (none of these need overriding, usually) |
 |--git-timeout                 | `20 seconds`                  | duration after which git operations time out |
-|--git-poll-interval           | `5 minutes`                   | period at which to poll git repo for new commits|
 |--chartsSyncInterval          | 3*time.Minute                 | Interval at which to check for changed charts.|
 |                              |                               | **k8s-secret backed ssh keyring configuration**|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`       | Mount location of the k8s secret storing the private SSH key|

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -24,10 +24,10 @@ helm-operator requires setup and offers customization though a multitude of flag
 |--tiller-tls-tls-ca-cert-path |                               | Path to CA certificate file used to validate the Tiller server. Required if tiller-tls-verify is enabled. |
 |--tiller-tls-hostname         |                               | The server name used to verify the hostname on the returned certificates from the Tiller server. |
 |                              |                               | **repo chart changes** (none of these need overriding, usually) |
-|--git-timeout                 | `20 seconds`                  | duration after which git operations time out |
-|--chartsSyncInterval          | 3*time.Minute                 | Interval at which to check for changed charts.|
+|--git-timeout                 | `20s`                         | duration after which git operations time out |
+|--chartsSyncInterval          | `3m`                          | Interval at which to check for changed charts.|
 |                              |                               | **k8s-secret backed ssh keyring configuration**|
-|--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`       | Mount location of the k8s secret storing the private SSH key|
+|--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`             | Mount location of the k8s secret storing the private SSH key|
 |--k8s-secret-data-key         | `identity`                    | Data key holding the private SSH key within the k8s secret|
 |--queueWorkerCount            |  2                            | Number of workers to process queue with Chart release jobs.|
 


### PR DESCRIPTION
Fixes #1551, supersedes #1552.

Image available for testing as `hiddeco/helm-operator:1551-git-timeout-fix-2`.