### PR TITLE
Add Helm force upgrade option

### DIFF
--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -40,6 +40,10 @@ spec:
               format: int64
             resetValues:
               type: boolean
+            skipDepUpdate:
+              type: boolean
+            forceUpgrade:
+              type: boolean
             valueFileSecrets:
               type: array
               properties:

--- a/deploy-helm/flux-helm-release-crd.yaml
+++ b/deploy-helm/flux-helm-release-crd.yaml
@@ -33,6 +33,8 @@ spec:
               type: boolean
             skipDepUpdate:
               type: boolean
+            forceUpgrade:
+              type: boolean
             valueFileSecrets:
               type: array
               properties:

--- a/integrations/apis/flux.weave.works/v1beta1/types.go
+++ b/integrations/apis/flux.weave.works/v1beta1/types.go
@@ -86,6 +86,9 @@ type HelmReleaseSpec struct {
 	// Do not run 'dep' update (assume requirements.yaml is already fulfilled)
 	// +optional
 	SkipDepUpdate bool `json:"skipDepUpdate,omitempty"`
+	// Force resource update through delete/recreate, allows recovery from a failed state
+	// +optional
+	ForceUpgrade bool `json:"forceUpgrade,omitempty"`
 }
 
 // GetTimeout returns the install or upgrade timeout (defaults to 300s)

--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -208,6 +208,7 @@ func (r *Release) Install(chartPath, releaseName string, fhr flux_v1beta1.HelmRe
 			k8shelm.UpgradeDryRun(opts.DryRun),
 			k8shelm.UpgradeTimeout(fhr.GetTimeout()),
 			k8shelm.ResetValues(fhr.Spec.ResetValues),
+			k8shelm.UpgradeForce(fhr.Spec.ForceUpgrade),
 		)
 
 		if err != nil {


### PR DESCRIPTION
When upgrading a release that's not backwards compatible (changes in volumes, selectors, etc) Tiller will mark the release as failed and helm-op users have to delete the HR with kubectl  or force the upgrade using Helm CLI. This PR adds `forceUpgrade` option to the HR CRD to avoid manually interventions on the cluster. 
