### PR TITLE
Add image pull secret options to Helm chart

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased (TBA)
+
+### Improvements
+
+ - Allow chart images to be pulled from a private container registry
+   [weaveworks/flux#1718](https://github.com/weaveworks/flux/pull/1718)
+
 ## 0.6.1 (2019-02-07)
 
 ### Improvements

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -24,6 +24,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       volumes:
       - name: kubedir
         configMap:

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -26,6 +26,10 @@ spec:
         release: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ template "flux.serviceAccountName" . }}
+      {{- if .Values.helmOperator.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.helmOperator.pullSecret }}
+      {{- end }}
       volumes:
       {{- if .Values.ssh.known_hosts }}
       - name: sshdir

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -21,6 +21,10 @@ spec:
         app: {{ template "flux.name" . }}-memcached
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.memcached.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.memcached.pullSecret }}
+      {{- end }}
       containers:
       - name: memcached
         image: {{ .Values.memcached.repository }}:{{ .Values.memcached.tag }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -9,6 +9,7 @@ image:
   repository: quay.io/weaveworks/flux
   tag: 1.10.0
   pullPolicy: IfNotPresent
+  pullSecret:
 
 service:
   type: ClusterIP
@@ -21,6 +22,7 @@ helmOperator:
   repository: quay.io/weaveworks/helm-operator
   tag: 0.6.0
   pullPolicy: IfNotPresent
+  pullSecret:
   # Limit the operator scope to a single namespace
   allowNamespace:
   # Update dependencies for charts
@@ -142,6 +144,7 @@ registry:
 memcached:
   repository: memcached
   tag: 1.4.25
+  pullSecret:
   createClusterIP: true
   verbose: false
   maxItemSize: 1m


### PR DESCRIPTION
Allows flux, helm-op and memcached images to be pulled from a private container registry.

Fix: #1716

