### PR TITLE
Extend namespace filtering to all operations on namespaced resources

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -27,6 +27,7 @@ type Cluster interface {
 	// Get all of the services (optionally, from a specific namespace), excluding those
 	AllWorkloads(maybeNamespace string) ([]Workload, error)
 	SomeWorkloads([]flux.ResourceID) ([]Workload, error)
+	IsAllowedResource(flux.ResourceID) bool
 	Ping() error
 	Export() ([]byte, error)
 	Sync(SyncSet) error

--- a/cluster/kubernetes/images.go
+++ b/cluster/kubernetes/images.go
@@ -123,7 +123,7 @@ func mergeCredentials(log func(...interface{}) error,
 func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 	allImageCreds := make(registry.ImageCreds)
 
-	namespaces, err := c.getAllowedNamespaces()
+	namespaces, err := c.getAllowedAndExistingNamespaces()
 	if err != nil {
 		c.logger.Log("err", errors.Wrap(err, "getting namespaces"))
 		return allImageCreds

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -157,7 +157,7 @@ func (c *Cluster) SomeWorkloads(ids []flux.ResourceID) (res []cluster.Workload, 
 // AllWorkloads returns all workloads in allowed namespaces matching the criteria; that is, in
 // the namespace (or any namespace if that argument is empty)
 func (c *Cluster) AllWorkloads(namespace string) (res []cluster.Workload, err error) {
-	namespaces, err := c.getAllowedNamespaces()
+	namespaces, err := c.getAllowedAndExistingNamespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting namespaces")
 	}
@@ -217,7 +217,7 @@ func (c *Cluster) Ping() error {
 func (c *Cluster) Export() ([]byte, error) {
 	var config bytes.Buffer
 
-	namespaces, err := c.getAllowedNamespaces()
+	namespaces, err := c.getAllowedAndExistingNamespaces()
 	if err != nil {
 		return nil, errors.Wrap(err, "getting namespaces")
 	}
@@ -266,11 +266,11 @@ func (c *Cluster) PublicSSHKey(regenerate bool) (ssh.PublicKey, error) {
 	return publicKey, nil
 }
 
-// getAllowedNamespaces returns a list of namespaces that the Flux instance is expected
-// to have access to and can look for resources inside of.
+// getAllowedAndExistingNamespaces returns a list of existing namespaces that
+// the Flux instance is expected to have access to and can look for resources inside of.
 // It returns a list of all namespaces unless an explicit list of allowed namespaces
 // has been set on the Cluster instance.
-func (c *Cluster) getAllowedNamespaces() ([]apiv1.Namespace, error) {
+func (c *Cluster) getAllowedAndExistingNamespaces() ([]apiv1.Namespace, error) {
 	if len(c.allowedNamespaces) > 0 {
 		nsList := []apiv1.Namespace{}
 		for _, name := range c.allowedNamespaces {

--- a/cluster/kubernetes/kubernetes_test.go
+++ b/cluster/kubernetes/kubernetes_test.go
@@ -28,7 +28,7 @@ func testGetAllowedNamespaces(t *testing.T, namespace []string, expected []strin
 	client := ExtendedClient{coreClient: clientset}
 	c := NewCluster(client, nil, nil, log.NewNopLogger(), namespace, []string{})
 
-	namespaces, err := c.getAllowedNamespaces()
+	namespaces, err := c.getAllowedAndExistingNamespaces()
 	if err != nil {
 		t.Errorf("The error should be nil, not: %s", err)
 	}

--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -258,7 +258,7 @@ func (c *Cluster) getAllowedResourcesBySelector(selector string) (map[string]*ku
 func (c *Cluster) listAllowedResources(
 	namespaced bool, gvr schema.GroupVersionResource, options meta_v1.ListOptions) ([]unstructured.Unstructured, error) {
 	if !namespaced {
-		// The resource is not namespaced
+		// The resource is not namespaced, everything is allowed
 		resourceClient := c.client.dynamicClient.Resource(gvr)
 		data, err := resourceClient.List(options)
 		if err != nil {

--- a/cluster/kubernetes/sync_test.go
+++ b/cluster/kubernetes/sync_test.go
@@ -290,8 +290,8 @@ metadata:
 			panic(err)
 		}
 
-		// Now check what resources remain in the sync set
-		actual, err := kube.getGCMarkedResourcesInSyncSet("testset")
+		// Now check that the resources were created
+		actual, err := kube.getAllowedGCMarkedResourcesInSyncSet("testset")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -553,7 +553,7 @@ spec:
 		assert.NoError(t, err)
 
 		// Check that our resource-getting also sees the pre-existing resource
-		resources, err := kube.getResourcesBySelector("")
+		resources, err := kube.getAllowedResourcesBySelector("")
 		assert.NoError(t, err)
 		assert.Contains(t, resources, "foobar:deployment/dep1")
 

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -10,15 +10,16 @@ import (
 
 // Doubles as a cluster.Cluster and cluster.Manifests implementation
 type Mock struct {
-	AllWorkloadsFunc   func(maybeNamespace string) ([]Workload, error)
-	SomeWorkloadsFunc  func([]flux.ResourceID) ([]Workload, error)
-	PingFunc           func() error
-	ExportFunc         func() ([]byte, error)
-	SyncFunc           func(SyncSet) error
-	PublicSSHKeyFunc   func(regenerate bool) (ssh.PublicKey, error)
-	UpdateImageFunc    func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
-	LoadManifestsFunc  func(base string, paths []string) (map[string]resource.Resource, error)
-	UpdatePoliciesFunc func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
+	AllWorkloadsFunc      func(maybeNamespace string) ([]Workload, error)
+	SomeWorkloadsFunc     func([]flux.ResourceID) ([]Workload, error)
+	IsAllowedResourceFunc func(flux.ResourceID) bool
+	PingFunc              func() error
+	ExportFunc            func() ([]byte, error)
+	SyncFunc              func(SyncSet) error
+	PublicSSHKeyFunc      func(regenerate bool) (ssh.PublicKey, error)
+	UpdateImageFunc       func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
+	LoadManifestsFunc     func(base string, paths []string) (map[string]resource.Resource, error)
+	UpdatePoliciesFunc    func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
 }
 
 func (m *Mock) AllWorkloads(maybeNamespace string) ([]Workload, error) {
@@ -27,6 +28,10 @@ func (m *Mock) AllWorkloads(maybeNamespace string) ([]Workload, error) {
 
 func (m *Mock) SomeWorkloads(s []flux.ResourceID) ([]Workload, error) {
 	return m.SomeWorkloadsFunc(s)
+}
+
+func (m *Mock) IsAllowedResource(id flux.ResourceID) bool {
+	return m.IsAllowedResourceFunc(id)
 }
 
 func (m *Mock) Ping() error {

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -377,6 +377,11 @@ func (d *Daemon) updatePolicy(spec update.Spec, updates policy.Updates) updateFu
 		var anythingAutomated bool
 
 		for workloadID, u := range updates {
+			if d.Cluster.IsAllowedResource(workloadID) {
+				result.Result[workloadID] = update.WorkloadResult{
+					Status: update.ReleaseStatusSkipped,
+				}
+			}
 			if policy.Set(u.Add).Has(policy.Automated) {
 				anythingAutomated = true
 			}
@@ -707,7 +712,7 @@ func policyEvents(us policy.Updates, now time.Time) map[string]event.Event {
 // policyEventTypes is a deduped list of all event types this update contains
 func policyEventTypes(u policy.Update) []string {
 	types := map[string]struct{}{}
-	for p, _ := range u.Add {
+	for p := range u.Add {
 		switch {
 		case p == policy.Automated:
 			types[event.EventAutomate] = struct{}{}
@@ -718,7 +723,7 @@ func policyEventTypes(u policy.Update) []string {
 		}
 	}
 
-	for p, _ := range u.Remove {
+	for p := range u.Remove {
 		switch {
 		case p == policy.Automated:
 			types[event.EventDeautomate] = struct{}{}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -693,6 +693,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 			}
 			return []cluster.Workload{}, nil
 		}
+		k8s.IsAllowedResourceFunc = func(flux.ResourceID) bool { return true }
 		k8s.ExportFunc = func() ([]byte, error) { return testBytes, nil }
 		k8s.PingFunc = func() error { return nil }
 		k8s.SomeWorkloadsFunc = func([]flux.ResourceID) ([]cluster.Workload, error) {

--- a/release/context.go
+++ b/release/context.go
@@ -82,11 +82,11 @@ func (rc *ReleaseContext) SelectWorkloads(results update.Result, prefilters, pos
 	for _, s := range allDefined {
 		res := s.Filter(prefilters...)
 		if res.Error == "" {
-			// Give these a default value, in case we don't find them
+			// Give these a default value, in case we cannot access them
 			// in the cluster.
 			results[s.ResourceID] = update.WorkloadResult{
 				Status: update.ReleaseStatusSkipped,
-				Error:  update.NotInCluster,
+				Error:  update.NotAccessibleInCluster,
 			}
 			toAskClusterAbout = append(toAskClusterAbout, s.ResourceID)
 		} else {

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -180,7 +180,7 @@ var ignoredNotInRepo = update.WorkloadResult{
 
 var ignoredNotInCluster = update.WorkloadResult{
 	Status: update.ReleaseStatusIgnored,
-	Error:  update.NotInCluster,
+	Error:  update.NotAccessibleInCluster,
 }
 
 var skippedLocked = update.WorkloadResult{
@@ -190,7 +190,7 @@ var skippedLocked = update.WorkloadResult{
 
 var skippedNotInCluster = update.WorkloadResult{
 	Status: update.ReleaseStatusSkipped,
-	Error:  update.NotInCluster,
+	Error:  update.NotAccessibleInCluster,
 }
 
 var skippedNotInRepo = update.WorkloadResult{
@@ -238,7 +238,7 @@ func Test_InitContainer(t *testing.T) {
 			initWorkloadID: update.WorkloadResult{
 				Status: update.ReleaseStatusSuccess,
 				PerContainer: []update.ContainerUpdate{
-					update.ContainerUpdate{
+					{
 						Container: helloContainer,
 						Current:   oldRef,
 						Target:    newHwRef,
@@ -292,12 +292,12 @@ func Test_FilterLogic(t *testing.T) {
 					flux.MustParseResourceID("default:deployment/helloworld"): update.WorkloadResult{
 						Status: update.ReleaseStatusSuccess,
 						PerContainer: []update.ContainerUpdate{
-							update.ContainerUpdate{
+							{
 								Container: helloContainer,
 								Current:   oldRef,
 								Target:    newHwRef,
 							},
-							update.ContainerUpdate{
+							{
 								Container: sidecarContainer,
 								Current:   sidecarRef,
 								Target:    newSidecarRef,
@@ -320,12 +320,12 @@ func Test_FilterLogic(t *testing.T) {
 					flux.MustParseResourceID("default:deployment/helloworld"): update.WorkloadResult{
 						Status: update.ReleaseStatusSuccess,
 						PerContainer: []update.ContainerUpdate{
-							update.ContainerUpdate{
+							{
 								Container: helloContainer,
 								Current:   oldRef,
 								Target:    newHwRef,
 							},
-							update.ContainerUpdate{
+							{
 								Container: sidecarContainer,
 								Current:   sidecarRef,
 								Target:    newSidecarRef,
@@ -352,7 +352,7 @@ func Test_FilterLogic(t *testing.T) {
 					flux.MustParseResourceID("default:deployment/helloworld"): update.WorkloadResult{
 						Status: update.ReleaseStatusSuccess,
 						PerContainer: []update.ContainerUpdate{
-							update.ContainerUpdate{
+							{
 								Container: helloContainer,
 								Current:   oldRef,
 								Target:    newHwRef,
@@ -381,12 +381,12 @@ func Test_FilterLogic(t *testing.T) {
 					flux.MustParseResourceID("default:deployment/helloworld"): update.WorkloadResult{
 						Status: update.ReleaseStatusSuccess,
 						PerContainer: []update.ContainerUpdate{
-							update.ContainerUpdate{
+							{
 								Container: helloContainer,
 								Current:   oldRef,
 								Target:    newHwRef,
 							},
-							update.ContainerUpdate{
+							{
 								Container: sidecarContainer,
 								Current:   sidecarRef,
 								Target:    newSidecarRef,
@@ -413,12 +413,12 @@ func Test_FilterLogic(t *testing.T) {
 					flux.MustParseResourceID("default:deployment/helloworld"): update.WorkloadResult{
 						Status: update.ReleaseStatusSuccess,
 						PerContainer: []update.ContainerUpdate{
-							update.ContainerUpdate{
+							{
 								Container: helloContainer,
 								Current:   oldRef,
 								Target:    newHwRef,
 							},
-							update.ContainerUpdate{
+							{
 								Container: sidecarContainer,
 								Current:   sidecarRef,
 								Target:    newSidecarRef,

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -86,7 +86,7 @@ fluxd requires setup and offers customization though a multitude of flags.
 | --k8s-secret-volume-mount-path                   | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key
 | --k8s-secret-data-key                            | `identity`               | data key holding the private SSH key within the k8s secret
 | **k8s configuration**
-| --k8s-namespace-whitelist                        |                          | Experimental, optional: restrict the view of the cluster to the namespaces listed. All namespaces are included if this is not set.
+| --k8s-allow-namespace                            |                          | experimental: restrict all operations to the provided namespaces
 | **upstream service**
 | --connect                                        |                          | connect to an upstream service e.g., Weave Cloud, at this base address
 | --token                                          |                          | authentication token for upstream service

--- a/update/filter.go
+++ b/update/filter.go
@@ -7,18 +7,18 @@ import (
 )
 
 const (
-	Locked               = "locked"
-	Ignore               = "ignore"
-	NotIncluded          = "not included"
-	Excluded             = "excluded"
-	DifferentImage       = "a different image"
-	NotInCluster         = "not running in cluster"
-	NotInRepo            = "not found in repository"
-	ImageNotFound        = "cannot find one or more images"
-	ImageUpToDate        = "image(s) up to date"
-	DoesNotUseImage      = "does not use image(s)"
-	ContainerNotFound    = "container(s) not found: %s"
-	ContainerTagMismatch = "container(s) tag mismatch: %s"
+	Locked                 = "locked"
+	Ignore                 = "ignore"
+	NotIncluded            = "not included"
+	Excluded               = "excluded"
+	DifferentImage         = "a different image"
+	NotAccessibleInCluster = "not accessible in cluster"
+	NotInRepo              = "not found in repository"
+	ImageNotFound          = "cannot find one or more images"
+	ImageUpToDate          = "image(s) up to date"
+	DoesNotUseImage        = "does not use image(s)"
+	ContainerNotFound      = "container(s) not found: %s"
+	ContainerTagMismatch   = "container(s) tag mismatch: %s"
 )
 
 type SpecificImageFilter struct {
@@ -30,7 +30,7 @@ func (f *SpecificImageFilter) Filter(u WorkloadUpdate) WorkloadResult {
 	if len(u.Workload.Containers.Containers) == 0 {
 		return WorkloadResult{
 			Status: ReleaseStatusIgnored,
-			Error:  NotInCluster,
+			Error:  NotAccessibleInCluster,
 		}
 	}
 	// For each container in update


### PR DESCRIPTION
Addresses part of #1471 

* Deprecate and rename flag `--kubernetes-namespace-whitelist` to ~`--kubernetes-allow-namespace`~ `--k8s-allow-namespace`
* Honor `--k8s-allow-namespace` for namespaced kubernetes resources in all flux operations.
* cluster-global resources cluster-global resources (i.e. resources without an associated namespace) won't be filtered out by this change (they will keep being synced).

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
