### PR TITLE
Let `fluxctl list-images` adhere to namespace filter 

### DIFF
--- a/api/v10/api.go
+++ b/api/v10/api.go
@@ -12,6 +12,7 @@ import (
 type ListImagesOptions struct {
 	Spec                    update.ResourceSpec
 	OverrideContainerFields []string
+	Namespace               string
 }
 
 type Server interface {

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -65,6 +65,7 @@ func (opts *controllerShowOpts) RunE(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		imageOpts.Spec = update.MakeResourceSpec(id)
+		imageOpts.Namespace = ""
 	}
 
 	ctx := context.Background()

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/api/v10"
 	"github.com/weaveworks/flux/api/v6"
 	"github.com/weaveworks/flux/registry"
 	"github.com/weaveworks/flux/update"
@@ -35,7 +36,7 @@ func (opts *controllerShowOpts) Command() *cobra.Command {
 		Example: makeExample("fluxctl list-images --namespace default --controller=deployment/foo"),
 		RunE:    opts.RunE,
 	}
-	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "default", "Controller namespace")
+	cmd.Flags().StringVarP(&opts.namespace, "namespace", "n", "", "Controller namespace")
 	cmd.Flags().StringVarP(&opts.controller, "controller", "c", "", "Show images for this controller")
 	cmd.Flags().IntVarP(&opts.limit, "limit", "l", 10, "Number of images to show (0 for all)")
 
@@ -54,20 +55,21 @@ func (opts *controllerShowOpts) RunE(cmd *cobra.Command, args []string) error {
 		return errorWantedNoArgs
 	}
 
-	var resourceSpec update.ResourceSpec
-	if len(opts.controller) == 0 {
-		resourceSpec = update.ResourceSpecAll
-	} else {
+	imageOpts := v10.ListImagesOptions{
+		Spec:      update.ResourceSpecAll,
+		Namespace: opts.namespace,
+	}
+	if len(opts.controller) > 0 {
 		id, err := flux.ParseResourceIDOptionalNamespace(opts.namespace, opts.controller)
 		if err != nil {
 			return err
 		}
-		resourceSpec = update.MakeResourceSpec(id)
+		imageOpts.Spec = update.MakeResourceSpec(id)
 	}
 
 	ctx := context.Background()
 
-	controllers, err := opts.API.ListImages(ctx, resourceSpec)
+	controllers, err := opts.API.ListImagesWithOptions(ctx, imageOpts)
 	if err != nil {
 		return err
 	}

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -326,6 +326,44 @@ func TestDaemon_ListImagesWithOptions(t *testing.T) {
 			expectedImages: nil,
 			shouldError:    true,
 		},
+		{
+			name: "Specific namespace",
+			opts: v10.ListImagesOptions{
+				Spec:      specAll,
+				Namespace: ns,
+			},
+			expectedImages: []v6.ImageStatus{
+				{
+					ID: svcID,
+					Containers: []v6.Container{
+						{
+							Name:           container,
+							Current:        image.Info{ID: currentImageRef},
+							LatestFiltered: image.Info{ID: newImageRef},
+							Available: []image.Info{
+								{ID: newImageRef},
+								{ID: currentImageRef},
+								{ID: oldImageRef},
+							},
+							AvailableImagesCount:    3,
+							NewAvailableImagesCount: 1,
+							FilteredImagesCount:     3,
+							NewFilteredImagesCount:  1,
+						},
+					},
+				},
+			},
+			shouldError: false,
+		},
+		{
+			name: "Specific namespace and service",
+			opts: v10.ListImagesOptions{
+				Spec:      update.ResourceSpec(svc),
+				Namespace: ns,
+			},
+			expectedImages: nil,
+			shouldError:    true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/http/client/client.go
+++ b/http/client/client.go
@@ -77,7 +77,7 @@ func (c *Client) ListImages(ctx context.Context, s update.ResourceSpec) ([]v6.Im
 
 func (c *Client) ListImagesWithOptions(ctx context.Context, opts v10.ListImagesOptions) ([]v6.ImageStatus, error) {
 	var res []v6.ImageStatus
-	err := c.Get(ctx, &res, transport.ListImagesWithOptions, "service", string(opts.Spec), "containerFields", strings.Join(opts.OverrideContainerFields, ","))
+	err := c.Get(ctx, &res, transport.ListImagesWithOptions, "service", string(opts.Spec), "containerFields", strings.Join(opts.OverrideContainerFields, ","), "namespace", opts.Namespace)
 	return res, err
 }
 

--- a/http/daemon/server.go
+++ b/http/daemon/server.go
@@ -99,7 +99,7 @@ func (s HTTPServer) ListImagesWithOptions(w http.ResponseWriter, r *http.Request
 	var opts v10.ListImagesOptions
 	queryValues := r.URL.Query()
 
-	// service - Select services to update.
+	// service - Select services to list images for.
 	service := queryValues.Get("service")
 	if service == "" {
 		service = string(update.ResourceSpecAll)
@@ -115,6 +115,12 @@ func (s HTTPServer) ListImagesWithOptions(w http.ResponseWriter, r *http.Request
 	containerFields := queryValues.Get("containerFields")
 	if containerFields != "" {
 		opts.OverrideContainerFields = strings.Split(containerFields, ",")
+	}
+
+	// namespace - Select namespace to list images for.
+	namespace := queryValues.Get("namespace")
+	if namespace != "" {
+		opts.Namespace = namespace
 	}
 
 	d, err := s.server.ListImagesWithOptions(r.Context(), opts)


### PR DESCRIPTION
Fixes #837.

Tested the daemon with previous `fluxctl` versions and saw no abnormalities.