### PR TITLE
min ver of kubernetes 1.12 specified

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -23,9 +23,9 @@ README](../chart/flux/README.md).
 
 ## Prerequisites
 
-You will need to have Kubernetes set up. To get up and running fast,
-you might want to use `minikube` or `kubeadm`. Any other Kubernetes
-setup will work as well though.
+You will need to have Kubernetes set up. Ensure you have version 1.12 or higher.
+To get up and running fast, you might want to use `minikube` or `kubeadm`.
+Any other Kubernetes setup will work as well though.
 
 Download Helm:
 


### PR DESCRIPTION
advice user to use version `1.12` or higher. It was discovered during. #1647 that version 1.10 would not work

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
