### PR TITLE
Merge existing image credentials into a fresh set

### DIFF
--- a/cluster/kubernetes/images.go
+++ b/cluster/kubernetes/images.go
@@ -152,7 +152,10 @@ func (c *Cluster) ImagesToFetch() registry.ImageCreds {
 			for imageID, creds := range imageCreds {
 				existingCreds, ok := allImageCreds[imageID]
 				if ok {
-					existingCreds.Merge(creds)
+					mergedCreds := registry.NoCredentials()
+					mergedCreds.Merge(existingCreds)
+					mergedCreds.Merge(creds)
+					allImageCreds[imageID] = mergedCreds
 				} else {
 					allImageCreds[imageID] = creds
 				}


### PR DESCRIPTION
Fixes #1485

With the previous merging strategy the set of credentials which got
mutated could be assigned to other images, resulting in overwrites
where we would (and did) not expect them.

This new approach is the most direct fix to work around mutating the
credentials of other images. It creates a fresh set of (empty)
credentials and merges the others into it before assigning it to the
image.

[Details](https://github.com/weaveworks/flux/pull/1702#issuecomment-460265100)