### PR TITLE
Warn users about external changes in sync tag

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -42,19 +42,17 @@ const (
 // Daemon is the fully-functional state of a daemon (compare to
 // `NotReadyDaemon`).
 type Daemon struct {
-	V                        string
-	Cluster                  cluster.Cluster
-	Manifests                cluster.Manifests
-	Registry                 registry.Registry
-	ImageRefresh             chan image.Name
-	Repo                     *git.Repo
-	GitConfig                git.Config
-	lastKnownSyncTagRev      string
-	warnedAboutSyncTagChange bool
-	Jobs                     *job.Queue
-	JobStatusCache           *job.StatusCache
-	EventWriter              event.EventWriter
-	Logger                   log.Logger
+	V              string
+	Cluster        cluster.Cluster
+	Manifests      cluster.Manifests
+	Registry       registry.Registry
+	ImageRefresh   chan image.Name
+	Repo           *git.Repo
+	GitConfig      git.Config
+	Jobs           *job.Queue
+	JobStatusCache *job.StatusCache
+	EventWriter    event.EventWriter
+	Logger         log.Logger
 	// bookkeeping
 	*LoopVars
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -42,17 +42,19 @@ const (
 // Daemon is the fully-functional state of a daemon (compare to
 // `NotReadyDaemon`).
 type Daemon struct {
-	V              string
-	Cluster        cluster.Cluster
-	Manifests      cluster.Manifests
-	Registry       registry.Registry
-	ImageRefresh   chan image.Name
-	Repo           *git.Repo
-	GitConfig      git.Config
-	Jobs           *job.Queue
-	JobStatusCache *job.StatusCache
-	EventWriter    event.EventWriter
-	Logger         log.Logger
+	V                        string
+	Cluster                  cluster.Cluster
+	Manifests                cluster.Manifests
+	Registry                 registry.Registry
+	ImageRefresh             chan image.Name
+	Repo                     *git.Repo
+	GitConfig                git.Config
+	lastKnownSyncTagRev      string
+	warnedAboutSyncTagChange bool
+	Jobs                     *job.Queue
+	JobStatusCache           *job.StatusCache
+	EventWriter              event.EventWriter
+	Logger                   log.Logger
 	// bookkeeping
 	*LoopVars
 }

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -62,8 +62,10 @@ func (d *Daemon) Loop(stop chan struct{}, wg *sync.WaitGroup, logger log.Logger)
 	d.AskForImagePoll()
 
 	for {
-		var lastKnownSyncTagRev string
-		var warnedAboutSyncTagChange bool
+		var (
+			lastKnownSyncTagRev      string
+			warnedAboutSyncTagChange bool
+		)
 		select {
 		case <-stop:
 			logger.Log("stopping", "true")

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -105,8 +105,12 @@ func TestPullAndSync_InitialSync(t *testing.T) {
 		syncDef = &def
 		return nil
 	}
-
-	d.doSync(log.NewLogfmtLogger(ioutil.Discard))
+	var (
+		logger                   = log.NewLogfmtLogger(ioutil.Discard)
+		lastKnownSyncTagRev      string
+		warnedAboutSyncTagChange bool
+	)
+	d.doSync(logger, &lastKnownSyncTagRev, &warnedAboutSyncTagChange)
 
 	// It applies everything
 	if syncCalled != 1 {
@@ -174,8 +178,12 @@ func TestDoSync_NoNewCommits(t *testing.T) {
 		syncDef = &def
 		return nil
 	}
-
-	if err := d.doSync(log.NewLogfmtLogger(ioutil.Discard)); err != nil {
+	var (
+		logger                   = log.NewLogfmtLogger(ioutil.Discard)
+		lastKnownSyncTagRev      string
+		warnedAboutSyncTagChange bool
+	)
+	if err := d.doSync(logger, &lastKnownSyncTagRev, &warnedAboutSyncTagChange); err != nil {
 		t.Error(err)
 	}
 
@@ -268,8 +276,12 @@ func TestDoSync_WithNewCommit(t *testing.T) {
 		syncDef = &def
 		return nil
 	}
-
-	d.doSync(log.NewLogfmtLogger(ioutil.Discard))
+	var (
+		logger                   = log.NewLogfmtLogger(ioutil.Discard)
+		lastKnownSyncTagRev      string
+		warnedAboutSyncTagChange bool
+	)
+	d.doSync(logger, &lastKnownSyncTagRev, &warnedAboutSyncTagChange)
 
 	// It applies everything
 	if syncCalled != 1 {


### PR DESCRIPTION
Multiple users have reported an unexpectedly high number of changes in the git
respository's sync tag.

This has been attributed to multiple fluxd instances, running in separate
clusters, using the same git repository and sync tag.

In addition, multiple fluxd instances using the same tag is a bad idea in
general, since it will lead to commits being missed by fluxd.

This change tracks the value of the sync tag and prints a warning when detecting
an external change.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
