### PR TITLE
Desambiguate revisions and files when invoking `git`

### DIFF
--- a/git/gittest/repo.go
+++ b/git/gittest/repo.go
@@ -75,6 +75,10 @@ func Workloads() (res []flux.ResourceID) {
 // CheckoutWithConfig makes a standard repo, clones it, and returns
 // the clone, the original repo, and a cleanup function.
 func CheckoutWithConfig(t *testing.T, config git.Config) (*git.Checkout, *git.Repo, func()) {
+	// Add files to the repo with the same name as the git branch and the sync tag.
+	// This is to make sure that git commands don't have ambiguity problems between revisions and files.
+	testfiles.Files[config.Branch] = "Filename doctored to create a conflict with the git branch name"
+	testfiles.Files[config.SyncTag] = "Filename doctored to create a conflict with the git sync tag"
 	repo, cleanup := Repo(t)
 	if err := repo.Ready(context.Background()); err != nil {
 		cleanup()
@@ -89,6 +93,8 @@ func CheckoutWithConfig(t *testing.T, config git.Config) (*git.Checkout, *git.Re
 	return co, repo, func() {
 		co.Clean()
 		cleanup()
+		delete(testfiles.Files, config.Branch)
+		delete(testfiles.Files, config.SyncTag)
 	}
 }
 


### PR DESCRIPTION
User Git repositories may use the same name for:
* A file and a branch used by Flux
* A file and the tag used by Flux for syncing

For instance:
```
ts=2019-03-13T19:36:40.432679542Z caller=loop.go:90 component=sync-loop err="fatal: ambiguous argument 'staging': both revision and filename"
```

(See https://weave-community.slack.com/archives/C4U5ATZ9S/p1552505808477700?thread_ts=1552504490.476100&cid=C4U5ATZ9S )

This change removes that ambiguity by appending `--` at the right places when invoking `git`.

In a few cases we were only appending it when adding files at the end, which wasn't correct.

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
