### PR TITLE
Wait for shutdown before returning from main()

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -222,15 +222,6 @@ func main() {
 		errc <- fmt.Errorf("%s", <-c)
 	}()
 
-	// This means we can return, and it will use the shutdown
-	// protocol.
-	defer func() {
-		// wait here until stopping.
-		logger.Log("exiting", <-errc)
-		close(shutdown)
-		shutdownWg.Wait()
-	}()
-
 	// Cluster component.
 	var clusterVersion string
 	var sshKeyRing ssh.KeyRing
@@ -546,5 +537,8 @@ func main() {
 		}()
 	}
 
-	// Fall off the end, into the waiting procedure.
+	// wait here until stopping.
+	logger.Log("exiting", <-errc)
+	close(shutdown)
+	shutdownWg.Wait()
 }


### PR DESCRIPTION
Fixes #1788

Currently, `memcachedClient.Stop()` is getting called at the beginning of the run, on return from `main()`, which breaks things if the cache moves address.

~Personally I find this style too confusing and would just wait at the end of `main()`, but this looks like a trivial fix.~