### PR TITLE
Make port forward label selector configurable

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -577,12 +577,12 @@
   version = "v0.0.1"
 
 [[projects]]
-  digest = "1:8e243c568f36b09031ec18dff5f7d2769dcf5ca4d624ea511c8e3197dc3d352d"
+  digest = "1:cbaf13cdbfef0e4734ed8a7504f57fe893d471d62a35b982bf6fb3f036449a66"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = ""
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
 
 [[projects]]
   digest = "1:a30066593578732a356dc7e5d7f78d69184ca65aeeff5939241a3ab10559bb06"

--- a/cmd/fluxctl/root_cmd.go
+++ b/cmd/fluxctl/root_cmd.go
@@ -113,6 +113,8 @@ func (opts *rootOpts) PersistentPreRunE(cmd *cobra.Command, _ []string) error {
 
 	if opts.URL == "" {
 		portforwarder, err := tryPortforwards(opts.Namespace, metav1.LabelSelector{
+			MatchLabels: opts.Labels,
+		}, metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				metav1.LabelSelectorRequirement{
 					Key:      "name",
@@ -120,8 +122,6 @@ func (opts *rootOpts) PersistentPreRunE(cmd *cobra.Command, _ []string) error {
 					Values:   []string{"flux", "fluxd", "weave-flux-agent"},
 				},
 			},
-		}, metav1.LabelSelector{
-			MatchLabels: opts.Labels,
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
Make the label selectors `fluxctl` uses for port forwarding configurable by providing a `--k8s-fwd-labels` flag or setting a `FLUX_FORWARD_LABELS` environment variable. The default value of the flag is inherited from the hardcoded value it was before (`app=flux`).

Fixes #1700 