### PR TITLE
AKS credentials for ACR

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -221,6 +221,8 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `registry.ecr.region` | Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned | `None`
 | `registry.ecr.includeId` | Restrict ECR scanning to these AWS account IDs; if empty, all account IDs that aren't excluded may be scanned | `None`
 | `registry.ecr.excludeId` | Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account | `602401143452`
+| `registry.acr.enabled` | Mount `azure.json` via HostPath into the Flux Pod, enabling Flux to use AKS's service principal for ACR authentication | `false`
+| `registry.acr.hostPath` | Alternative location of `azure.json` on the host | `/etc/kubernetes/azure.json`
 | `memcached.verbose` | Enable request logging in memcached | `false`
 | `memcached.maxItemSize` | Maximum size for one item | `1m`
 | `memcached.maxMemory` | Maximum memory to use, in megabytes | `64`

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
       - name: git-keygen
         emptyDir:
           medium: Memory
+      {{- if .Values.registry.acr.enabled }}
+      - name: acr-credentials
+        hostPath:
+          path: "{{ .Values.registry.acr.mountPath }}"
+          type: ""
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -66,6 +72,11 @@ spec:
             readOnly: true
           - name: git-keygen
             mountPath: /var/fluxd/keygen
+          {{- if .Values.registry.acr.enabled }}
+          - name: acr-credentials
+            mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+          {{- end }}
           env:
           - name: KUBECONFIG
             value: /root/.kubectl/config

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- if .Values.registry.acr.enabled }}
       - name: acr-credentials
         hostPath:
-          path: "{{ .Values.registry.acr.mountPath }}"
+          path: "{{ .Values.registry.acr.hostPath }}"
           type: ""
       {{- end }}
       containers:

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -136,6 +136,10 @@ registry:
     region:
     includeId:
     excludeId:
+  # Azure ACR settings
+  acr:
+    enabled: false
+    hostPath: /etc/kubernetes/azure.json
 
 memcached:
   repository: memcached

--- a/registry/azure.go
+++ b/registry/azure.go
@@ -1,0 +1,55 @@
+package registry
+
+import (
+	"encoding/json"
+	"os"
+	yaml "gopkg.in/yaml.v2"
+)
+
+const (
+    // Mount volume from hostpath.
+    azureCloudConfigJsonFile = "/etc/kubernetes/azure.json"
+
+    // List from https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/azure/azure_credentials.go
+    azureContainerRegistryHosts = []string{".azurecr.io", ".azurecr.cn", ".azurecr.de", ".azurecr.us"};
+)
+
+type azureCloudConfig struct {
+    aadClientId string `json:"aadClientId"`
+    aadClientSecret string `json:"aadClientSecret"`
+}
+
+// Fetch Azure Active Directory clientid/secret pair from azure.json, usable for container registry authentication.
+//
+// Note: azure.json is populated by AKS/AKS-Engine script kubernetesconfigs.sh. The file is then passed to kubelet via
+// --azure-container-registry-config=/etc/kubernetes/azure.json, parsed by kubernetes/kubernetes' azure_credentials.go
+// https://github.com/kubernetes/kubernetes/issues/58034 seeks to deprecate this kubelet command-line argument, possibly
+// replacing it with managed identity for the Node VMs. See https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md
+func GetAzureCloudConfigAADToken(host string) (creds, error) {
+    jsonFile, err := os.Open(azureCloudConfigJsonFile)
+    if err != nil {
+        return creds{}, err
+    }
+    defer jsonFile.Close()
+
+    var token azureCloudConfig
+    decoder := json.NewDecoder(jsonFile)
+    if err := decoder.Decode(&token); err != nil {
+        return creds{}, err
+    }
+
+    return creds{
+        registry:   host,
+        provenance: "azure.json",
+        username:   token.aadClientId,
+        password:   token.aadClientSecret}, nil
+}
+
+func HostIsAzureContainerRegistry(host string) (bool) {
+    for _, v := range azureContainerRegistryHosts {
+        if strings.HasSuffix(host, v) {
+            return true
+        }
+    }
+    return false
+}

