### PR TITLE
Make garbage-collection labelling resource-specific

### DIFF
--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -79,7 +79,7 @@ func (o *baseObject) debyte() {
 	o.bytes = nil
 }
 
-func PolicyFromAnnotations(annotations map[string]string) policy.Set {
+func PoliciesFromAnnotations(annotations map[string]string) policy.Set {
 	set := policy.Set{}
 	for k, v := range annotations {
 		if strings.HasPrefix(k, PolicyPrefix) {
@@ -95,7 +95,7 @@ func PolicyFromAnnotations(annotations map[string]string) policy.Set {
 }
 
 func (o baseObject) Policies() policy.Set {
-	return PolicyFromAnnotations(o.Meta.Annotations)
+	return PoliciesFromAnnotations(o.Meta.Annotations)
 }
 
 func (o baseObject) Source() string {

--- a/cluster/kubernetes/sync_test.go
+++ b/cluster/kubernetes/sync_test.go
@@ -291,7 +291,7 @@ metadata:
 		}
 
 		// Now check that the resources were created
-		actual, err := kube.getResourcesInSyncSet("testset")
+		actual, err := kube.getGCMarkedResourcesInSyncSet("testset")
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -160,7 +160,7 @@ func (d *Daemon) doSync(logger log.Logger, lastKnownSyncTagRev *string, warnedAb
 		).Observe(time.Since(started).Seconds())
 	}()
 
-	syncSetName := makeSyncLabel(d.Repo.Origin(), d.GitConfig)
+	syncSetName := makeGitConfigHash(d.Repo.Origin(), d.GitConfig)
 
 	// We don't care how long this takes overall, only about not
 	// getting bogged down in certain operations, so use an
@@ -455,7 +455,7 @@ func isUnknownRevision(err error) bool {
 			strings.Contains(err.Error(), "bad revision"))
 }
 
-func makeSyncLabel(remote git.Remote, conf git.Config) string {
+func makeGitConfigHash(remote git.Remote, conf git.Config) string {
 	urlbit := remote.SafeURL()
 	pathshash := sha256.New()
 	pathshash.Write([]byte(urlbit))
@@ -463,7 +463,5 @@ func makeSyncLabel(remote git.Remote, conf git.Config) string {
 	for _, path := range conf.Paths {
 		pathshash.Write([]byte(path))
 	}
-	// the prefix is in part to make sure it's a valid (Kubernetes)
-	// label value -- a modest abstraction leak
-	return "git-" + base64.RawURLEncoding.EncodeToString(pathshash.Sum(nil))
+	return base64.RawURLEncoding.EncodeToString(pathshash.Sum(nil))
 }


### PR DESCRIPTION
This prevents unintended delitions from happening if/when cluster object labels
are copied around.

I also changed some names and tweaked comments a bit.

Fixes #1787 

Disclaimer: I haven't tested it (yet)

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
