### PR TITLE
Apply user defined Git timeout on all operations

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -442,6 +442,7 @@ func main() {
 		LoopVars: &daemon.LoopVars{
 			SyncInterval:         *syncInterval,
 			RegistryPollInterval: *registryPollInterval,
+			GitOpTimeout:         *gitTimeout,
 		},
 	}
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -704,7 +704,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
 		Logger:         logger,
-		LoopVars:       &LoopVars{},
+		LoopVars:       &LoopVars{GitOpTimeout: 5 * time.Second},
 	}
 
 	start := func() {

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -76,7 +76,7 @@ func daemon(t *testing.T) (*Daemon, func()) {
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
 		Logger:         log.NewLogfmtLogger(os.Stdout),
-		LoopVars:       &LoopVars{},
+		LoopVars:       &LoopVars{GitOpTimeout: 5 * time.Second},
 	}
 	return d, func() {
 		close(shutdown)


### PR DESCRIPTION
Per [users comment](https://github.com/weaveworks/flux/pull/1416#issuecomment-467127450) on #1416.

This enables the user to tweak the timeout on slower/remote networks to let the loop succeed in one take instead of waiting for the entire loop cycle to get retried (and possibly fail again).