### PR TITLE
Bump Alpine version from v3.6 to v3.9

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.9
 
 WORKDIR /home/flux
 

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -1,4 +1,4 @@
-FROM alpine:3.6
+FROM alpine:3.9
 
 WORKDIR /home/flux
 


### PR DESCRIPTION
We have multiple nightly builds (from `44874ead` up to and including
`c9cda8ab` at time of this commit) with gnupg 2.1.20-r1 baked into
them which is effected by CVE-2018-12020 (patched in >=2.2.3-r1).

As there is no newer version of gnupg available in the Alpine
main/v3.6 repository, and 3.6 is only receiving security updates
(but with a delay?), and support for 3.6 ends on 2019-05-01,
this bump is mandatory.