### PR TITLE
Helm Chart allow mounting of docker credentials file

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -225,6 +225,8 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `registry.ecr.excludeId` | Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account | `602401143452`
 | `registry.acr.enabled` | Mount `azure.json` via HostPath into the Flux Pod, enabling Flux to use AKS's service principal for ACR authentication | `false`
 | `registry.acr.hostPath` | Alternative location of `azure.json` on the host | `/etc/kubernetes/azure.json`
+| `registry.dockercfg.enabled` | Mount `.dockerconfigjson` via Secret into the Flux Pod, enabling Flux to use a custom docker config file | `false`
+| `registry.dockercfg.secretName` | Kubernetes secret with the docker/config.json, in imagePullSecret format | `None`
 | `memcached.verbose` | Enable request logging in memcached | `false`
 | `memcached.maxItemSize` | Maximum size for one item | `1m`
 | `memcached.maxMemory` | Maximum memory to use, in megabytes | `64`

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -225,8 +225,8 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `registry.ecr.excludeId` | Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account | `602401143452`
 | `registry.acr.enabled` | Mount `azure.json` via HostPath into the Flux Pod, enabling Flux to use AKS's service principal for ACR authentication | `false`
 | `registry.acr.hostPath` | Alternative location of `azure.json` on the host | `/etc/kubernetes/azure.json`
-| `registry.dockercfg.enabled` | Mount `.dockerconfigjson` via Secret into the Flux Pod, enabling Flux to use a custom docker config file | `false`
-| `registry.dockercfg.secretName` | Kubernetes secret with the docker/config.json, in imagePullSecret format | `None`
+| `registry.dockercfg.enabled` | Mount `config.json` via Secret into the Flux Pod, enabling Flux to use a custom docker config file | `false`
+| `registry.dockercfg.secretName` | Kubernetes secret with the docker config.json | `None`
 | `memcached.verbose` | Enable request logging in memcached | `false`
 | `memcached.maxItemSize` | Maximum size for one item | `1m`
 | `memcached.maxMemory` | Maximum memory to use, in megabytes | `64`

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -58,6 +58,12 @@ spec:
           path: "{{ .Values.registry.acr.hostPath }}"
           type: ""
       {{- end }}
+      {{- if .Values.registry.dockercfg.enabled }}
+      - name: docker-credentials
+        secret:
+          secretName: "{{ .Values.registry.dockercfg.secretName }}"
+          defaultMode: 0400
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -82,6 +88,11 @@ spec:
           {{- if .Values.registry.acr.enabled }}
           - name: acr-credentials
             mountPath: /etc/kubernetes/azure.json
+            readOnly: true
+          {{- end }}
+          {{- if .Values.registry.dockercfg.enabled }}
+          - name: docker-credentials
+            mountPath: /dockercfg/
             readOnly: true
           {{- end }}
           env:
@@ -131,6 +142,9 @@ spec:
           {{- end }}
           {{- if .Values.registry.ecr.excludeId }}
           - --registry-ecr-exclude-id={{ .Values.registry.ecr.excludeId }}
+          {{- end }}
+          {{- if .Values.registry.dockercfg.enabled }}
+          - --docker-config=/dockercfg/.dockerconfigjson
           {{- end }}
           {{- if .Values.token }}
           - --connect=wss://cloud.weave.works/api/flux

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -144,7 +144,7 @@ spec:
           - --registry-ecr-exclude-id={{ .Values.registry.ecr.excludeId }}
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}
-          - --docker-config=/dockercfg/.dockerconfigjson
+          - --docker-config=/dockercfg/config.json
           {{- end }}
           {{- if .Values.token }}
           - --connect=wss://cloud.weave.works/api/flux

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -147,7 +147,9 @@ registry:
   acr:
     enabled: false
     hostPath: /etc/kubernetes/azure.json
-
+  dockercfg:
+    enabled: false
+    secretName: ""
 memcached:
   repository: memcached
   tag: 1.4.25


### PR DESCRIPTION
Fixes https://github.com/weaveworks/flux/issues/1310 as an alternative solution to https://github.com/weaveworks/flux/pull/1314

Enables fluxd to connect to private registries via the Helm Chart. This is done by mounting a custom docker config file from a Kubernetes Secret. The credentials are not placed in the Helm values or overrides, but instead must be side-loaded.

This is compatible with https://github.com/bzon/ecr-k8s-secret-creator per https://github.com/weaveworks/flux/pull/1314#issuecomment-418668316