### PR TITLE
Use ClusterIP service name for connecting to memcached

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 0.6.0 (TBA)
+
+**Note** To fix the connectivity problems between Flux and memcached we've changed the 
+memcached service from headless to ClusterIP. This change will make the Helm upgrade fail 
+with `ClusterIP field is immutable`. 
+
+Before upgrading to 0.6.0 you have to delete the memcached headless service:
+
+```bash
+kubectl -n flux delete svc flux-memcached
+```
+
+### Improvements
+
+ - Use ClusterIP service name for connecting to memcached
+   [weaveworks/flux#1618](https://github.com/weaveworks/flux/pull/1618)
+   
 ## 0.5.2 (2018-12-20)
 
 ### Improvements

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -76,6 +76,9 @@ spec:
           - --ssh-keygen-dir=/var/fluxd/keygen
           - --k8s-secret-name={{ template "flux.fullname" . }}-git-deploy
           - --memcached-hostname={{ template "flux.fullname" . }}-memcached
+          {{- if .Values.memcached.createClusterIP }}
+          - --memcached-service=
+          {{- end }}
           - --git-url={{ .Values.git.url }}
           - --git-branch={{ .Values.git.branch }}
           - --git-path={{ .Values.git.path }}

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -60,6 +60,9 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if eq .Values.memcached.createClusterIP false }}
+  clusterIP: None
+  {{- end }}
   ports:
     - port: 11211
       targetPort: memcached

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -60,7 +60,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  clusterIP: None
   ports:
     - port: 11211
       targetPort: memcached

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -126,6 +126,7 @@ registry:
 memcached:
   repository: memcached
   tag: 1.4.25
+  createClusterIP: true
   verbose: false
   maxItemSize: 1m
   maxMemory: 64

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       labels:
         name: flux
     spec:
-      serviceAccount: flux
+      serviceAccountName: flux
       volumes:
       - name: git-key
         secret:
@@ -93,7 +93,10 @@ spec:
         # or with a different service name, you can supply these
         # following two arguments to tell fluxd how to connect to it.
         # - --memcached-hostname=memcached.default.svc.cluster.local
-        # - --memcached-service=memcached
+
+        # use the memcached ClusterIP service name by setting the
+        # memcached-service to string empty
+        - --memcached-service=
 
         # this must be supplied, and be in the tmpfs (emptyDir)
         # mounted above, for K8s >= 1.10

--- a/deploy/memcache-svc.yaml
+++ b/deploy/memcache-svc.yaml
@@ -4,9 +4,6 @@ kind: Service
 metadata:
   name: memcached
 spec:
-  # The memcache client uses DNS to get a list of memcached servers and then
-  # uses a consistent hash of the key to determine which server to pick.
-  clusterIP: None
   ports:
     - name: memcached
       port: 11211

--- a/registry/cache/memcached/memcached.go
+++ b/registry/cache/memcached/memcached.go
@@ -14,8 +14,6 @@ package memcached
 import (
 	"encoding/binary"
 	"fmt"
-	"net"
-	"sort"
 	"sync"
 	"time"
 
@@ -158,20 +156,8 @@ func (c *MemcacheClient) updateLoop(updateInterval time.Duration) {
 	}
 }
 
-// updateMemcacheServers sets a memcache server list from SRV records. SRV
-// priority & weight are ignored.
+// updateMemcacheServers sets the memcache server address using the K8s service name
 func (c *MemcacheClient) updateMemcacheServers() error {
-	_, addrs, err := net.LookupSRV(c.service, "tcp", c.hostname)
-	if err != nil {
-		return err
-	}
-	var servers []string
-	for _, srv := range addrs {
-		servers = append(servers, fmt.Sprintf("%s:%d", srv.Target, srv.Port))
-	}
-	// ServerList deterministically maps keys to _index_ of the server list.
-	// Since DNS returns records in different order each time, we sort to
-	// guarantee best possible match between nodes.
-	sort.Strings(servers)
+	servers := []string{fmt.Sprintf("%s:11211", c.hostname)}
 	return c.serverList.SetServers(servers...)
 }


### PR DESCRIPTION
- add an option to replace memcached headless service with ClusterIP in Helm chart
- make Flux use the memcached ClusterIP name instead of SRV records when the `memcached-service` is set to string empty

Fix: #1591

Test image: stefanprodan/flux:mem-v5

~~PS. This is a breaking change in the Helm chart, using the new image with the old chart will not work since the old chart deploys memcached with a headless service~~
