### PR TITLE
Improve testing in local environments other than linux-amd64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ testdata/sidecar/sidecar-linux-amd64
 testdata/sidecar/.sidecar
 docker/fluxy-dumbconf.priv
 test/profiles
+test/bin/kubectl
+test/bin/helm


### PR DESCRIPTION
Unit tests rely on the `helm` binary and assume that the executing environment
is `linux-amd64`.

This makes tests fail in other environments like `darwin`, making development
unpleasant.

This change improves the situation by downloading and running test-specific
binaries from the local OS/architecture.

Apart from running the `helm` binary this change also downloads `kubectl` in
preparation for testing the parsing of `kubectl config current-context` in
https://github.com/weaveworks/flux/pull/1442 .

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
