### PR TITLE
Try to make private registry FAQ less confusing

### DIFF
--- a/site/faq.md
+++ b/site/faq.md
@@ -159,7 +159,7 @@ There are exceptions:
  - In some environments, authorisation provided by the platform is
    used instead of image pull secrets. Google Container Registry works
    this way, for example (and we have introduced a special case for it
-   so Flux will work there too). See below regarding ECR.
+   so Flux will work there too with image pull secrets). See below regarding ECR.
 
 To work around the exceptional cases, you can mount a docker config into
 the Flux container. See the argument `--docker-config` in


### PR DESCRIPTION
> In some environments, authorisation provided by the platform is
   used instead of image pull secrets. Google Container Registry works
   this way, for example (and we have introduced a special case for it
   so Flux will work there too)

This sentence drove me in the wrong direction, I thought GCR wouldn't work with `imagePullSecrets` at all while I believe the "special case for it" meant that it actually IS working with `imagePullSecrets` ... I hope my change makes things a bit clearer for others that may be confused in the same way.