### PR TITLE
Continue when k8s returns Forbidden when getting resources of resourc…

### DIFF
--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -177,9 +177,18 @@ func (c *Cluster) AllControllers(namespace string) (res []cluster.Controller, er
 		for kind, resourceKind := range resourceKinds {
 			podControllers, err := resourceKind.getPodControllers(c, ns.Name)
 			if err != nil {
-				if se, ok := err.(*apierrors.StatusError); ok && se.ErrStatus.Reason == meta_v1.StatusReasonNotFound {
-					// Kind not supported by API server, skip
-					continue
+				if se, ok := err.(*apierrors.StatusError); ok {
+					switch (se.ErrStatus.Reason) {
+						case meta_v1.StatusReasonNotFound:
+							// Kind not supported by API server, skip
+							continue
+						case meta_v1.StatusReasonForbidden:
+							// K8s can return forbidden instead of not found for non super admins
+							c.logger.Log("warning", "not allowed to list resources", "err", err)
+							continue
+						default:
+							return nil, err
+					}
 				} else {
 					return nil, err
 				}
@@ -281,9 +290,18 @@ func (c *Cluster) Export() ([]byte, error) {
 		for _, resourceKind := range resourceKinds {
 			podControllers, err := resourceKind.getPodControllers(c, ns.Name)
 			if err != nil {
-				if se, ok := err.(*apierrors.StatusError); ok && se.ErrStatus.Reason == meta_v1.StatusReasonNotFound {
-					// Kind not supported by API server, skip
-					continue
+				if se, ok := err.(*apierrors.StatusError); ok {
+					switch (se.ErrStatus.Reason) {
+						case meta_v1.StatusReasonNotFound:
+							// Kind not supported by API server, skip
+							continue
+						case meta_v1.StatusReasonForbidden:
+							// K8s can return forbidden instead of not found for non super admins
+							c.logger.Log("warning", "not allowed to list resources", "err", err)
+							continue
+						default:
+							return nil, err
+					}
 				} else {
 					return nil, err
 				}


### PR DESCRIPTION
When flux is used with more restricted permissions (as is required in our kubernetes cluster) k8s will create a 403 instead of an 404 error when trying to get missing resources (such as helm resources).

This is why I would propose generating a warning but continuing with the sync process in such instances.