### PR TITLE
Do not require 'values' object in HelmRelease CRD

### DIFF
--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -30,7 +30,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          required: ['values', 'chart']
+          required: ['chart']
           properties:
             releaseName:
               type: string

--- a/deploy-helm/flux-helm-release-crd.yaml
+++ b/deploy-helm/flux-helm-release-crd.yaml
@@ -21,7 +21,7 @@ spec:
     openAPIV3Schema:
       properties:
         spec:
-          required: ['values', 'chart']
+          required: ['chart']
           properties:
             releaseName:
               type: string


### PR DESCRIPTION
Fixes #1812 

People sometimes just want to deploy a chart without setting any custom values. Before this commit this required setting a `values: {}` in the `HelmRelease`, which was quite inconvenient.

Change to the CRD only is sufficient as the code already takes, not receiving values, into account.