### PR TITLE
Increase timeouts in daemon_test.go

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -50,10 +50,9 @@ const (
 	testVersion = "test"
 )
 
-var (
-	testBytes = []byte(`{}`)
-	timeout   = 5 * time.Second
-)
+var testBytes = []byte(`{}`)
+
+const timeout = 10 * time.Second
 
 // When I ping, I should get a response
 func TestDaemon_Ping(t *testing.T) {
@@ -743,7 +742,7 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 		JobStatusCache: &job.StatusCache{Size: 100},
 		EventWriter:    events,
 		Logger:         logger,
-		LoopVars:       &LoopVars{GitOpTimeout: 5 * time.Second},
+		LoopVars:       &LoopVars{GitOpTimeout: timeout},
 	}
 
 	start := func() {


### PR DESCRIPTION
The 5s timeout was making local tests flakey in my (admitedly a bit old)
machine.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
