### PR TITLE
Provide hook to instruct Helm operator to refresh git mirrors

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -186,7 +186,7 @@ func main() {
 	checkpoint.CheckForUpdates(product, version, nil, log.With(logger, "component", "checkpoint"))
 
 	// start HTTP server
-	go daemonhttp.ListenAndServe(*listenAddr, log.With(logger, "component", "daemonhttp"), shutdown)
+	go daemonhttp.ListenAndServe(*listenAddr, chartSync, log.With(logger, "component", "daemonhttp"), shutdown)
 
 	// start operator
 	go func() {

--- a/integrations/helm/api/api.go
+++ b/integrations/helm/api/api.go
@@ -1,0 +1,7 @@
+package api
+
+// Server is the interface that must be satisfied in order to serve
+// HTTP API requests.
+type Server interface {
+	SyncMirrors()
+}

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -59,7 +59,6 @@ import (
 	fluxv1beta1 "github.com/weaveworks/flux/integrations/apis/flux.weave.works/v1beta1"
 	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
 	helmop "github.com/weaveworks/flux/integrations/helm"
-	"github.com/weaveworks/flux/integrations/helm/api"
 	"github.com/weaveworks/flux/integrations/helm/release"
 	"github.com/weaveworks/flux/integrations/helm/status"
 )
@@ -121,8 +120,6 @@ type ChartChangeSync struct {
 
 	namespace string
 }
-
-var _ api.Server = &ChartChangeSync{}
 
 func New(logger log.Logger, polling Polling, clients Clients, release *release.Release, config Config, namespace string) *ChartChangeSync {
 	return &ChartChangeSync{

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -59,6 +59,7 @@ import (
 	fluxv1beta1 "github.com/weaveworks/flux/integrations/apis/flux.weave.works/v1beta1"
 	ifclientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
 	helmop "github.com/weaveworks/flux/integrations/helm"
+	"github.com/weaveworks/flux/integrations/helm/api"
 	"github.com/weaveworks/flux/integrations/helm/release"
 	"github.com/weaveworks/flux/integrations/helm/status"
 )
@@ -120,6 +121,8 @@ type ChartChangeSync struct {
 
 	namespace string
 }
+
+var _ api.Server = &ChartChangeSync{}
 
 func New(logger log.Logger, polling Polling, clients Clients, release *release.Release, config Config, namespace string) *ChartChangeSync {
 	return &ChartChangeSync{
@@ -400,6 +403,15 @@ func (chs *ChartChangeSync) DeleteRelease(fhr fluxv1beta1.HelmRelease) {
 	if err != nil {
 		chs.logger.Log("warning", "Chart release not deleted", "release", name, "error", err)
 	}
+}
+
+// SyncMirrors instructs all mirrors to refresh from their upstream.
+func (chs *ChartChangeSync) SyncMirrors() {
+	chs.logger.Log("info", "Starting mirror sync")
+	for _, err := range chs.mirrors.RefreshAll(chs.config.GitTimeout) {
+		chs.logger.Log("error", fmt.Sprintf("Failure while syncing mirror: %s", err))
+	}
+	chs.logger.Log("info", "Finished syncing mirrors")
 }
 
 // getCustomResources assembles all custom resources in all namespaces

--- a/integrations/helm/http/daemon/server.go
+++ b/integrations/helm/http/daemon/server.go
@@ -73,7 +73,7 @@ type APIServer struct {
 // has been started.
 // TODO(hidde): in the future we may want to give users the option to
 // request the status after it has been started. The Flux (daemon) API
-// archives this by working with jobs whos IDs can be tracked.
+// achieves this by working with jobs whos IDs can be tracked.
 func (s APIServer) SyncGit(w http.ResponseWriter, r *http.Request) {
 	go s.server.SyncMirrors()
 

--- a/integrations/helm/http/daemon/server.go
+++ b/integrations/helm/http/daemon/server.go
@@ -4,19 +4,29 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-kit/kit/log"
+	"github.com/gorilla/mux"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/weaveworks/flux/integrations/helm/api"
+	transport "github.com/weaveworks/flux/integrations/helm/http"
 	"net/http"
 	"time"
 )
 
-// ListenAndServe starts a HTTP server instrumented with Prometheus on the specified address
-func ListenAndServe(listenAddr string, logger log.Logger, stopCh <-chan struct{}) {
+// ListenAndServe starts a HTTP server instrumented with Prometheus metrics,
+// health and API endpoints on the specified address.
+func ListenAndServe(listenAddr string, apiServer api.Server, logger log.Logger, stopCh <-chan struct{}) {
 	mux := http.DefaultServeMux
+
+	// setup metrics and health endpoints
 	mux.Handle("/metrics", promhttp.Handler())
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("OK"))
 	})
+
+	// setup api endpoints
+	handler := NewHandler(apiServer, transport.NewRouter())
+	mux.Handle("/api/", http.StripPrefix("/api", handler))
 
 	srv := &http.Server{
 		Addr:         listenAddr,
@@ -45,4 +55,28 @@ func ListenAndServe(listenAddr string, logger log.Logger, stopCh <-chan struct{}
 	} else {
 		logger.Log("info", "HTTP server stopped")
 	}
+}
+
+// NewHandler registers handlers on the given router.
+func NewHandler(s api.Server, r *mux.Router) http.Handler {
+	handle := APIServer{s}
+	r.Get(transport.SyncGit).HandlerFunc(handle.SyncGit)
+	return r
+}
+
+type APIServer struct {
+	server api.Server
+}
+
+// SyncGit starts a goroutine in the background to sync all git mirrors
+// and writes back a HTTP 200 status header and 'OK' body to inform it
+// has been started.
+// TODO(hidde): in the future we may want to give users the option to
+// request the status after it has been started. The Flux (daemon) API
+// archives this by working with jobs whos IDs can be tracked.
+func (s APIServer) SyncGit(w http.ResponseWriter, r *http.Request) {
+	go s.server.SyncMirrors()
+
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("OK"))
 }

--- a/integrations/helm/http/routes.go
+++ b/integrations/helm/http/routes.go
@@ -1,0 +1,5 @@
+package http
+
+const (
+	SyncGit = "SyncGit"
+)

--- a/integrations/helm/http/transport.go
+++ b/integrations/helm/http/transport.go
@@ -1,0 +1,13 @@
+package http
+
+import (
+	"github.com/gorilla/mux"
+)
+
+// NewRouter creates a new routeri nstance, registers all API routes
+// and returns it.
+func NewRouter() *mux.Router {
+	r := mux.NewRouter()
+	r.NewRoute().Name(SyncGit).Methods("POST").Path("/v1/sync-git")
+	return r
+}

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -109,7 +109,7 @@ func New(
 			}
 		},
 		UpdateFunc: func(old, new interface{}) {
-			controller.enqueueUpateJob(old, new)
+			controller.enqueueUpdateJob(old, new)
 		},
 		DeleteFunc: func(old interface{}) {
 			fhr, ok := checkCustomResourceType(controller.logger, old)
@@ -287,7 +287,7 @@ func (c *Controller) enqueueJob(obj interface{}) {
 }
 
 // enqueueUpdateJob decides if there is a genuine resource update
-func (c *Controller) enqueueUpateJob(old, new interface{}) {
+func (c *Controller) enqueueUpdateJob(old, new interface{}) {
 	oldFhr, ok := checkCustomResourceType(c.logger, old)
 	if !ok {
 		return

--- a/site/helm-integration.md
+++ b/site/helm-integration.md
@@ -6,6 +6,7 @@ menu_order: 90
 - [Using Flux with Helm](#using-flux-with-helm)
   * [The `HelmRelease` custom resource](#the-helmrelease-custom-resource)
     + [Using a chart from a Git repo instead of a Helm repo](#using-a-chart-from-a-git-repo-instead-of-a-helm-repo)
+      - [Notifying Helm Operator about Git changes](#notifying-helm-operator-about-git-changes)
     + [What the Helm Operator does](#what-the-helm-operator-does)
   * [Supplying values to the chart](#supplying-values-to-the-chart)
     + [`.spec.values`](#specvalues)
@@ -95,6 +96,25 @@ to the git repository. The example deployment shows how to mount a
 secret at the expected location of the key (`/etc/fluxd/ssh/`). If you
 need more than one SSH key, you'll need to also mount an adapted
 ssh_config; this is also demonstrated in the example deployment.
+
+#### Notifying Helm Operator about Git changes
+
+The Helm Operator fetches the upstream of mirrored Git repositories
+with a 5 minute interval. In some scenarios (think CI/CD), you may not
+want to wait for this interval to occur.
+
+To help you with this the Helm Operator serves a HTTP API endpoint to
+instruct it to immediately refresh all Git mirrors.
+
+```sh
+$ kubectl -n flux port-forward deployment/flux-helm-operator 3030:3030 &
+$ curl -XPOST http://localhost:3030/api/v1/sync-git
+OK
+```
+
+> **Note:** the HTTP API has no built-in authentication, this means you
+> either need to port forward before making the request or put something
+> in front of it to serve as a gatekeeper.
 
 ### What the Helm Operator does
 

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -29,7 +29,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 | --log-release-diffs       | `false`                       | Log the diff when a chart release diverges. **Potentially insecure.**
 | --update-chart-deps       | `true`                        | Update chart dependencies before installing or upgrading a release.
 
-## Installing Weave Flux helm-operator and Helm with TLS enabled
+## Installing Weave Flux Helm Operator and Helm with TLS enabled
 
 ### Installing Helm / Tiller
 
@@ -166,7 +166,7 @@ helm --tls --tls-verify \
   ls
 ```
 
-### deploy weave Flux helm-operator
+### Deploy Weave Flux Helm Operator
 
 First create a new Kubernetes TLS secret for the client certs;
 
@@ -197,7 +197,7 @@ helm upgrade --install \
 
 #### Check if it worked
 
-Use `kubectl logs` on the helm-operator and observe the helm client being created.
+Use `kubectl logs` on the Helm Operator and observe the helm client being created.
 
 #### Debugging
 
@@ -223,7 +223,7 @@ metadata:
   uid: c106f866-7f9e-11e8-904a-025000000001
 ```
 
-## Installing Weave Flux helm-operator for Weave Cloud
+## Installing Weave Flux Helm Operator for Weave Cloud
 
 In order to use the Helm operator with Weave Cloud you have to apply the `HelmRelease` CRD definition and the operator
 deployment in the `weave` namespace:


### PR DESCRIPTION
Fixes #1430

This adds a webhook to the Helm operator as described in the issue above. The webhook starts a goroutine which instructs every mirror to refresh.