### PR TITLE
Helm chart: Fix custom SSH secret mapping

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
           {{- end }}
           args:
           - --ssh-keygen-dir=/var/fluxd/keygen
-          - --k8s-secret-name={{ template "flux.fullname" . }}-git-deploy
+          - --k8s-secret-name={{ .Values.git.secretName | default (printf "%s-git-deploy" (include "flux.fullname" .)) }}
           - --memcached-hostname={{ template "flux.fullname" . }}-memcached
           {{- if .Values.memcached.createClusterIP }}
           - --memcached-service=

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -52,7 +52,7 @@ helmOperator:
     # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
     # create a Kubernetes secret: kubectl -n flux create secret generic helm-ssh --from-file=./identity
     # delete the private key: rm ./identity
-    # add ./identity.pub as a read-only deployment key in your GitHub repo where the charts are
+    # add ./identity.pub as a read-only deployment key in your Git repo where the charts are
     # set the secret name (helm-ssh) below
     secretName: ""
   # Additional environment variables to set
@@ -114,7 +114,7 @@ git:
   # generate a SSH key named identity: ssh-keygen -q -N "" -f ./identity
   # create a Kubernetes secret: kubectl -n flux create secret generic flux-ssh --from-file=./identity
   # delete the private key: rm ./identity
-  # add ./identity.pub as a read-only deployment key in your GitHub repo where the charts are
+  # add ./identity.pub as a deployment key with write access in your Git repo
   # set the secret name (flux-ssh) below
   secretName: ""
 


### PR DESCRIPTION
Override Flux default SSH secret name with the one specified in values.

Fix: #1709 
