### PR TITLE
Add `repositories.yaml` mounting to Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -247,6 +247,10 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.tls.certFile` | Name of the certificate file within the k8s secret | `tls.crt`
 | `helmOperator.tls.caContent` | Certificate Authority content used to validate the Tiller server certificate | `None`
 | `helmOperator.tls.hostname` | The server name used to verify the hostname on the returned certificates from the Tiller server | `None`
+| `helmOperator.configureRepositories.enable` | Enable volume mount for a `repositories.yaml` configuration file and respository cache | `false`
+| `helmOperator.configureRepositories.volumeName` | Name of the volume for the `repositories.yaml` file | `repositories-yaml`
+| `helmOperator.configureRepositories.secretName` | Name of the secret containing the contents of the `repositories.yaml` file | `flux-helm-repositories`
+| `helmOperator.configureRepositories.cacheName` | Name for the repository cache volume | `repositories-cache`
 | `helmOperator.resources.requests.cpu` | CPU resource requests for the helmOperator deployment | `50m`
 | `helmOperator.resources.requests.memory` | Memory resource requests for the helmOperator deployment | `64Mi`
 | `helmOperator.resources.limits` | CPU/memory resource limits for the helmOperator deployment | `None`

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -55,6 +55,13 @@ spec:
           defaultMode: 0600
       {{- end }}
       {{- end }}
+      {{- if .Values.helmOperator.configureRepositories.enable }}
+      - name: {{ .Values.helmOperator.configureRepositories.volumeName | quote }}
+        secret:
+          secretName: {{ .Values.helmOperator.configureRepositories.secretName | quote }}
+      - name: {{ .Values.helmOperator.configureRepositories.cacheVolumeName | quote }}
+        emptyDir: {}
+      {{- end }}
       containers:
       - name: flux-helm-operator
         image: "{{ .Values.helmOperator.repository }}:{{ .Values.helmOperator.tag }}"
@@ -81,6 +88,12 @@ spec:
           mountPath: /etc/fluxd/helm-ca
           readOnly: true
         {{- end }}
+        {{- end }}
+        {{- if .Values.helmOperator.configureRepositories.enable }}
+        - name: {{ .Values.helmOperator.configureRepositories.volumeName | quote }}
+          mountPath: /var/fluxd/helm/repository
+        - name: {{ .Values.helmOperator.configureRepositories.cacheVolumeName | quote }}
+          mountPath: /var/fluxd/helm/repository/cache
         {{- end }}
         args:
         - --git-timeout={{ $gitTimeout }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -37,6 +37,12 @@ helmOperator:
     certFile: "tls.crt"
     caContent: ""
     hostname: ""
+  # Mount repositories.yaml configuration in a volume
+  configureRepositories:
+    enable: false
+    volumeName: repositories-yaml
+    secretName: flux-helm-repositories
+    cacheVolumeName: repositories-cache
   # Override Flux git settings
   git:
     pollInterval: ""

--- a/site/helm-integration.md
+++ b/site/helm-integration.md
@@ -225,9 +225,10 @@ the Helm operator, from the repositories file:
 kubectl create secret generic flux-helm-repositories --from-file=./repositories.yaml
 ```
 
-Lastly, mount that secret into the container, as shown in the
-commented-out sections of the [example
-deployment](../deploy-helm/helm-operator-deployment.yaml).
+Lastly, mount that secret into the container. This can be done by
+setting `helmOperator.configureRepositories.enable` to `true` for the
+flux Helm release, or as shown in the commented-out sections of the
+[example deployment](../deploy-helm/helm-operator-deployment.yaml).
 
 ### Authentication for Git repos
 


### PR DESCRIPTION
If users wish to configure their own `repositories.yaml` file, they can do this by setting `helmOperator.configureRepositories.enable` to `true`. This will mount a volume for the `respositories.yaml` file to be fetched from a secret as well as set up a repositories cache.

This will allow users to set up authentication for Helm Repos as described in the flux documentation.
https://github.com/weaveworks/flux/blob/master/site/helm-integration.md#authentication-for-helm-repos
