### PR TITLE
Replace ':' with '.' in GC mark

### DIFF
--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -298,7 +298,8 @@ func makeGCMark(syncSetName, resourceID string) string {
 	// To prevent deleting objects with copied labels
 	// an object-specific mark is created (by including its identifier).
 	hasher.Write([]byte(resourceID))
-	return "sha256:" + base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
+	// The prefix is in part to make sure it's a valid (Kubernetes) label.
+	return "sha256." + base64.RawURLEncoding.EncodeToString(hasher.Sum(nil))
 }
 
 // --- internal types for keeping track of syncing


### PR DESCRIPTION
A valid Kubernetes label may only contain alphanumeric characters, '-',
'_' or '.', and must start and end with an alphanumeric character (e.g.
'MyValue',  or 'my_value',  or '12345'.