### PR TITLE
Release Flux Helm chart 0.6.0

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.6.0 (TBA)
+## 0.6.0 (2019-01-14)
 
 **Note** To fix the connectivity problems between Flux and memcached we've changed the 
 memcached service from headless to ClusterIP. This change will make the Helm upgrade fail 
@@ -26,6 +26,8 @@ kubectl -n flux delete svc flux-memcached
     the `caContent` in `values.yaml`. Otherwise, the existing caContent will be overriden with an
     empty value.
     [weaveworks/flux#1649](https://github.com/weaveworks/flux/pull/1649)
+  - Add Flux AWS ECR flags
+   [weaveworks/flux#1655](https://github.com/weaveworks/flux/pull/1655)
 
    
 ## 0.5.2 (2018-12-20)

--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -27,7 +27,7 @@ kubectl -n flux delete svc flux-memcached
     empty value.
     [weaveworks/flux#1649](https://github.com/weaveworks/flux/pull/1649)
   - Add Flux AWS ECR flags
-   [weaveworks/flux#1655](https://github.com/weaveworks/flux/pull/1655)
+    [weaveworks/flux#1655](https://github.com/weaveworks/flux/pull/1655)
 
    
 ## 0.5.2 (2018-12-20)

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.8.2"
-version: 0.5.2
+appVersion: "1.9.0"
+version: 0.6.0
 kubeVersion: ">=1.9.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/weaveworks/flux
-  tag: 1.8.2
+  tag: 1.9.0
   pullPolicy: IfNotPresent
 
 service:
@@ -19,7 +19,7 @@ helmOperator:
   create: false
   createCRD: true
   repository: quay.io/weaveworks/helm-operator
-  tag: 0.5.2
+  tag: 0.5.3
   pullPolicy: IfNotPresent
   # Update dependencies for charts
   updateChartDeps: true


### PR DESCRIPTION
- bump Flux version to v1.9.0
- bump helm-op version to v0.5.3
- update chart change log