### PR TITLE
create minimal nsswitch.conf file in Docker image

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -37,6 +37,15 @@ ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 COPY --from=quay.io/squaremo/kubeyaml:0.5.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
+# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
+# This resolves the conflict between:
+# * fluxd using netgo for static compilation. netgo reads nsswitch.conf to mimic glibc,
+#   defaulting to prioritize DNS queries over /etc/hosts if nsswitch.conf is missing:
+#   https://github.com/golang/go/issues/22846
+# * Alpine not including a nsswitch.conf file. Since Alpine doesn't use glibc
+#   (it uses musl), maintainers argue that the need of nsswitch.conf is a Go bug:
+#   https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
+RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 COPY ./kubeconfig /root/.kube/config
 COPY ./fluxd /usr/local/bin/
 


### PR DESCRIPTION
As a result, /etc/hosts will be prioritized over DNS queries

This resolves the conflict between:
 * fluxd using netgo for static compilation. netgo reads nsswitch.conf to mimic glibc,
   defaulting to prioritize DNS queries over /etc/hosts if nsswitch.conf is missing:
   https://github.com/golang/go/issues/22846
 * Alpine not including a nsswitch.conf file. Since Alpine doesn't use glibc
   (it uses musl), maintainers argue that the need of nsswitch.conf is a Go bug:
   https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460

Fixes #1627 

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