--- a/registry/azure.go
+++ b/registry/azure.go
@@ -9,9 +9,6 @@ import (
 const (
     // Mount volume from hostpath.
     azureCloudConfigJsonFile = "/etc/kubernetes/azure.json"
-
-    // List from https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/azure/azure_credentials.go
-    azureContainerRegistryHosts = []string{".azurecr.io", ".azurecr.cn", ".azurecr.de", ".azurecr.us"};
 )
 
 type azureCloudConfig struct {
@@ -45,8 +42,9 @@ func GetAzureCloudConfigAADToken(host string) (creds, error) {
         password:   token.aadClientSecret}, nil
 }
 
+// List from https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/azure/azure_credentials.go
 func HostIsAzureContainerRegistry(host string) (bool) {
-    for _, v := range azureContainerRegistryHosts {
+    for _, v := range []string{".azurecr.io", ".azurecr.cn", ".azurecr.de", ".azurecr.us"} {
         if strings.HasSuffix(host, v) {
             return true
         }

--- a/registry/azure.go
+++ b/registry/azure.go
@@ -3,7 +3,7 @@ package registry
 import (
 	"encoding/json"
 	"os"
-	yaml "gopkg.in/yaml.v2"
+	"strings"
 )
 
 const (

--- a/registry/azure.go
+++ b/registry/azure.go
@@ -7,13 +7,13 @@ import (
 )
 
 const (
-    // Mount volume from hostpath.
-    azureCloudConfigJsonFile = "/etc/kubernetes/azure.json"
+	// Mount volume from hostpath.
+	azureCloudConfigJsonFile = "/etc/kubernetes/azure.json"
 )
 
 type azureCloudConfig struct {
-    AADClientId string `json:"aadClientId"`
-    AADClientSecret string `json:"aadClientSecret"`
+	AADClientId     string `json:"aadClientId"`
+	AADClientSecret string `json:"aadClientSecret"`
 }
 
 // Fetch Azure Active Directory clientid/secret pair from azure.json, usable for container registry authentication.
@@ -23,31 +23,31 @@ type azureCloudConfig struct {
 // https://github.com/kubernetes/kubernetes/issues/58034 seeks to deprecate this kubelet command-line argument, possibly
 // replacing it with managed identity for the Node VMs. See https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md
 func GetAzureCloudConfigAADToken(host string) (creds, error) {
-    jsonFile, err := ioutil.ReadFile(azureCloudConfigJsonFile)
-    if err != nil {
-        return creds{}, err
-    }
+	jsonFile, err := ioutil.ReadFile(azureCloudConfigJsonFile)
+	if err != nil {
+		return creds{}, err
+	}
 
-    var token azureCloudConfig
+	var token azureCloudConfig
 
-    err = json.Unmarshal(jsonFile, &token)
-    if err != nil {
-        return creds{}, err
-    }
+	err = json.Unmarshal(jsonFile, &token)
+	if err != nil {
+		return creds{}, err
+	}
 
-    return creds{
-        registry:   host,
-        provenance: "azure.json",
-        username:   token.AADClientId,
-        password:   token.AADClientSecret}, nil
+	return creds{
+		registry:   host,
+		provenance: "azure.json",
+		username:   token.AADClientId,
+		password:   token.AADClientSecret}, nil
 }
 
 // List from https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/azure/azure_credentials.go
-func HostIsAzureContainerRegistry(host string) (bool) {
-    for _, v := range []string{".azurecr.io", ".azurecr.cn", ".azurecr.de", ".azurecr.us"} {
-        if strings.HasSuffix(host, v) {
-            return true
-        }
-    }
-    return false
+func HostIsAzureContainerRegistry(host string) bool {
+	for _, v := range []string{".azurecr.io", ".azurecr.cn", ".azurecr.de", ".azurecr.us"} {
+		if strings.HasSuffix(host, v) {
+			return true
+		}
+	}
+	return false
 }

--- a/registry/azure.go
+++ b/registry/azure.go
@@ -22,7 +22,7 @@ type azureCloudConfig struct {
 // --azure-container-registry-config=/etc/kubernetes/azure.json, parsed by kubernetes/kubernetes' azure_credentials.go
 // https://github.com/kubernetes/kubernetes/issues/58034 seeks to deprecate this kubelet command-line argument, possibly
 // replacing it with managed identity for the Node VMs. See https://github.com/Azure/acr/blob/master/docs/AAD-OAuth.md
-func GetAzureCloudConfigAADToken(host string) (creds, error) {
+func getAzureCloudConfigAADToken(host string) (creds, error) {
 	jsonFile, err := ioutil.ReadFile(azureCloudConfigJsonFile)
 	if err != nil {
 		return creds{}, err
@@ -43,7 +43,7 @@ func GetAzureCloudConfigAADToken(host string) (creds, error) {
 }
 
 // List from https://github.com/kubernetes/kubernetes/blob/master/pkg/credentialprovider/azure/azure_credentials.go
-func HostIsAzureContainerRegistry(host string) bool {
+func hostIsAzureContainerRegistry(host string) bool {
 	for _, v := range []string{".azurecr.io", ".azurecr.cn", ".azurecr.de", ".azurecr.us"} {
 		if strings.HasSuffix(host, v) {
 			return true

--- a/registry/azure_test.go
+++ b/registry/azure_test.go
@@ -6,8 +6,8 @@ import (
 
 func Test_HostIsAzureContainerRegistry(t *testing.T) {
 	for _, v := range []struct {
-		host        string
-		isACR       bool
+		host  string
+		isACR bool
 	}{
 		{
 			host:  "azurecr.io",

--- a/registry/azure_test.go
+++ b/registry/azure_test.go
@@ -48,7 +48,7 @@ func Test_HostIsAzureContainerRegistry(t *testing.T) {
 			isACR: true,
 		},
 	} {
-		result := HostIsAzureContainerRegistry(v.host)
+		result := hostIsAzureContainerRegistry(v.host)
 		if result != v.isACR {
 			t.Fatalf("For test %q, expected isACR = %v but got %v", v.host, v.isACR, result)
 		}

--- a/registry/azure_test.go
+++ b/registry/azure_test.go
@@ -1,0 +1,56 @@
+package registry
+
+import (
+	"testing"
+)
+
+func Test_HostIsAzureContainerRegistry(t *testing.T) {
+	for _, v := range []struct {
+		host        string
+		isACR       bool
+	}{
+		{
+			host:  "azurecr.io",
+			isACR: false,
+		},
+		{
+			host:  "",
+			isACR: false,
+		},
+		{
+			host:  "gcr.io",
+			isACR: false,
+		},
+		{
+			host:  "notazurecr.io",
+			isACR: false,
+		},
+		{
+			host:  "example.azurecr.io.not",
+			isACR: false,
+		},
+		// Public cloud
+		{
+			host:  "example.azurecr.io",
+			isACR: true,
+		},
+		// Sovereign clouds
+		{
+			host:  "example.azurecr.cn",
+			isACR: true,
+		},
+		{
+			host:  "example.azurecr.de",
+			isACR: true,
+		},
+		{
+			host:  "example.azurecr.us",
+			isACR: true,
+		},
+	} {
+		result := HostIsAzureContainerRegistry(v.host)
+		if result != v.isACR {
+			t.Fatalf("For test %q, expected isACR = %v but got %v", v.host, v.isACR, result)
+		}
+	}
+}

--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -144,6 +144,13 @@ func (cs Credentials) credsFor(host string) creds {
 			return cred
 		}
 	}
+
+    if HostIsAzureContainerRegistry(host) {
+        if cred, err := GetAzureCloudConfigAADToken(host); err == nil {
+            return cred
+        }
+    }
+
 	return creds{}
 }
 

--- a/registry/credentials.go
+++ b/registry/credentials.go
@@ -145,8 +145,8 @@ func (cs Credentials) credsFor(host string) creds {
 		}
 	}
 
-    if HostIsAzureContainerRegistry(host) {
-        if cred, err := GetAzureCloudConfigAADToken(host); err == nil {
+    if hostIsAzureContainerRegistry(host) {
+        if cred, err := getAzureCloudConfigAADToken(host); err == nil {
             return cred
         }
     }

--- a/site/faq.md
+++ b/site/faq.md
@@ -246,7 +246,7 @@ happen:
    if you've only just started using a particular image in a workload.
  - Flux can't get suitable credentials for the image repository. At
    present, it looks at `imagePullSecret`s attached to workloads,
-   service accounts, platform-provided credentials on GCP or AWS, and
+   service accounts, platform-provided credentials on GCP, AWS or Azure, and
    a Docker config file if you mount one into the fluxd container (see
    the [command-line usage](./daemon.md)).
  - When using images in ECR, from EC2, the `NodeInstanceRole` for the
@@ -256,6 +256,25 @@ happen:
    [`kops`](https://github.com/kubernetes/kops) (with
    [`.iam.allowContainerRegistry=true`](https://github.com/kubernetes/kops/blob/master/docs/iam_roles.md#iam-roles))
    both make sure this is the case.
+ - When using images from ACR in AKS, the HostPath `/etc/kubernetes/azure.json`
+   should be [mounted](https://kubernetes.io/docs/concepts/storage/volumes/) into the Flux Pod.
+   Set `registry.acr.enabled=True` in the [helm chart](../chart/flux/README.md)
+   or alter the [Deployment](../deploy/flux-deployment.yaml):
+   ```yaml
+    spec:
+      containers:
+        image: quay.io/weaveworks/flux
+        ...
+        volumeMounts:
+        - name: acr-credentials
+          mountPath: /etc/kubernetes/azure.json
+          readOnly: true
+      volumes:
+      - name: acr-credentials
+        hostPath:
+          path: /etc/kubernetes/azure.json
+          type: ""
+   ```
  - Flux excludes images with no suitable manifest (linux amd64) in manifestlist
  - Flux doesn't yet understand image refs that use digests instead of
    tags; see


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

Azure Kubernetes Service (AKS) nodes' kubelet can use the cluster's
service principal to fetch images from Azure Container Registry (ACR).

If azure.json is projected into the Flux pod, consume the service
principal credentials when authenticating to azure container registry.

Note that this method may eventually be deprecated, possibly replaced
by Managed Identity + OAuth, similar to the GCP implementation.
See https://github.com/kubernetes/kubernetes/issues/58034

Prompted by [discussion](https://weave-community.slack.com/archives/C4U5ATZ9S/p1547928858828100) with @squaremo on slack