### PR TITLE
Conditionally create the flux-helm-tls-ca-config configmap

### DIFF
--- a/CHANGELOG-helmop.md
+++ b/CHANGELOG-helmop.md
@@ -1,3 +1,22 @@
+## Version (Date)
+
+### Bug fixes
+
+  - 
+    
+### Improvements
+
+  - Only create the `flux-helm-tls-ca-config` file if `.Values.helmOperator.tls.caContent` exists.
+    Useful when doing flux upgrades but do not happen to know or want to specify 
+    the `caContent` in `values.yaml`. Otherwise, the existing caContent will be overriden with an
+    empty value. 
+    [weaveworks/flux#1649](https://github.com/weaveworks/flux/pull/1649)
+    
+
+### Thanks
+
+Thanks to
+
 ## 0.5.2 (2018-12-20)
 
 ### Bug fixes

--- a/CHANGELOG-helmop.md
+++ b/CHANGELOG-helmop.md
@@ -1,22 +1,3 @@
-## Version (Date)
-
-### Bug fixes
-
-  - 
-    
-### Improvements
-
-  - Only create the `flux-helm-tls-ca-config` file if `.Values.helmOperator.tls.caContent` exists.
-    Useful when doing flux upgrades but do not happen to know or want to specify 
-    the `caContent` in `values.yaml`. Otherwise, the existing caContent will be overriden with an
-    empty value. 
-    [weaveworks/flux#1649](https://github.com/weaveworks/flux/pull/1649)
-    
-
-### Thanks
-
-Thanks to
-
 ## 0.5.2 (2018-12-20)
 
 ### Bug fixes

--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -21,7 +21,11 @@ kubectl -n flux delete svc flux-memcached
     - Rectify error where `resources` are not `None` by default in `chart/flux/values.yaml`
     - Add more fields that are actually in `chart/flux/values.yaml`
     - Separate `replicaCount` into a flux one and `helmOperator.replicaCount` one
-
+  - Only create the `flux-helm-tls-ca-config` file if `.Values.helmOperator.tls.caContent` exists.
+    Useful when doing flux upgrades but do not happen to know or want to specify
+    the `caContent` in `values.yaml`. Otherwise, the existing caContent will be overriden with an
+    empty value.
+    [weaveworks/flux#1649](https://github.com/weaveworks/flux/pull/1649)
 
    
 ## 0.5.2 (2018-12-20)

--- a/chart/flux/templates/helm-tls.yaml
+++ b/chart/flux/templates/helm-tls.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.helmOperator.tls.enable -}}
 {{- if .Values.helmOperator.tls.verify -}}
+{{- if .Values.helmOperator.tls.caContent }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -7,5 +8,6 @@ metadata:
 data:
   ca.crt: |
 {{ .Values.helmOperator.tls.caContent | indent 4 }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/chart/flux/templates/helm-tls.yaml
+++ b/chart/flux/templates/helm-tls.yaml
@@ -1,6 +1,4 @@
-{{- if .Values.helmOperator.tls.enable -}}
-{{- if .Values.helmOperator.tls.verify -}}
-{{- if .Values.helmOperator.tls.caContent }}
+{{- if and .Values.helmOperator.tls.enable .Values.helmOperator.tls.verify .Values.helmOperator.tls.caContent -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -8,6 +6,4 @@ metadata:
 data:
   ca.crt: |
 {{ .Values.helmOperator.tls.caContent | indent 4 }}
-{{- end -}}
-{{- end -}}
 {{- end -}}


### PR DESCRIPTION
What does this commit/MR/PR do?

- Conditionally create the flux-helm-tls-ca-config configmap
- Only create the configmap if caContent actually exists

Why is this commit/MR/PR needed?

- Useful for a flux upgrade when you don't want to specify the
caContent into `values.yaml` and don't want the existing configmap
value overriden with an empty value.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
