### PR TITLE
Bump go-k8s-portforward to version 1.0.2

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -410,12 +410,12 @@
   revision = "f2b4162afba35581b6d4a50d3b8f34e33c144682"
 
 [[projects]]
-  digest = "1:299e9c1586503c6b99458b97a2a53de42502b1f64e71f8ffbd577ad69cf9f82d"
+  digest = "1:3b678937c9a04e39da29326dfb9eee430cb5b889296875bcd5b2be09a9adc9a2"
   name = "github.com/justinbarrick/go-k8s-portforward"
   packages = ["."]
   pruneopts = ""
-  revision = "d39d2092197c730c96523ab78491f481860eaa89"
-  version = "v1.0.1"
+  revision = "805ce918f289eed30719aea9999413c2f95d0f33"
+  version = "v1.0.2"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -44,7 +44,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 
 [[constraint]]
   name = "github.com/justinbarrick/go-k8s-portforward"
-  version = "v1.0.1"
+  version = "v1.0.2"
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
After https://github.com/justinbarrick/go-k8s-portforward/pull/3 ,
it correctly handles multiple paths in the KUBECONFIG env variable.

Fixes #1613 

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
