### PR TITLE
Publish Flux chart with GitHub actions

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,10 @@
+workflow "Publish Helm chart" {
+  on = "push"
+  resolves = ["helm-gh-pages"]
+}
+
+action "helm-gh-pages" {
+  uses = "stefanprodan/gh-actions/helm-gh-pages@master"
+  args = ["chart/flux","https://weaveworks.github.io/flux","chart-"]
+  secrets = ["GITHUB_TOKEN"]
+}

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -8,9 +8,15 @@ action "helm-lint" {
   args = ["lint chart/flux"]
 }
 
-action "helm-gh-pages" {
+action "tag-filter" {
   needs = ["helm-lint"]
+  uses = "actions/bin/filter@master"
+  args = "tag chart-*"
+}
+
+action "helm-gh-pages" {
+  needs = ["tag-filter"]
   uses = "stefanprodan/gh-actions/helm-gh-pages@master"
-  args = ["chart/flux","https://weaveworks.github.io/flux","chart-"]
+  args = ["chart/flux","https://weaveworks.github.io/flux"]
   secrets = ["GITHUB_TOKEN"]
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -3,7 +3,13 @@ workflow "Publish Helm chart" {
   resolves = ["helm-gh-pages"]
 }
 
+action "helm-lint" {
+  uses = "stefanprodan/gh-actions/helm@master"
+  args = ["lint chart/flux"]
+}
+
 action "helm-gh-pages" {
+  needs = ["helm-lint"]
   uses = "stefanprodan/gh-actions/helm-gh-pages@master"
   args = ["chart/flux","https://weaveworks.github.io/flux","chart-"]
   secrets = ["GITHUB_TOKEN"]


### PR DESCRIPTION
This PR adds a GitHub workflow that lints, packages and pushes the Flux chart to `gh-pages` branch when tagging the master branch with `chart-*`

For more details on this: [Automate Helm chart repository publishing with GitHub Actions and Pages](https://medium.com/@stefanprodan/automate-helm-chart-repository-publishing-with-github-actions-and-pages-8a374ce24cf4)
