### PR TITLE
Allow pod annotations to be set when using the helm chart

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -15,9 +15,12 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-      {{- if .Values.prometheus.enabled }}
       annotations:
+      {{- if .Values.prometheus.enabled }}
         prometheus.io.scrape: "true"
+      {{- end }}
+      {{- if .Values.annotations }}
+      {{- .Values.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "flux.name" . }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -17,9 +17,12 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
-      {{- if .Values.prometheus.enabled }}
       annotations:
+      {{- if .Values.prometheus.enabled }}
         prometheus.io.scrape: "true"
+      {{- end }}
+      {{- if .Values.helmOperator.annotations }}
+      {{- .Values.helmOperator.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
       {{- end }}
       labels:
         app: {{ template "flux.name" . }}-helm-operator

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -63,6 +63,7 @@ helmOperator:
   #   - name: FOO
   #     value: bar
   nodeSelector: {}
+  annotations: {}
   tolerations: []
   affinity: {}
   resources:
@@ -87,6 +88,8 @@ resources:
     memory: 64Mi
 
 nodeSelector: {}
+
+annotations: {}
 
 tolerations: []
 


### PR DESCRIPTION
Currently it is not possible to set pod annotations for the flux pods, this is useful if for example you are using something like kube2iam and need to assign an IAM role to the pods so that ECR image scanning can work.