### PR TITLE
Add option to limit helm-op to a single namespace

### DIFF
--- a/CHANGELOG-helmop.md
+++ b/CHANGELOG-helmop.md
@@ -1,3 +1,10 @@
+## 0.5.4 (TBA)
+
+### Improvements
+
+ - Add option to limit the Helm operator to a single namespace
+   [weaveworks/flux#1664](https://github.com/weaveworks/flux/pull/1664)
+
 ## 0.5.3 (2019-01-14)
 
 ### Improvements

--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.1 (TBA)
+
+### Improvements
+
+ - Add option to limit the Helm operator to a single namespace
+   [weaveworks/flux#1664](https://github.com/weaveworks/flux/pull/1664)
+
 ## 0.6.0 (2019-01-14)
 
 **Note** To fix the connectivity problems between Flux and memcached we've changed the 

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -238,6 +238,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.chartsSyncInterval` | Interval at which to check for changed charts | `3m`
 | `helmOperator.extraEnvs` | Extra environment variables for the Helm operator pod | `[]`
 | `helmOperator.logReleaseDiffs` | Helm operator should log the diff when a chart release diverges (possibly insecure) | `false`
+| `helmOperator.namespace` | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched | `None`
 | `helmOperator.tillerNamespace` | Namespace in which the Tiller server can be found | `kube-system`
 | `helmOperator.tls.enable` | Enable TLS for communicating with Tiller | `false`
 | `helmOperator.tls.verify` | Verify the Tiller certificate, also enables TLS when set to true | `false`

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -238,7 +238,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.chartsSyncInterval` | Interval at which to check for changed charts | `3m`
 | `helmOperator.extraEnvs` | Extra environment variables for the Helm operator pod | `[]`
 | `helmOperator.logReleaseDiffs` | Helm operator should log the diff when a chart release diverges (possibly insecure) | `false`
-| `helmOperator.namespace` | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched | `None`
+| `helmOperator.allowNamespace` | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched | `None`
 | `helmOperator.tillerNamespace` | Namespace in which the Tiller server can be found | `kube-system`
 | `helmOperator.tls.enable` | Enable TLS for communicating with Tiller | `false`
 | `helmOperator.tls.verify` | Verify the Tiller certificate, also enables TLS when set to true | `false`

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -87,6 +87,9 @@ spec:
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}
         - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}
+        {{- if .Values.helmOperator.namespace }}
+        - --namespace={{ .Values.helmOperator.namespace }}
+        {{- end }}
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
         {{- if .Values.helmOperator.tls.enable }}
         - --tiller-tls-enable={{ .Values.helmOperator.tls.enable }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -88,7 +88,7 @@ spec:
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}
         - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}
         {{- if .Values.helmOperator.namespace }}
