### PR TITLE
Rename resource method Policy() to Policies()

### DIFF
--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -94,7 +94,7 @@ func PolicyFromAnnotations(annotations map[string]string) policy.Set {
 	return set
 }
 
-func (o baseObject) Policy() policy.Set {
+func (o baseObject) Policies() policy.Set {
 	return PolicyFromAnnotations(o.Meta.Annotations)
 }
 

--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -60,7 +60,7 @@ func (c *Cluster) Sync(spec cluster.SyncSet) error {
 		csum := sha1.Sum(res.Bytes())
 		checkHex := hex.EncodeToString(csum[:])
 		checksums[id] = checkHex
-		if res.Policy().Has(policy.Ignore) {
+		if res.Policies().Has(policy.Ignore) {
 			logger.Log("info", "not applying resource; ignore annotation in file", "resource", res.ResourceID(), "source", res.Source())
 			continue
 		}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -128,7 +128,7 @@ func (d *Daemon) ListServicesWithOptions(ctx context.Context, opts v11.ListServi
 		readOnly := v6.ReadOnlyOK
 		var policies policy.Set
 		if resource, ok := resources[service.ID.String()]; ok {
-			policies = resource.Policy()
+			policies = resource.Policies()
 		}
 		switch {
 		case policies == nil:
@@ -637,7 +637,7 @@ func getServiceContainers(service cluster.Controller, imageRepos update.ImageRep
 		imageRepo := c.Image.Name
 		var policies policy.Set
 		if resource != nil {
-			policies = resource.Policy()
+			policies = resource.Policies()
 		}
 		tagPattern := policy.GetTagPattern(policies, c.Name)
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -520,7 +520,7 @@ func TestDaemon_PolicyUpdate(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Error: %s", err.Error())
 		}
-		return len(m[svc].Policy()) > 0
+		return len(m[svc].Policies()) > 0
 	}, "Waiting for new annotation")
 }
 

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -44,7 +44,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 	for _, service := range services {
 		var p policy.Set
 		if resource, ok := candidateServices[service.ID]; ok {
-			p = resource.Policy()
+			p = resource.Policies()
 		}
 	containers:
 		for _, container := range service.ContainersOrNil() {
@@ -106,7 +106,7 @@ func (d *Daemon) getAllowedAutomatedResources(ctx context.Context) (resources, e
 
 	result := map[flux.ResourceID]resource.Resource{}
 	for _, resource := range resources {
-		policies := resource.Policy()
+		policies := resource.Policies()
 		if policies.Has(policy.Automated) && !policies.Has(policy.Locked) && !policies.Has(policy.Ignore) {
 			result[resource.ResourceID()] = resource
 		}

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -16,10 +16,10 @@ func TestJSON(t *testing.T) {
 	policy := boolPolicy.Set(LockedUser, "user@example.com")
 
 	if !(policy.Has(Ignore) && policy.Has(Locked)) {
-		t.Errorf("Policy did not include those added")
+		t.Errorf("Policies did not include those added")
 	}
 	if val, ok := policy.Get(LockedUser); !ok || val != "user@example.com" {
-		t.Errorf("Policy did not include policy that was set")
+		t.Errorf("Policies did not include policy that was set")
 	}
 
 	bs, err := json.Marshal(policy)

--- a/resource/resource.go
+++ b/resource/resource.go
@@ -9,7 +9,7 @@ import (
 // For the minute we just care about
 type Resource interface {
 	ResourceID() flux.ResourceID // name, to correlate with what's in the cluster
-	Policy() policy.Set          // policy for this resource; e.g., whether it is locked, automated, ignored
+	Policies() policy.Set        // policy for this resource; e.g., whether it is locked, automated, ignored
 	Source() string              // where did this come from (informational)
 	Bytes() []byte               // the definition, for sending to cluster.Sync
 }

--- a/update/filter.go
+++ b/update/filter.go
@@ -82,7 +82,7 @@ type LockedFilter struct {
 }
 
 func (f *LockedFilter) Filter(u ControllerUpdate) ControllerResult {
-	if u.Resource.Policy().Has(policy.Locked) {
+	if u.Resource.Policies().Has(policy.Locked) {
 		return ControllerResult{
 			Status: ReleaseStatusSkipped,
 			Error:  Locked,

--- a/update/release_image.go
+++ b/update/release_image.go
@@ -229,7 +229,7 @@ func (s ReleaseImageSpec) calculateImageUpdates(rc ReleaseContext, candidates []
 			// Use the container's filter if the spec does not want to force release, or
 			// all images requested
 			if !s.Force || s.ImageSpec == ImageSpecLatest {
-				if pattern, ok := u.Resource.Policy().Get(policy.TagPrefix(container.Name)); ok {
+				if pattern, ok := u.Resource.Policies().Get(policy.TagPrefix(container.Name)); ok {
 					tagPattern = policy.NewPattern(pattern)
 				}
 			}


### PR DESCRIPTION
It returns a policy set not a single policy.
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
