### PR TITLE
Native ECR auth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1163,6 +1163,7 @@
   input-imports = [
     "github.com/Masterminds/semver",
     "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/ec2metadata",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/ecr",
     "github.com/bradfitz/gomemcache/memcache",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -41,6 +41,47 @@
   version = "v1.4.0"
 
 [[projects]]
+  digest = "1:81f300bb8c779b70cdae0285c220ceb21d09b282eb7d1a07a28078dadd305f1a"
+  name = "github.com/aws/aws-sdk-go"
+  packages = [
+    "aws",
+    "aws/awserr",
+    "aws/awsutil",
+    "aws/client",
+    "aws/client/metadata",
+    "aws/corehandlers",
+    "aws/credentials",
+    "aws/credentials/ec2rolecreds",
+    "aws/credentials/endpointcreds",
+    "aws/credentials/processcreds",
+    "aws/credentials/stscreds",
+    "aws/csm",
+    "aws/defaults",
+    "aws/ec2metadata",
+    "aws/endpoints",
+    "aws/request",
+    "aws/session",
+    "aws/signer/v4",
+    "internal/ini",
+    "internal/sdkio",
+    "internal/sdkrand",
+    "internal/sdkuri",
+    "internal/shareddefaults",
+    "private/protocol",
+    "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
+    "private/protocol/query",
+    "private/protocol/query/queryutil",
+    "private/protocol/rest",
+    "private/protocol/xml/xmlutil",
+    "service/ecr",
+    "service/sts",
+  ]
+  pruneopts = ""
+  revision = "fb5f514796fc4fdc6afdcf5a675a5b2baa714b9f"
+  version = "v1.16.14"
+
+[[projects]]
   branch = "master"
   digest = "1:0c5485088ce274fac2e931c1b979f2619345097b39d91af3239977114adf0320"
   name = "github.com/beorn7/perks"
@@ -353,6 +394,13 @@
   pruneopts = ""
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
+
+[[projects]]
+  digest = "1:13fe471d0ed891e8544eddfeeb0471fd3c9f2015609a1c000aefdedf52a19d40"
+  name = "github.com/jmespath/go-jmespath"
+  packages = ["."]
+  pruneopts = ""
+  revision = "c2b33e84"
 
 [[projects]]
   digest = "1:31c6f3c4f1e15fcc24fcfc9f5f24603ff3963c56d6fa162116493b4025fb6acc"
@@ -1114,6 +1162,9 @@
   analyzer-version = 1
   input-imports = [
     "github.com/Masterminds/semver",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/ecr",
     "github.com/bradfitz/gomemcache/memcache",
     "github.com/docker/distribution",
     "github.com/docker/distribution/manifest/manifestlist",

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -266,7 +266,7 @@ func main() {
 		}
 
 		imageCreds = k8sInst.ImagesToFetch
-		if *awsRegion != "" && len(*awsRegistryIDs) > 0 {
+		{
 			awsConf := registry.AWSRegistryConfig{
 				Region:      *awsRegion,
 				RegistryIDs: *awsRegistryIDs,
@@ -277,15 +277,16 @@ func main() {
 			} else {
 				imageCreds = credsWithAWSAuth
 			}
-		}
-		if *dockerConfig != "" {
-			credsWithDefaults, err := registry.ImageCredsWithDefaults(imageCreds, *dockerConfig)
-			if err != nil {
-				logger.Log("warning", "--docker-config not used; pre-flight check failed", "err", err)
-			} else {
-				imageCreds = credsWithDefaults
+			if *dockerConfig != "" {
+				credsWithDefaults, err := registry.ImageCredsWithDefaults(imageCreds, *dockerConfig)
+				if err != nil {
+					logger.Log("warning", "--docker-config not used; pre-flight check failed", "err", err)
+				} else {
+					imageCreds = credsWithDefaults
+				}
 			}
 		}
+
 		k8s = k8sInst
 		// There is only one way we currently interpret a repo of
 		// files as manifests, and that's as Kubernetes yamels.

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -107,8 +107,8 @@ func main() {
 		registryInsecure     = fs.StringSlice("registry-insecure-host", []string{}, "use HTTP for this image registry domain (e.g., registry.cluster.local), instead of HTTPS")
 
 		// AWS authentication
-		awsRegion      = fs.String("aws-region", "", "AWS region to authenticate to, e.g., 'us-east-1'; AWS authorization needs both this, and at least one --aws-registry-id to be supplied")
-		awsRegistryIDs = fs.StringSlice("aws-registry-id", nil, "AWS ECR account ID to authenticate with (multiple values allowed)")
+		awsRegions    = fs.StringSlice("aws-region", nil, "Restrict ECR scanning to these AWS regions; if empty, ECR only in the cluster's region will be scanned")
+		awsAccountIDs = fs.StringSlice("aws-account-id", nil, "Restrict ECR scanning to these AWS account IDs; if empty, there will be no restriction")
 
 		// k8s-secret backed ssh keyring configuration
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "Name of the k8s secret used to store the private SSH key")
@@ -268,8 +268,8 @@ func main() {
 		imageCreds = k8sInst.ImagesToFetch
 		{
 			awsConf := registry.AWSRegistryConfig{
-				Region:      *awsRegion,
-				RegistryIDs: *awsRegistryIDs,
+				Regions:    *awsRegions,
+				AccountIDs: *awsAccountIDs,
 			}
 			credsWithAWSAuth, err := registry.ImageCredsWithAWSAuth(imageCreds, log.With(logger, "component", "aws"), awsConf)
 			if err != nil {

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -107,8 +107,9 @@ func main() {
 		registryInsecure     = fs.StringSlice("registry-insecure-host", []string{}, "use HTTP for this image registry domain (e.g., registry.cluster.local), instead of HTTPS")
 
 		// AWS authentication
-		registryAWSRegions    = fs.StringSlice("registry-ecr-region", nil, "Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned")
-		registryAWSAccountIDs = fs.StringSlice("registry-ecr-account-id", nil, "Restrict ECR scanning to these AWS account IDs; if empty, there will be no restriction")
+		registryAWSRegions         = fs.StringSlice("registry-ecr-region", nil, "Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned")
+		registryAWSAccountIDs      = fs.StringSlice("registry-ecr-include-id", nil, "Restrict ECR scanning to these AWS account IDs; if empty, all account IDs that aren't excluded may be scanned")
+		registryAWSBlockAccountIDs = fs.StringSlice("registry-ecr-exclude-id", []string{registry.EKS_SYSTEM_ACCOUNT}, "Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account")
 
 		// k8s-secret backed ssh keyring configuration
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "Name of the k8s secret used to store the private SSH key")
@@ -277,6 +278,7 @@ func main() {
 		awsConf := registry.AWSRegistryConfig{
 			Regions:    *registryAWSRegions,
 			AccountIDs: *registryAWSAccountIDs,
+			BlockIDs:   *registryAWSBlockAccountIDs,
 		}
 		credsWithAWSAuth, err := registry.ImageCredsWithAWSAuth(imageCreds, log.With(logger, "component", "aws"), awsConf)
 		if err != nil {

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -107,8 +107,8 @@ func main() {
 		registryInsecure     = fs.StringSlice("registry-insecure-host", []string{}, "use HTTP for this image registry domain (e.g., registry.cluster.local), instead of HTTPS")
 
 		// AWS authentication
-		awsRegions    = fs.StringSlice("aws-region", nil, "Restrict ECR scanning to these AWS regions; if empty, ECR only in the cluster's region will be scanned")
-		awsAccountIDs = fs.StringSlice("aws-account-id", nil, "Restrict ECR scanning to these AWS account IDs; if empty, there will be no restriction")
+		registryAWSRegions    = fs.StringSlice("registry-ecr-region", nil, "Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned")
+		registryAWSAccountIDs = fs.StringSlice("registry-ecr-account-id", nil, "Restrict ECR scanning to these AWS account IDs; if empty, there will be no restriction")
 
 		// k8s-secret backed ssh keyring configuration
 		k8sSecretName            = fs.String("k8s-secret-name", "flux-git-deploy", "Name of the k8s secret used to store the private SSH key")
@@ -275,8 +275,8 @@ func main() {
 	// Wrap the procedure for collecting images to scan
 	{
 		awsConf := registry.AWSRegistryConfig{
-			Regions:    *awsRegions,
-			AccountIDs: *awsAccountIDs,
+			Regions:    *registryAWSRegions,
+			AccountIDs: *registryAWSAccountIDs,
 		}
 		credsWithAWSAuth, err := registry.ImageCredsWithAWSAuth(imageCreds, log.With(logger, "component", "aws"), awsConf)
 		if err != nil {

--- a/registry/aws.go
+++ b/registry/aws.go
@@ -27,7 +27,7 @@ type AWSRegistryConfig struct {
 	RegistryIDs []string
 }
 
-func ImageCredsWithAWS(lookup func() ImageCreds, logger log.Logger, config AWSRegistryConfig) (func() ImageCreds, error) {
+func ImageCredsWithAWSAuth(lookup func() ImageCreds, logger log.Logger, config AWSRegistryConfig) (func() ImageCreds, error) {
 	awsCreds := NoCredentials()
 	var credsExpire time.Time
 

--- a/registry/aws.go
+++ b/registry/aws.go
@@ -1,0 +1,95 @@
+package registry
+
+// References:
+//  - https://github.com/bzon/ecr-k8s-secret-creator
+//  - https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/aws/aws_credentials.go
+//  - https://github.com/weaveworks/flux/pull/1455
+
+import (
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecr"
+	"github.com/go-kit/kit/log"
+)
+
+const (
+	// For recognising ECR hosts
+	ecrHostSuffix = ".amazonaws.com"
+	// How long AWS tokens remain valid
+	tokenValid = 12 * time.Hour
+)
+
+type AWSRegistryConfig struct {
+	Region      string
+	RegistryIDs []string
+}
+
+func ImageCredsWithAWS(lookup func() ImageCreds, logger log.Logger, config AWSRegistryConfig) (func() ImageCreds, error) {
+	awsCreds := NoCredentials()
+	var credsExpire time.Time
+
+	refresh := func(now time.Time) error {
+		var err error
+		awsCreds, err = fetchAWSCreds(config)
+		if err != nil {
+			// bump this along so we don't spam the log
+			credsExpire = now.Add(time.Hour)
+			return err
+		}
+		credsExpire = now.Add(tokenValid)
+		return nil
+	}
+
+	// pre-flight check
+	if err := refresh(time.Now()); err != nil {
+		return nil, err
+	}
+
+	return func() ImageCreds {
+		imageCreds := lookup()
+
+		now := time.Now()
+		if now.After(credsExpire) {
+			if err := refresh(now); err != nil {
+				logger.Log("warning", "AWS token not refreshed", "err", err)
+			}
+		}
+
+		for name, creds := range imageCreds {
+			if strings.HasSuffix(name.Domain, ecrHostSuffix) {
+				newCreds := NoCredentials()
+				newCreds.Merge(awsCreds)
+				newCreds.Merge(creds)
+				imageCreds[name] = newCreds
+			}
+		}
+		return imageCreds
+	}, nil
+}
+
+func fetchAWSCreds(config AWSRegistryConfig) (Credentials, error) {
+	sess := session.Must(session.NewSession(&aws.Config{Region: &config.Region}))
+	svc := ecr.New(sess)
+	ecrToken, err := svc.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{
+		RegistryIds: aws.StringSlice(config.RegistryIDs),
+	})
+	if err != nil {
+		return Credentials{}, err
+	}
+	auths := make(map[string]creds)
+	for _, v := range ecrToken.AuthorizationData {
+		// Remove the https prefix
+		host := strings.TrimPrefix(*v.ProxyEndpoint, "https://")
+		creds, err := parseAuth(*v.AuthorizationToken)
+		if err != nil {
+			return Credentials{}, err
+		}
+		creds.provenance = "AWS API"
+		creds.registry = host
+		auths[host] = creds
+	}
+	return Credentials{m: auths}, nil
+}

--- a/registry/aws.go
+++ b/registry/aws.go
@@ -6,6 +6,7 @@ package registry
 //  - https://github.com/weaveworks/flux/pull/1455
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -18,8 +19,12 @@ import (
 const (
 	// For recognising ECR hosts
 	ecrHostSuffix = ".amazonaws.com"
-	// How long AWS tokens remain valid
-	tokenValid = 12 * time.Hour
+	// How long AWS tokens remain valid, according to AWS docs; this
+	// is used as an upper bound, overridden by any sooner expiry
+	// returned in the API response.
+	defaultTokenValid = 12 * time.Hour
+	// how long to skip refreshing a region after we've failed
+	embargoDuration = 10 * time.Minute
 )
 
 type AWSRegistryConfig struct {
@@ -27,39 +32,83 @@ type AWSRegistryConfig struct {
 	RegistryIDs []string
 }
 
+// ECR registry URLs look like this:
+//
+//     <account-id>.dkr.ecr.<region>.amazonaws.com
+//
+// i.e., they can differ in the account ID and in the region. It's
+// possible to refer to any registry from any cluster (although, being
+// AWS, there will be a cost incurred).
+
 func ImageCredsWithAWSAuth(lookup func() ImageCreds, logger log.Logger, config AWSRegistryConfig) (func() ImageCreds, error) {
 	awsCreds := NoCredentials()
-	var credsExpire time.Time
+	// this has the expiry time from the last request made per region. We request new tokens whenever
+	//  - we don't have credentials for the particular registry URL
+	//  - the credentials have expired
+	// and when we do, we get new tokens for all account IDs in the
+	// region that we've seen. This means that credentials are
+	// fetched, and expire, per region.
+	regionExpire := map[string]time.Time{}
+	// we can get an error when refreshing the credentials; to avoid
+	// spamming the log, keep track of failed refreshes.
+	regionEmbargo := map[string]time.Time{}
 
-	refresh := func(now time.Time) error {
-		var err error
-		awsCreds, err = fetchAWSCreds(config)
+	ensureCreds := func(domain string, now time.Time) error {
+		bits := strings.Split(domain, ".")
+		if len(bits) != 6 {
+			return fmt.Errorf("AWS registry domain not in expected format <account-id>.dkr.ecr.<region>.amazonaws.com: %q", domain)
+		}
+		accountID := bits[0]
+		region := bits[3]
+
+		// if we had an error getting a token before, don't try again
+		// until the embargo has passed
+		if embargo, ok := regionEmbargo[region]; ok {
+			if embargo.After(now) {
+				return nil // i.e., fail silently
+			}
+			delete(regionEmbargo, region)
+		}
+
+		// if we don't have the entry at all, we need to get a
+		// token. NB we can't check the inverse and return early,
+		// since if the creds do exist, we need to check their expiry.
+		if c := awsCreds.credsFor(domain); c == (creds{}) {
+			goto refresh
+		}
+
+		// otherwise, check if the tokens have expired
+		if expiry, ok := regionExpire[region]; !ok || expiry.Before(now) {
+			goto refresh
+		}
+
+		// the creds exist and are before the use-by; nothing to be done.
+		return nil
+
+	refresh:
+		// unconditionally append the sought-after account, and let
+		// the AWS API figure out if it's a duplicate.
+		accountIDs := append(allAccountIDsInRegion(awsCreds.Hosts(), region), accountID)
+		logger.Log("info", "attempting to refresh auth tokens", "region", region, "account-ids", strings.Join(accountIDs, ", "))
+		regionCreds, expiry, err := fetchAWSCreds(region, accountIDs)
 		if err != nil {
-			// bump this along so we don't spam the log
-			credsExpire = now.Add(time.Hour)
+			regionEmbargo[region] = now.Add(embargoDuration)
+			logger.Log("error", "fetching credentials for AWS region", "region", region, "err", err, "embargo", embargoDuration)
 			return err
 		}
-		credsExpire = now.Add(tokenValid)
+		regionExpire[region] = expiry
+		awsCreds.Merge(regionCreds)
 		return nil
-	}
-
-	// pre-flight check
-	if err := refresh(time.Now()); err != nil {
-		return nil, err
 	}
 
 	return func() ImageCreds {
 		imageCreds := lookup()
 
-		now := time.Now()
-		if now.After(credsExpire) {
-			if err := refresh(now); err != nil {
-				logger.Log("warning", "AWS token not refreshed", "err", err)
-			}
-		}
-
 		for name, creds := range imageCreds {
 			if strings.HasSuffix(name.Domain, ecrHostSuffix) {
+				if err := ensureCreds(name.Domain, time.Now()); err != nil {
+					logger.Log("warning", "unable to ensure credentials for ECR", "domain", name.Domain, "err", err)
+				}
 				newCreds := NoCredentials()
 				newCreds.Merge(awsCreds)
 				newCreds.Merge(creds)
@@ -70,26 +119,46 @@ func ImageCredsWithAWSAuth(lookup func() ImageCreds, logger log.Logger, config A
 	}, nil
 }
 
-func fetchAWSCreds(config AWSRegistryConfig) (Credentials, error) {
-	sess := session.Must(session.NewSession(&aws.Config{Region: &config.Region}))
+func allAccountIDsInRegion(hosts []string, region string) []string {
+	var ids []string
+	// this returns a list of unique accountIDs, assuming that the input is unique hostnames
+	for _, host := range hosts {
+		bits := strings.Split(host, ".")
+		if len(bits) != 6 {
+			continue
+		}
+		if bits[3] == region {
+			ids = append(ids, bits[0])
+		}
+	}
+	return ids
+}
+
+func fetchAWSCreds(region string, accountIDs []string) (Credentials, time.Time, error) {
+	sess := session.Must(session.NewSession(&aws.Config{Region: aws.String(region)}))
 	svc := ecr.New(sess)
 	ecrToken, err := svc.GetAuthorizationToken(&ecr.GetAuthorizationTokenInput{
-		RegistryIds: aws.StringSlice(config.RegistryIDs),
+		RegistryIds: aws.StringSlice(accountIDs),
 	})
 	if err != nil {
-		return Credentials{}, err
+		return Credentials{}, time.Time{}, err
 	}
 	auths := make(map[string]creds)
+	expiry := time.Now().Add(defaultTokenValid)
 	for _, v := range ecrToken.AuthorizationData {
 		// Remove the https prefix
 		host := strings.TrimPrefix(*v.ProxyEndpoint, "https://")
 		creds, err := parseAuth(*v.AuthorizationToken)
 		if err != nil {
-			return Credentials{}, err
+			return Credentials{}, time.Time{}, err
 		}
 		creds.provenance = "AWS API"
 		creds.registry = host
 		auths[host] = creds
+		ex := *v.ExpiresAt
+		if ex.Before(expiry) {
+			expiry = ex
+		}
 	}
-	return Credentials{m: auths}, nil
+	return Credentials{m: auths}, expiry, nil
 }

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -74,6 +74,8 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--registry-burst        | `125`      | maximum number of warmer connections to remote and memcache|
 |--registry-insecure-host| []         | registry hosts to use HTTP for (instead of HTTPS) |
 |--docker-config         | `""`       | path to a Docker config file with default image registry credentials |
+|--aws-region            | `""`       | AWS region for authentication, when scanning image in ECR |
+|--aws-registry-id       | `[]`       | ECR registry ID(s) for authentication, when scanning images in ECR (multiple values allowed) |
 |**k8s-secret backed ssh keyring configuration**      |  | |
 |--k8s-secret-name       | `flux-git-deploy`               | name of the k8s secret used to store the private SSH key|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -74,8 +74,8 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--registry-burst        | `125`      | maximum number of warmer connections to remote and memcache|
 |--registry-insecure-host| []         | registry hosts to use HTTP for (instead of HTTPS) |
 |--docker-config         | `""`       | path to a Docker config file with default image registry credentials |
-|--aws-region            | `""`       | AWS region for authentication, when scanning image in ECR |
-|--aws-registry-id       | `[]`       | ECR registry ID(s) for authentication, when scanning images in ECR (multiple values allowed) |
+|--aws-region            | `[]`       | Allow these AWS regions when scanning images from ECR; defaults to the cluster region |
+|--aws-account-id        | `[]`       | Allow these account (registry) ID(s) when scanning images in ECR (multiple values allowed); empty means no restriction |
 |**k8s-secret backed ssh keyring configuration**      |  | |
 |--k8s-secret-name       | `flux-git-deploy`               | name of the k8s secret used to store the private SSH key|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -74,8 +74,8 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--registry-burst        | `125`      | maximum number of warmer connections to remote and memcache|
 |--registry-insecure-host| []         | registry hosts to use HTTP for (instead of HTTPS) |
 |--docker-config         | `""`       | path to a Docker config file with default image registry credentials |
-|--aws-region            | `[]`       | Allow these AWS regions when scanning images from ECR; defaults to the cluster region |
-|--aws-account-id        | `[]`       | Allow these account (registry) ID(s) when scanning images in ECR (multiple values allowed); empty means no restriction |
+|--registry-ecr-region   | `[]`       | Allow these AWS regions when scanning images from ECR (multiple values alllowed); defaults to the detected cluster region |
+|--registry-ecr-account-id | `[]`       | Allow these AWS account ID(s) when scanning images in ECR (multiple values allowed); empty means no restriction |
 |**k8s-secret backed ssh keyring configuration**      |  | |
 |--k8s-secret-name       | `flux-git-deploy`               | name of the k8s secret used to store the private SSH key|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -75,7 +75,8 @@ fluxd requires setup and offers customization though a multitude of flags.
 |--registry-insecure-host| []         | registry hosts to use HTTP for (instead of HTTPS) |
 |--docker-config         | `""`       | path to a Docker config file with default image registry credentials |
 |--registry-ecr-region   | `[]`       | Allow these AWS regions when scanning images from ECR (multiple values alllowed); defaults to the detected cluster region |
-|--registry-ecr-account-id | `[]`       | Allow these AWS account ID(s) when scanning images in ECR (multiple values allowed); empty means no restriction |
+|--registry-ecr-include-id | `[]`       | Include these AWS account ID(s) when scanning images in ECR (multiple values allowed); empty means allow all, unless excluded |
+|--registry-ecr-exclude-id | `[<EKS SYSTEM ACCOUNT>]` | Exclude these AWS account ID(s) when scanning ECR (multiple values allowed); defaults to the EKS system account, so system images will not be scanned |
 |**k8s-secret backed ssh keyring configuration**      |  | |
 |--k8s-secret-name       | `flux-git-deploy`               | name of the k8s secret used to store the private SSH key|
 |--k8s-secret-volume-mount-path | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key|

--- a/site/faq.md
+++ b/site/faq.md
@@ -162,8 +162,8 @@ There are exceptions:
       automatically attempt to use platform-provided credentials when
       scanning images in GCR.
     - (Amazon) Elastic Container Registry has its own authentication
-      using IAM; Flux can scan for images in ECR if you tell it which
-      region and registry ID(s) to use.
+      using IAM; Flux will use AWS credentials to scan for images in
+      ECR, if it detects them.
 
 To work around exceptional cases, you can mount a docker config into
 the Flux container. See the argument `--docker-config` in [the daemon
@@ -246,8 +246,9 @@ happen:
    if you've only just started using a particular image in a workload.
  - Flux can't get suitable credentials for the image repository. At
    present, it looks at `imagePullSecret`s attached to workloads,
-   service accounts, and a Docker config file if you mount one into the fluxd container
-   (see the [command-line usage](./daemon.md)).
+   service accounts, platform-provided credentials on GCP or AWS, and
+   a Docker config file if you mount one into the fluxd container (see
+   the [command-line usage](./daemon.md)).
  - When using images in ECR, from AWS, the IAM account used to run the
    fluxd container must have permissions to query the ECR registry or
    registries in question.

--- a/site/faq.md
+++ b/site/faq.md
@@ -157,19 +157,18 @@ There are exceptions:
  - One way of supplying credentials in Kubernetes is to put them on each
    node; Flux does not have access to those credentials.
  - In some environments, authorisation provided by the platform is
-   used instead of image pull secrets. Google Container Registry works
-   this way, for example (and we have introduced a special case for it
-   so Flux will work there too with image pull secrets). See below regarding ECR.
+   used instead of image pull secrets:
+    - Google Container Registry works this way; Flux will
+      automatically attempt to use platform-provided credentials when
+      scanning images in GCR.
+    - (Amazon) Elastic Container Registry has its own authentication
+      using IAM; Flux can scan for images in ECR if you tell it which
+      region and registry ID(s) to use.
 
-To work around the exceptional cases, you can mount a docker config into
-the Flux container. See the argument `--docker-config` in
-[the daemon arguments reference](https://github.com/weaveworks/flux/blob/master/site/daemon.md#flags).
-
-For ECR (Elastic Container Registry), the credentials supplied by the
-environment are rotated, so it's not possible to supply a file with
-credentials ahead of time. See
-[weaveworks/flux#539](https://github.com/weaveworks/flux/issues/539) for
-workarounds.
+To work around exceptional cases, you can mount a docker config into
+the Flux container. See the argument `--docker-config` in [the daemon
+arguments
+reference](https://github.com/weaveworks/flux/blob/master/site/daemon.md#flags).
 
 See also
 [Why are my images not showing up in the list of images?](#why-are-my-images-not-showing-up-in-the-list-of-images)
@@ -247,11 +246,11 @@ happen:
    if you've only just started using a particular image in a workload.
  - Flux can't get suitable credentials for the image repository. At
    present, it looks at `imagePullSecret`s attached to workloads,
-   service accounts and a Docker config file if you mount one into the fluxd container
+   service accounts, and a Docker config file if you mount one into the fluxd container
    (see the [command-line usage](./daemon.md)).
- - Flux doesn't know how to obtain registry credentials for ECR. A
-   workaround is described in
-   [weaveworks/flux#539](https://github.com/weaveworks/flux/issues/539#issuecomment-394588423)
+ - When using images in ECR, from AWS, the IAM account used to run the
+   fluxd container must have permissions to query the ECR registry or
+   registries in question.
  - Flux excludes images with no suitable manifest (linux amd64) in manifestlist
  - Flux doesn't yet understand image refs that use digests instead of
    tags; see

--- a/site/faq.md
+++ b/site/faq.md
@@ -161,9 +161,9 @@ There are exceptions:
     - Google Container Registry works this way; Flux will
       automatically attempt to use platform-provided credentials when
       scanning images in GCR.
-    - (Amazon) Elastic Container Registry has its own authentication
-      using IAM; Flux will use AWS credentials to scan for images in
-      ECR, if it detects them.
+    - Amazon Elastic Container Registry (ECR) has its own
+      authentication using IAM. If your worker nodes can read from
+      ECR, then Flux will be able to access it too.
 
 To work around exceptional cases, you can mount a docker config into
 the Flux container. See the argument `--docker-config` in [the daemon
@@ -249,9 +249,13 @@ happen:
    service accounts, platform-provided credentials on GCP or AWS, and
    a Docker config file if you mount one into the fluxd container (see
    the [command-line usage](./daemon.md)).
- - When using images in ECR, from AWS, the IAM account used to run the
-   fluxd container must have permissions to query the ECR registry or
-   registries in question.
+ - When using images in ECR, from EC2, the `NodeInstanceRole` for the
+   worker node running fluxd must have permissions to query the ECR
+   registry (or registries) in
+   question. [`eksctl`](https://github.com/weaveworks/eksctl) and
+   [`kops`](https://github.com/kubernetes/kops) (with
+   [`.iam.allowContainerRegistry=true`](https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md#iam-roles))
+   both make sure this is the case.
  - Flux excludes images with no suitable manifest (linux amd64) in manifestlist
  - Flux doesn't yet understand image refs that use digests instead of
    tags; see


### PR DESCRIPTION
Taking inspiration (and code) from #1455, this PR builds support for fetching authorization tokens into the registry credentials code.

The design is simple: it's a wrapper for ImageCreds which keeps an authentication token, refreshing when it needs to via the AWS API. This is pretty similar to `ImageCredsWithDefaults`, and is composed with that in fluxd's main.go. The arguments `--registry-ecr-region`, `--registry-ecr-include-id` and `--registry-ecr-exclude-id` control which images it will scan:

 -  region gives the region(s) that will be scanned; if empty, the cluster region will be assumed
 - include-id gives the AWS accounts (registries) to scan; if empty, any image in the allowed regions will be scanned
 - exclude-id excludes an AWS account (registry) from those to scan; it defaults to the account used for EKS "system" images (e.g., coredns), so images from there won't be scanned.

None of the arguments are necessary; the default will be "scan images from any registry in the cluster region, except the EKS system images".

If fluxd is not running on EC2 (or hasn't been rigged so that it can authenticate as an AWS user, to access ECR), the wrapper will fail to be initialised, a message will be logged, and image scanning will proceed as before.

Fixes #539.

(EDIT: update to reflect latest changes)