### PR TITLE
Add helm install timeout option

### DIFF
--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -107,6 +107,9 @@ spec:
             releaseName:
               type: string
               pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            timeout:
+              type: integer
+              format: int64
             chartGitPath:
               type: string
             values:

--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -35,6 +35,9 @@ spec:
             releaseName:
               type: string
               pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            timeout:
+              type: integer
+              format: int64
             valueFileSecrets:
               type: array
               items:
@@ -107,9 +110,6 @@ spec:
             releaseName:
               type: string
               pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
-            timeout:
-              type: integer
-              format: int64
             chartGitPath:
               type: string
             values:

--- a/deploy-helm/flux-helm-release-crd.yaml
+++ b/deploy-helm/flux-helm-release-crd.yaml
@@ -26,6 +26,9 @@ spec:
             releaseName:
               type: string
               pattern: "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            timeout:
+              type: integer
+              format: int64
             valueFileSecrets:
               type: array
               items:

--- a/integrations/apis/flux.weave.works/v1beta1/types.go
+++ b/integrations/apis/flux.weave.works/v1beta1/types.go
@@ -2,7 +2,7 @@ package v1beta1
 
 import (
 	"github.com/ghodss/yaml"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/helm/pkg/chartutil"
 
@@ -65,11 +65,21 @@ type RepoChartSource struct {
 // FluxHelmReleaseSpec is the spec for a FluxHelmRelease resource
 // FluxHelmReleaseSpec
 type HelmReleaseSpec struct {
-	ChartSource `json:"chart"`
-	ReleaseName string `json:"releaseName,omitempty"`
-
+	ChartSource      `json:"chart"`
+	ReleaseName      string                    `json:"releaseName,omitempty"`
 	ValueFileSecrets []v1.LocalObjectReference `json:"valueFileSecrets,omitempty"`
 	HelmValues       `json:",inline"`
+	// Install or upgrade timeout in seconds
+	// +optional
+	Timeout *int64 `json:"timeout,omitempty"`
+}
+
+// GetTimeout returns the install or upgrade timeout (defaults to 300s)
+func (r HelmRelease) GetTimeout() int64 {
+	if r.Spec.Timeout == nil {
+		return 300
+	}
+	return *r.Spec.Timeout
 }
 
 type HelmReleaseStatus struct {

--- a/integrations/apis/flux.weave.works/v1beta1/zz_generated.deepcopy.go
+++ b/integrations/apis/flux.weave.works/v1beta1/zz_generated.deepcopy.go
@@ -165,6 +165,15 @@ func (in *HelmReleaseSpec) DeepCopyInto(out *HelmReleaseSpec) {
 		copy(*out, *in)
 	}
 	in.HelmValues.DeepCopyInto(&out.HelmValues)
+	if in.Timeout != nil {
+		in, out := &in.Timeout, &out.Timeout
+		if *in == nil {
+			*out = nil
+		} else {
+			*out = new(int64)
+			**out = **in
+		}
+	}
 	return
 }
 

--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -31,12 +31,10 @@ const (
 // Release contains clients needed to provide functionality related to helm releases
 type Release struct {
 	logger log.Logger
-
 	HelmClient *k8shelm.Client
 }
 
 type Releaser interface {
-	GetCurrent() (map[string][]DeployInfo, error)
 	GetDeployedRelease(name string) (*hapi_release.Release, error)
 	Install(dir string, releaseName string, fhr flux_v1beta1.HelmRelease, action Action, opts InstallOptions) (*hapi_release.Release, error)
 }
@@ -60,7 +58,7 @@ func New(logger log.Logger, helmClient *k8shelm.Client) *Release {
 }
 
 // GetReleaseName either retrieves the release name from the Custom Resource or constructs a new one
-//  in the form : $Namespace-$CustomResourceName
+// in the form : $Namespace-$CustomResourceName
 func GetReleaseName(fhr flux_v1beta1.HelmRelease) string {
 	namespace := fhr.Namespace
 	if namespace == "" {
@@ -105,17 +103,16 @@ func (r *Release) canDelete(name string) (bool, error) {
 		"PENDING_ROLLBACK": 8,
 	*/
 	status := rls.GetInfo().GetStatus()
-	r.logger.Log("info", fmt.Sprintf("Release [%s] status: %s", name, status.Code.String()))
 	switch status.Code {
 	case 1, 4:
-		r.logger.Log("info", fmt.Sprintf("Deleting release (%s)", name))
+		r.logger.Log("info", fmt.Sprintf("Deleting release %s", name))
 		return true, nil
 	case 2:
-		r.logger.Log("info", fmt.Sprintf("Release (%s) already deleted", name))
+		r.logger.Log("info", fmt.Sprintf("Release %s already deleted", name))
 		return false, nil
 	default:
-		r.logger.Log("info", fmt.Sprintf("Release (%s) with status %s cannot be deleted", name, status.Code.String()))
-		return false, fmt.Errorf("Release (%s) with status %s cannot be deleted", name, status.Code.String())
+		r.logger.Log("info", fmt.Sprintf("Release %s with status %s cannot be deleted", name, status.Code.String()))
+		return false, fmt.Errorf("release %s with status %s cannot be deleted", name, status.Code.String())
 	}
 }
 
@@ -139,7 +136,10 @@ func (r *Release) Install(chartPath, releaseName string, fhr flux_v1beta1.HelmRe
 		return nil, fmt.Errorf("error statting path given for chart %s: %s", chartPath, err.Error())
 	}
 
-	r.logger.Log("info", "releaseName", releaseName, "action", action, "options", fmt.Sprintf("%+v", opts))
+	r.logger.Log("info", fmt.Sprintf("processing release %s", releaseName),
+		"action", fmt.Sprintf("%v", action),
+		"options", fmt.Sprintf("%+v", opts),
+		"timeout", fmt.Sprintf("%vs", fhr.GetTimeout()))
 
 	// Read values from given valueFile paths (configmaps, etc.)
 	mergedValues := chartutil.Values{}
@@ -179,12 +179,7 @@ func (r *Release) Install(chartPath, releaseName string, fhr flux_v1beta1.HelmRe
 			k8shelm.ReleaseName(releaseName),
 			k8shelm.InstallDryRun(opts.DryRun),
 			k8shelm.InstallReuseName(opts.ReuseName),
-			/*
-				helm.InstallReuseName(i.replace),
-				helm.InstallDisableHooks(i.disableHooks),
-				helm.InstallTimeout(i.timeout),
-				helm.InstallWait(i.wait)
-			*/
+			k8shelm.InstallTimeout(fhr.GetTimeout()),
 		)
 
 		if err != nil {
@@ -211,15 +206,7 @@ func (r *Release) Install(chartPath, releaseName string, fhr flux_v1beta1.HelmRe
 			chartPath,
 			k8shelm.UpdateValueOverrides(rawVals),
 			k8shelm.UpgradeDryRun(opts.DryRun),
-			/*
-				helm.UpgradeRecreate(u.recreate),
-				helm.UpgradeForce(u.force),
-				helm.UpgradeDisableHooks(u.disableHooks),
-				helm.UpgradeTimeout(u.timeout),
-				helm.ResetValues(u.resetValues),
-				helm.ReuseValues(u.reuseValues),
-				helm.UpgradeWait(u.wait))
-			*/
+			k8shelm.UpgradeTimeout(fhr.GetTimeout()),
 		)
 
 		if err != nil {
@@ -256,29 +243,6 @@ func (r *Release) Delete(name string) error {
 	return nil
 }
 
-// GetCurrent provides Chart releases (stored in tiller ConfigMaps)
-//		output:
-//						map[namespace][release name] = nil
-func (r *Release) GetCurrent() (map[string][]DeployInfo, error) {
-	response, err := r.HelmClient.ListReleases()
-	if err != nil {
-		return nil, r.logger.Log("error", err)
-	}
-	r.logger.Log("info", fmt.Sprintf("Number of Chart releases: %d\n", response.GetCount()))
-
-	relsM := make(map[string][]DeployInfo)
-	var depl []DeployInfo
-
-	for _, r := range response.GetReleases() {
-		ns := r.Namespace
-		depl = relsM[ns]
-
-		depl = append(depl, DeployInfo{Name: r.Name})
-		relsM[ns] = depl
-	}
-	return relsM, nil
-}
-
 // annotateResources annotates each of the resources created (or updated)
 // by the release so that we can spot them.
 func (r *Release) annotateResources(release *hapi_release.Release, fhr flux_v1beta1.HelmRelease) error {
@@ -299,8 +263,7 @@ func (r *Release) annotateResources(release *hapi_release.Release, fhr flux_v1be
 	return err
 }
 
-// fhrResourceID constructs a flux.ResourceID for a HelmRelease
-// resource.
+// fhrResourceID constructs a flux.ResourceID for a HelmRelease resource.
 func fhrResourceID(fhr flux_v1beta1.HelmRelease) flux.ResourceID {
 	return flux.MakeResourceID(fhr.Namespace, "HelmRelease", fhr.Name)
 }


### PR DESCRIPTION
* add timeout field to HelmRelease CRD (defaults to 300s)
* add helm release timeout to install and upgrade operations
* remove dead code from the `release` package and fix install logging

Fix: #1545

Docker Hub image for testing: `stefanprodan/helm-operator:timeout-v5`