### PR TITLE
Take ignore policy into account when working with automated resources

### DIFF
--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -6,6 +6,7 @@ import (
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/ssh"
+	"github.com/weaveworks/flux/policy"
 )
 
 // Constants for workload ready status. These are defined here so that
@@ -69,6 +70,7 @@ type Controller struct {
 	// in this field.
 	Antecedent flux.ResourceID
 	Labels     map[string]string
+	Policies   policy.Set
 	Rollout    RolloutStatus
 	// Errors during the recurring sync from the Git repository to the
 	// cluster will surface here.

--- a/update/automated.go
+++ b/update/automated.go
@@ -28,9 +28,13 @@ func (a *Automated) CalculateRelease(rc ReleaseContext, logger log.Logger) ([]*C
 	prefilters := []ControllerFilter{
 		&IncludeFilter{a.serviceIDs()},
 	}
+	postfilters := []ControllerFilter{
+		&LockedFilter{},
+		&IgnoreFilter{},
+	}
 
 	result := Result{}
-	updates, err := rc.SelectServices(result, prefilters, nil)
+	updates, err := rc.SelectServices(result, prefilters, postfilters)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/update/filter.go
+++ b/update/filter.go
@@ -8,6 +8,7 @@ import (
 
 const (
 	Locked               = "locked"
+	Ignore               = "ignore"
 	NotIncluded          = "not included"
 	Excluded             = "excluded"
 	DifferentImage       = "a different image"
@@ -85,6 +86,19 @@ func (f *LockedFilter) Filter(u ControllerUpdate) ControllerResult {
 		return ControllerResult{
 			Status: ReleaseStatusSkipped,
 			Error:  Locked,
+		}
+	}
+	return ControllerResult{}
+}
+
+type IgnoreFilter struct {
+}
+
+func (f *IgnoreFilter) Filter(u ControllerUpdate) ControllerResult {
+	if u.Controller.Policies.Has(policy.Ignore) {
+		return ControllerResult{
+			Status: ReleaseStatusSkipped,
+			Error:  Ignore,
 		}
 	}
 	return ControllerResult{}

--- a/update/release_containers.go
+++ b/update/release_containers.go
@@ -64,7 +64,7 @@ func (s ReleaseContainersSpec) filters() ([]ControllerFilter, []ControllerFilter
 	pre := []ControllerFilter{&IncludeFilter{IDs: rids}}
 
 	if !s.Force {
-		return pre, []ControllerFilter{&LockedFilter{}}
+		return pre, []ControllerFilter{&LockedFilter{}, &IgnoreFilter{}}
 	}
 	return pre, []ControllerFilter{}
 }

--- a/update/release_image.go
+++ b/update/release_image.go
@@ -151,7 +151,7 @@ func (s ReleaseImageSpec) filters(rc ReleaseContext) ([]ControllerFilter, []Cont
 
 	// Filter out locked controllers unless given a specific controller(s) and forced
 	if !(len(ids) > 0 && s.Force) {
-		postfilters = append(postfilters, &LockedFilter{})
+		postfilters = append(postfilters, &LockedFilter{}, &IgnoreFilter{})
 	}
 
 	return prefilters, postfilters, nil


### PR DESCRIPTION
Fixes #1748

Before this change having a HelmRelease annotated with both 'automated' and 'ignore' put automated releases to a halt for all resources known to Flux.

The reason for this was the image check failing while comparing with a non-existent controller, resulting in an early error return; which short circuited image updates for everything else.