### PR TITLE
Record the Revision in the status

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -172,10 +172,15 @@ func main() {
 
 	// release instance is needed during the sync of Charts changes and during the sync of HelmRelease changes
 	rel := release.New(log.With(logger, "component", "release"), helmClient)
-	chartSync := chartsync.New(log.With(logger, "component", "chartsync"),
+	chartSync := chartsync.New(
+		log.With(logger, "component", "chartsync"),
 		chartsync.Polling{Interval: *chartsSyncInterval},
 		chartsync.Clients{KubeClient: *kubeClient, IfClient: *ifClient},
-		rel, chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, GitTimeout: *gitTimeout}, *namespace)
+		rel,
+		chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, GitTimeout: *gitTimeout},
+		*namespace,
+		statusUpdater,
+	)
 	chartSync.Run(shutdown, errc, shutdownWg)
 
 	nsOpt := ifinformers.WithNamespace(*namespace)

--- a/integrations/apis/flux.weave.works/v1beta1/types.go
+++ b/integrations/apis/flux.weave.works/v1beta1/types.go
@@ -105,6 +105,11 @@ type HelmReleaseStatus struct {
 	// managed by this resource.
 	ReleaseStatus string `json:"releaseStatus"`
 
+	// Revision would define what Git hash or Chart version has currently
+	// been deployed.
+	// +optional
+	Revision string `json:"revision,omitempty"`
+
 	// Conditions contains observations of the resource's state, e.g.,
 	// has the chart which it refers to been fetched.
 	// +optional

--- a/integrations/helm/status/status.go
+++ b/integrations/helm/status/status.go
@@ -119,3 +119,21 @@ func UpdateReleaseStatus(client v1beta1client.HelmReleaseInterface, fhr v1beta1.
 	}
 	return err
 }
+
+func (a *Updater) UpdateReleaseRevision(fhr v1beta1.HelmRelease, revision string) error {
+	client := a.fluxhelm.FluxV1beta1().HelmReleases(fhr.Namespace)
+
+	patchBytes, err := json.Marshal(map[string]interface{}{
+		"status": map[string]interface{}{
+			"revision": revision,
+		},
+	})
+	if err == nil {
+		// CustomResources don't get
+		// StrategicMergePatch, for now, but since we
+		// want to unconditionally set the value, this
+		// is OK.
+		_, err = client.Patch(fhr.Name, types.MergePatchType, patchBytes)
+	}
+	return err
+}

--- a/integrations/helm/status/status.go
+++ b/integrations/helm/status/status.go
@@ -120,9 +120,7 @@ func UpdateReleaseStatus(client v1beta1client.HelmReleaseInterface, fhr v1beta1.
 	return err
 }
 
-func (a *Updater) UpdateReleaseRevision(fhr v1beta1.HelmRelease, revision string) error {
-	client := a.fluxhelm.FluxV1beta1().HelmReleases(fhr.Namespace)
-
+func UpdateReleaseRevision(client v1beta1client.HelmReleaseInterface, fhr v1beta1.HelmRelease, revision string) error {
 	patchBytes, err := json.Marshal(map[string]interface{}{
 		"status": map[string]interface{}{
 			"revision": revision,


### PR DESCRIPTION
## What

At current state, we're unable to track what exact revision of code is
running on our clusters.

This should not be a problem, if we'd rely on chart "version" being the
source of truth, however sadly it is possible to make changes to the
chart without bumping a version. Possibly should be bumped with a CI/CD
tool, but it also has a potential to fail.

Our use case:

```
Merge to master happens
CI picks the changes up
CI runs unit tests
CI marks merge as staging ready by promoting a tag
Flux running on staging cluster/namespace picks up the changes
CI (that is not exposed to the internet - webhooks are a no no) is
   assured the change has been applied
CI runs the integration tests
CI marks merge as staging ready by promoting a tag
Flux running on production cluster/namespace picks up the changes
CI notifies of completion
```

This could be done better. Instead of us passing around a string from
function to function, we could convert the current code obtaining the
revision into it's own function and call it at the very end to gather
this again. Open to interpretation.

## How to review

- Code review and sanity check should be sufficient
