### PR TITLE
add "skipDepUpdate" config parameter to HelmRelease

### DIFF
--- a/deploy-helm/flux-helm-release-crd.yaml
+++ b/deploy-helm/flux-helm-release-crd.yaml
@@ -31,6 +31,8 @@ spec:
               format: int64
             resetValues:
               type: boolean
+            skipDepUpdate:
+              type: boolean
             valueFileSecrets:
               type: array
               properties:

--- a/integrations/apis/flux.weave.works/v1beta1/types.go
+++ b/integrations/apis/flux.weave.works/v1beta1/types.go
@@ -75,6 +75,9 @@ type HelmReleaseSpec struct {
 	// Reset values on helm upgrade
 	// +optional
 	ResetValues bool `json:"resetValues,omitempty"`
+	// Do not run 'dep' update (assume requirements.yaml is already fulfilled)
+	// +optional
+	SkipDepUpdate bool `json:"skipDepUpdate,omitempty"`
 }
 
 // GetTimeout returns the install or upgrade timeout (defaults to 300s)

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -327,7 +327,7 @@ func (chs *ChartChangeSync) reconcileReleaseDef(fhr fluxv1beta1.HelmRelease) {
 		chs.setCondition(&fhr, fluxv1beta1.HelmReleaseChartFetched, v1.ConditionTrue, ReasonCloned, "successfully cloned git repo")
 		chartPath = filepath.Join(chartClone.export.Dir(), chartSource.Path)
 
-		if chs.config.UpdateDeps {
+		if chs.config.UpdateDeps && !fhr.Spec.SkipDepUpdate {
 			if err := updateDependencies(chartPath, ""); err != nil {
 				chs.setCondition(&fhr, fluxv1beta1.HelmReleaseReleased, v1.ConditionFalse, ReasonDependencyFailed, err.Error())
 				chs.logger.Log("warning", "Failed to update chart dependencies", "namespace", fhr.Namespace, "name", fhr.Name, "error", err)


### PR DESCRIPTION
some helm charts (istio being an example) add helm charts into the "charts" folder directly and do not need "helm dep up" to be called. In fact doing so will cause an error since the requirements have already been fulfilled.  While you can disable this feature system wide it is much more useful to allow individual helm releases to specify this behavior.  this commit adds a skipDepUpdate attribute to the
HelmRelease crd that causes the dependency update step to be skipped for that release.

It defaults to "false" and is backward compatible (as it is not required).