-        - --namespace={{ .Values.helmOperator.namespace }}
+        - --allow-namespace={{ .Values.helmOperator.allowNamespace }}
         {{- end }}
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
         {{- if .Values.helmOperator.tls.enable }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -21,6 +21,8 @@ helmOperator:
   repository: quay.io/weaveworks/helm-operator
   tag: 0.5.3
   pullPolicy: IfNotPresent
+  # Limit the operator scope to a single namespace
+  namespace:
   # Update dependencies for charts
   updateChartDeps: true
   # Log the diff when a chart release diverges

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -22,7 +22,7 @@ helmOperator:
   tag: 0.5.3
   pullPolicy: IfNotPresent
   # Limit the operator scope to a single namespace
-  namespace:
+  allowNamespace:
   # Update dependencies for charts
   updateChartDeps: true
   # Log the diff when a chart release diverges

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -173,7 +173,7 @@ func main() {
 
 	// The status updater, to keep track the release status for each
 	// HelmRelease. It runs as a separate loop for now.
-	statusUpdater := status.New(ifClient, kubeClient, helmClient)
+	statusUpdater := status.New(ifClient, kubeClient, helmClient, *namespace)
 	go statusUpdater.Loop(shutdown, log.With(logger, "component", "annotator"))
 
 	// release instance is needed during the sync of Charts changes and during the sync of HelmRelease changes

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -77,7 +77,7 @@ func init() {
 
 	kubeconfig = fs.String("kubeconfig", "", "path to a kubeconfig; required if out-of-cluster")
 	master = fs.String("master", "", "address of the Kubernetes API server; overrides any value in kubeconfig; required if out-of-cluster")
-	namespace = fs.String("namespace", "", "if set, this limits the scope to a single namespace; if not specified, all namespaces will be watched")
+	namespace = fs.String("allow-namespace", "", "if set, this limits the scope to a single namespace; if not specified, all namespaces will be watched")
 
 	listenAddr = fs.StringP("listen", "l", ":3030", "Listen address where /metrics and API will be served")
 

--- a/integrations/helm/status/status.go
+++ b/integrations/helm/status/status.go
@@ -58,7 +58,7 @@ bail:
 			break bail
 		case <-ticker.C:
 		}
-		namespaces := []string{}
+		var namespaces []string
 		if a.namespace != "" {
 			namespaces = append(namespaces, a.namespace)
 		} else {

--- a/integrations/helm/status/status.go
+++ b/integrations/helm/status/status.go
@@ -35,13 +35,15 @@ type Updater struct {
 	fluxhelm   fluxclientset.Interface
 	kube       kube.Interface
 	helmClient *helm.Client
+	namespace  string
 }
 
-func New(fhrClient fluxclientset.Interface, kubeClient kube.Interface, helmClient *helm.Client) *Updater {
+func New(fhrClient fluxclientset.Interface, kubeClient kube.Interface, helmClient *helm.Client, namespace string) *Updater {
 	return &Updater{
 		fluxhelm:   fhrClient,
 		kube:       kubeClient,
 		helmClient: helmClient,
+		namespace:  namespace,
 	}
 }
 
@@ -56,14 +58,23 @@ bail:
 			break bail
 		case <-ticker.C:
 		}
-		// Look up HelmReleases
-		namespaces, err := a.kube.CoreV1().Namespaces().List(metav1.ListOptions{})
-		if err != nil {
-			logErr = err
-			break bail
+		namespaces := []string{}
+		if a.namespace != "" {
+			namespaces = append(namespaces, a.namespace)
+		} else {
+			all, err := a.kube.CoreV1().Namespaces().List(metav1.ListOptions{})
+			if err != nil {
+				logErr = err
+				break bail
+			}
+			for _, ns := range all.Items {
+				namespaces = append(namespaces, ns.Name)
+			}
 		}
-		for _, ns := range namespaces.Items {
-			fhrClient := a.fluxhelm.FluxV1beta1().HelmReleases(ns.Name)
+
+		// Look up HelmReleases
+		for _, ns := range namespaces {
+			fhrClient := a.fluxhelm.FluxV1beta1().HelmReleases(ns)
 			fhrs, err := fhrClient.List(metav1.ListOptions{})
 			if err != nil {
 				logErr = err
@@ -80,7 +91,7 @@ bail:
 				if status.GetCode().String() != fhr.Status.ReleaseStatus {
 					err := UpdateReleaseStatus(fhrClient, fhr, releaseName, status.GetCode().String())
 					if err != nil {
-						logger.Log("namespace", ns.Name, "resource", fhr.Name, "err", err)
+						logger.Log("namespace", ns, "resource", fhr.Name, "err", err)
 						continue
 					}
 				}

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -12,6 +12,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |------------------------------|-------------------------------|---------|
 |--kubeconfig                  |                               | Path to a kubeconfig. Only required if out-of-cluster. |
 |--master                      |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster. |
+|--namespace                   |                               | If set, this limits the scope to a single namespace. if not specified, all namespaces will be watched. |
 |                              |                               | **Tiller options** |
 |--tiller-ip                   |                               | Tiller IP address. Only required if out-of-cluster. |
 |--tiller-port                 |                               | Tiller port. |

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -12,7 +12,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 |------------------------------|-------------------------------|---------|
 |--kubeconfig                  |                               | Path to a kubeconfig. Only required if out-of-cluster. |
 |--master                      |                               | The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster. |
-|--namespace                   |                               | If set, this limits the scope to a single namespace. if not specified, all namespaces will be watched. |
+|--allow-namespace             |                               | If set, this limits the scope to a single namespace. if not specified, all namespaces will be watched. |
 |                              |                               | **Tiller options** |
 |--tiller-ip                   |                               | Tiller IP address. Only required if out-of-cluster. |
 |--tiller-port                 |                               | Tiller port. |


### PR DESCRIPTION
- add namespace restriction to Kubernetes informer and chart sync component
- by default all namespaces are used 

Fix #1406
