### PR TITLE
Allow optional memcached.securityContext

### DIFF
--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -49,6 +49,10 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.memcached.securityContext }}
+      securityContext:
+{{ toYaml . | indent 8 }}
+    {{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Allow optional memcached.securityContext in helm chart deployment template to mitigate PSP runAsNonRoot verification failure.

ie, Following value can be added if deploying on PSP enabled cluster:

```
memcached:
  securityContext:
    runAsUser: 65534
```