### PR TITLE
Provide descriptive error when chart dir is absent while updating deps

### DIFF
--- a/integrations/helm/chartsync/deps.go
+++ b/integrations/helm/chartsync/deps.go
@@ -1,6 +1,7 @@
 package chartsync
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -12,8 +13,13 @@ func updateDependencies(chartDir, helmhome string) error {
 	var hasLockFile bool
 
 	// sanity check: does the chart directory exist
+	if chartDir == "" {
+		return errors.New("empty path to chart supplied")
+	}
 	chartInfo, err := os.Stat(chartDir)
 	switch {
+	case os.IsNotExist(err):
+		return fmt.Errorf("chart path %s does not exist", chartDir)
 	case err != nil:
 		return err
 	case !chartInfo.IsDir():


### PR DESCRIPTION
Fixes #1764 

Explicitly check if the given chart directory does exist before trying to stat the `requirements.yaml` file and return a descriptive error if this is not the case. This provides users more guidance than the stat error we returned in the past.

```
ts=2019-02-26T17:58:36.52551703Z caller=chartsync.go:247 component=chartsync info="Start of releasesync"
ts=2019-02-26T17:58:36.566542344Z caller=chartsync.go:333 component=chartsync warning="Failed to update chart dependencies" namespace=default name=ghost error="chart path /tmp/flux-working475910449/charts/ghost does not exist"
ts=2019-02-26T17:58:36.566698882Z caller=chartsync.go:252 component=chartsync info="End of releasesync"
```