### PR TITLE
Log skipped Charts directories

### DIFF
--- a/cluster/kubernetes/manifests.go
+++ b/cluster/kubernetes/manifests.go
@@ -1,6 +1,7 @@
 package kubernetes
 
 import (
+	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
 	kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
 	"github.com/weaveworks/flux/image"
@@ -8,10 +9,11 @@ import (
 )
 
 type Manifests struct {
+	Logger log.Logger
 }
 
 func (c *Manifests) LoadManifests(base string, paths []string) (map[string]resource.Resource, error) {
-	return kresource.Load(base, paths)
+	return kresource.Load(base, paths, c.Logger)
 }
 
 func (c *Manifests) ParseManifests(allDefs []byte) (map[string]resource.Resource, error) {

--- a/cluster/kubernetes/resource/load.go
+++ b/cluster/kubernetes/resource/load.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"github.com/weaveworks/flux/resource"
 )
@@ -15,7 +16,7 @@ import (
 // Load takes paths to directories or files, and creates an object set
 // based on the file(s) therein. Resources are named according to the
 // file content, rather than the file name of directory structure.
-func Load(base string, paths []string) (map[string]resource.Resource, error) {
+func Load(base string, paths []string, logger log.Logger) (map[string]resource.Resource, error) {
 	if _, err := os.Stat(base); os.IsNotExist(err) {
 		return nil, fmt.Errorf("git path %q not found", base)
 	}
@@ -31,6 +32,7 @@ func Load(base string, paths []string) (map[string]resource.Resource, error) {
 			}
 
 			if charts.isDirChart(path) {
+				logger.Log("msg", "skipped potential Chart directory", "path", path)
 				return filepath.SkipDir
 			}
 

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -6,12 +6,14 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 	"github.com/weaveworks/flux/resource"
 )
+
+var logger = log.NewNopLogger()
 
 // for convenience
 func base(source, kind, namespace, name string) baseObject {
@@ -200,7 +202,7 @@ func TestLoadSome(t *testing.T) {
 	if err := testfiles.WriteTestFiles(dir); err != nil {
 		t.Fatal(err)
 	}
-	objs, err := Load(dir, []string{dir})
+	objs, err := Load(dir, []string{dir}, logger)
 	if err != nil {
 		t.Error(err)
 	}
@@ -231,7 +233,7 @@ func TestChartTracker(t *testing.T) {
 		if f == "garbage" {
 			continue
 		}
-		if m, err := Load(dir, []string{fq}); err != nil || len(m) == 0 {
+		if m, err := Load(dir, []string{fq}, logger); err != nil || len(m) == 0 {
 			t.Errorf("Load returned 0 objs, err=%v", err)
 		}
 	}
@@ -250,7 +252,7 @@ func TestChartTracker(t *testing.T) {
 	}
 	for _, f := range chartfiles {
 		fq := filepath.Join(dir, f)
-		if m, err := Load(dir, []string{fq}); err != nil || len(m) != 0 {
+		if m, err := Load(dir, []string{fq}, logger); err != nil || len(m) != 0 {
 			t.Errorf("%q not ignored as a chart should be", f)
 		}
 	}

--- a/cluster/mock.go
+++ b/cluster/mock.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"github.com/go-kit/kit/log"
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
@@ -10,6 +11,7 @@ import (
 
 // Doubles as a cluster.Cluster and cluster.Manifests implementation
 type Mock struct {
+	Logger             log.Logger
 	AllServicesFunc    func(maybeNamespace string) ([]Controller, error)
 	SomeServicesFunc   func([]flux.ResourceID) ([]Controller, error)
 	PingFunc           func() error
@@ -17,7 +19,7 @@ type Mock struct {
 	SyncFunc           func(SyncDef) error
 	PublicSSHKeyFunc   func(regenerate bool) (ssh.PublicKey, error)
 	UpdateImageFunc    func(def []byte, id flux.ResourceID, container string, newImageID image.Ref) ([]byte, error)
-	LoadManifestsFunc  func(base string, paths []string) (map[string]resource.Resource, error)
+	LoadManifestsFunc  func(base string, paths []string, logger log.Logger) (map[string]resource.Resource, error)
 	ParseManifestsFunc func([]byte) (map[string]resource.Resource, error)
 	UpdateManifestFunc func(path, resourceID string, f func(def []byte) ([]byte, error)) error
 	UpdatePoliciesFunc func([]byte, flux.ResourceID, policy.Update) ([]byte, error)
@@ -52,7 +54,7 @@ func (m *Mock) UpdateImage(def []byte, id flux.ResourceID, container string, new
 }
 
 func (m *Mock) LoadManifests(base string, paths []string) (map[string]resource.Resource, error) {
-	return m.LoadManifestsFunc(base, paths)
+	return m.LoadManifestsFunc(base, paths, m.Logger)
 }
 
 func (m *Mock) ParseManifests(def []byte) (map[string]resource.Resource, error) {

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -273,7 +273,9 @@ func main() {
 		imageCreds = k8sInst.ImagesToFetch
 		// There is only one way we currently interpret a repo of
 		// files as manifests, and that's as Kubernetes yamels.
-		k8sManifests = &kubernetes.Manifests{}
+		k8sManifests = &kubernetes.Manifests{
+			Logger: logger,
+		}
 	}
 
 	// Wrap the procedure for collecting images to scan

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaveworks/flux"
-	"github.com/weaveworks/flux/api/v10"
-	"github.com/weaveworks/flux/api/v11"
-	"github.com/weaveworks/flux/api/v6"
-	"github.com/weaveworks/flux/api/v9"
+	v10 "github.com/weaveworks/flux/api/v10"
+	v11 "github.com/weaveworks/flux/api/v11"
+	v6 "github.com/weaveworks/flux/api/v6"
+	v9 "github.com/weaveworks/flux/api/v9"
 	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/cluster/kubernetes"
 	kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
@@ -638,7 +638,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 
 	var k8s *cluster.Mock
 	{
-		k8s = &cluster.Mock{}
+		k8s = &cluster.Mock{Logger: logger}
 		k8s.AllServicesFunc = func(maybeNamespace string) ([]cluster.Controller, error) {
 			if maybeNamespace == ns {
 				return []cluster.Controller{
@@ -697,7 +697,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 		Repo:           repo,
 		GitConfig:      params,
 		Cluster:        k8s,
-		Manifests:      &kubernetes.Manifests{},
+		Manifests:      &kubernetes.Manifests{Logger: logger},
 		Registry:       imageRegistry,
 		V:              testVersion,
 		Jobs:           jobs,

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -39,9 +39,10 @@ var (
 )
 
 func daemon(t *testing.T) (*Daemon, func()) {
+	logger := log.NewLogfmtLogger(os.Stdout)
 	repo, repoCleanup := gittest.Repo(t)
 
-	k8s = &cluster.Mock{}
+	k8s = &cluster.Mock{Logger: logger}
 	k8s.LoadManifestsFunc = kresource.Load
 	k8s.ParseManifestsFunc = func(allDefs []byte) (map[string]resource.Resource, error) {
 		return kresource.ParseMultidoc(allDefs, "exported")
@@ -75,7 +76,7 @@ func daemon(t *testing.T) (*Daemon, func()) {
 		Jobs:           jobs,
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
-		Logger:         log.NewLogfmtLogger(os.Stdout),
+		Logger:         logger,
 		LoopVars:       &LoopVars{},
 	}
 	return d, func() {

--- a/release/releaser_test.go
+++ b/release/releaser_test.go
@@ -135,7 +135,7 @@ var (
 			},
 		},
 	}
-	mockManifests = &kubernetes.Manifests{}
+	mockManifests = &kubernetes.Manifests{Logger: log.NewNopLogger()}
 )
 
 func mockCluster(running ...cluster.Controller) *cluster.Mock {
@@ -1070,7 +1070,7 @@ func Test_BadRelease(t *testing.T) {
 
 	ctx := &ReleaseContext{
 		cluster:   cluster,
-		manifests: &kubernetes.Manifests{},
+		manifests: &kubernetes.Manifests{Logger: log.NewNopLogger()},
 		repo:      checkout1,
 		registry:  mockRegistry,
 	}
@@ -1084,7 +1084,7 @@ func Test_BadRelease(t *testing.T) {
 
 	ctx = &ReleaseContext{
 		cluster:   cluster,
-		manifests: &badManifests{Manifests: kubernetes.Manifests{}},
+		manifests: &badManifests{Manifests: kubernetes.Manifests{Logger: log.NewNopLogger()}},
 		repo:      checkout2,
 		registry:  mockRegistry,
 	}

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -30,8 +30,8 @@ func TestSync(t *testing.T) {
 	// things when we add and remove resources from the config.
 
 	// Start with nothing running. We should be told to apply all the things.
-	mockCluster := &cluster.Mock{}
-	manifests := &kubernetes.Manifests{}
+	mockCluster := &cluster.Mock{Logger: log.NewNopLogger()}
+	manifests := &kubernetes.Manifests{Logger: log.NewNopLogger()}
 	var clus cluster.Cluster = &syncCluster{mockCluster, map[string][]byte{}}
 
 	dirs := checkout.ManifestDirs()


### PR DESCRIPTION
We [occassionally get cases](https://weave-community.slack.com/archives/C4U5ATZ9S/p1550650777411900) where it is difficult to understand why Helm integration doesn't work well, and in particular, which directories are taken into account by Flux or not. Extra logging might help there?

N.B.: I noticed loggers are only created in `main`s, and propagated down to where needed. However, this consequently introduces many small signature / field changes in various places. Please let me know if we'd rather do this differently and I'll happily update this PR.