### PR TITLE
Improve handling of registry challenge requests

### DIFF
--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -87,6 +87,7 @@ func (f *RemoteClientFactory) ClientFor(repo image.CanonicalName, creds Credenti
 		if err != nil {
 			return nil, err
 		}
+		defer res.Body.Close()
 		if err = manager.AddResponse(res); err != nil {
 			return nil, err
 		}

--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -1,9 +1,11 @@
 package registry
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"sync"
+	"time"
 
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/docker/distribution/registry/client/auth/challenge"
@@ -81,9 +83,11 @@ func (f *RemoteClientFactory) ClientFor(repo image.CanonicalName, creds Credenti
 		if err != nil {
 			return nil, err
 		}
+		ctx, cancel := context.WithTimeout(req.Context(), 30*time.Second)
+		defer cancel()
 		res, err := (&http.Client{
 			Transport: tx,
-		}).Do(req)
+		}).Do(req.WithContext(ctx))
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
1. Close the response body, which wasn't getting closed and which is partly or fully causing #1602 
2. Include a timeout in the request

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
