### PR TITLE
Allow $HOME when invoking git

### DIFF
--- a/git/operations.go
+++ b/git/operations.go
@@ -20,7 +20,7 @@ import (
 const trace = false
 
 // Env vars that are allowed to be inherited from the os
-var allowedEnvVars = []string{"http_proxy", "https_proxy", "no_proxy"}
+var allowedEnvVars = []string{"http_proxy", "https_proxy", "no_proxy", "HOME"}
 
 func config(ctx context.Context, workingDir, user, email string) error {
 	for k, v := range map[string]string{


### PR DESCRIPTION
If you want to customise how `git` works in your flux deployment, you most likely want to mount a config file under $HOME/.config/git. But we don't include HOME in the environment of the git command (which is supplied explicitly so it can include GIT_TERMINAL_PROMPT=0).
