### PR TITLE
Check that chart exists when updating its deps

### DIFF
--- a/integrations/helm/chartsync/deps.go
+++ b/integrations/helm/chartsync/deps.go
@@ -11,6 +11,15 @@ import (
 func updateDependencies(chartDir, helmhome string) error {
 	var hasLockFile bool
 
+	// sanity check: does the chart directory exist
+	chartInfo, err := os.Stat(chartDir)
+	switch {
+	case err != nil:
+		return err
+	case !chartInfo.IsDir():
+		return fmt.Errorf("chart path %s is not a directory", chartDir)
+	}
+
 	// check if the requirements file exists
 	reqFilePath := filepath.Join(chartDir, "requirements.yaml")
 	reqInfo, err := os.Stat(reqFilePath)


### PR DESCRIPTION
This PR fixes the CI failure that resulted from #1562 and #1561 interacting: the latter makes `updateDependencies` succeed trivially if the `requirements.yaml` file is missing, but accidentally also succeeds if the entire chart is missing. The latter tests specifically that `updateDependencies` will fail if the chart is missing.

We don't want to fail at updating chart dependencies when a chart doesn't have a requirements.yaml file (which is optional, for a chart). However, we _do_ want to fail if the chart doesn't exist in the filesystem at all.
