### PR TITLE
Run signal listener in a goroutine instead of deferring.

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -131,7 +131,7 @@ func main() {
 		errc <- fmt.Errorf("%s", <-c)
 	}()
 
-	defer func() {
+	go func() {
 		logger.Log("exiting...", <-errc)
 		close(shutdown)
 		shutdownWg.Wait()


### PR DESCRIPTION
Fixes #1679

