### PR TITLE
Require creation metadata during auto release

### DIFF
--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -2,7 +2,6 @@ package daemon
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -619,62 +618,6 @@ func TestDaemon_Automated_semver(t *testing.T) {
 
 	// helloworld:3 is older than helloworld:2 but semver orders by version
 	w.ForImageTag(t, d, resid.String(), container, "3")
-}
-
-func TestDaemon_Automated_no_metadata(t *testing.T) {
-	d, start, clean, k8s, _, _ := mockDaemon(t)
-	var imageRegistry registry.Registry
-	{
-		imageRegistry = &registryMock.Registry{
-			Images: []image.Info{
-				image.Info{ID: mustParseImageRef(currentHelloImage)},
-				makeImageInfo(newHelloImage, time.Now()),
-			},
-		}
-	}
-	d.Registry = imageRegistry
-	start()
-	defer clean()
-
-	workload := cluster.Workload{
-		ID: flux.MakeResourceID(ns, "deployment", "helloworld"),
-		Containers: cluster.ContainersOrExcuse{
-			Containers: []resource.Container{
-				{
-					Name:  container,
-					Image: mustParseImageRef(currentHelloImage),
-				},
-			},
-		},
-	}
-	k8s.SomeWorkloadsFunc = func([]flux.ResourceID) ([]cluster.Workload, error) {
-		return []cluster.Workload{workload}, nil
-	}
-
-	b := &bytes.Buffer{}
-	d.pollForNewImages(log.NewLogfmtLogger(b))
-
-	sc := bufio.NewScanner(b)
-	var msg, current, new bool
-	for sc.Scan() {
-		if strings.Contains(sc.Text(), "image with zero created timestamp") {
-			msg = true
-		}
-		if strings.Contains(sc.Text(), "quay.io/weaveworks/helloworld:master-a000001 (0001-01-01 00:00:00 +0000 UTC)") {
-			current = true
-		}
-		if strings.Contains(sc.Text(), "quay.io/weaveworks/helloworld:2") {
-			new = true
-		}
-	}
-
-	if !msg {
-		t.Error("expected zero created timestamp warning")
-	} else if !current {
-		t.Error("expected current image with zero timestamp")
-	} else if !new {
-		t.Error("expected new image")
-	}
 }
 
 func makeImageInfo(ref string, t time.Time) image.Info {

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/cluster"
 	"github.com/weaveworks/flux/policy"
 	"github.com/weaveworks/flux/resource"
 	"github.com/weaveworks/flux/update"
@@ -40,38 +41,7 @@ func (d *Daemon) pollForNewImages(logger log.Logger) {
 		return
 	}
 
-	changes := &update.Automated{}
-	for _, workload := range workloads {
-		var p policy.Set
-		if resource, ok := candidateWorkloads[workload.ID]; ok {
-			p = resource.Policies()
-		}
-	containers:
-		for _, container := range workload.ContainersOrNil() {
-			currentImageID := container.Image
-			pattern := policy.GetTagPattern(p, container.Name)
-			repo := currentImageID.Name
-			logger := log.With(logger, "workload", workload.ID, "container", container.Name, "repo", repo, "pattern", pattern, "current", currentImageID)
-
-			images := imageRepos.GetRepoImages(repo)
-			filteredImages := images.FilterAndSort(pattern)
-
-			if latest, ok := filteredImages.Latest(); ok && latest.ID != currentImageID {
-				if latest.ID.Tag == "" {
-					logger.Log("warning", "untagged image in available images", "action", "skip container")
-					continue containers
-				}
-				current := images.FindWithRef(currentImageID)
-				if current.CreatedAt.IsZero() || latest.CreatedAt.IsZero() {
-					logger.Log("warning", "image with zero created timestamp", "current", fmt.Sprintf("%s (%s)", current.ID, current.CreatedAt), "latest", fmt.Sprintf("%s (%s)", latest.ID, latest.CreatedAt), "action", "skip container")
-					continue containers
-				}
-				newImage := currentImageID.WithNewTag(latest.ID.Tag)
-				changes.Add(workload.ID, container, newImage)
-				logger.Log("info", "added update to automation run", "new", newImage, "reason", fmt.Sprintf("latest %s (%s) > current %s (%s)", latest.ID.Tag, latest.CreatedAt, currentImageID.Tag, current.CreatedAt))
-			}
-		}
-	}
+	changes := calculateChanges(logger, candidateWorkloads, workloads, imageRepos)
 
 	if len(changes.Changes) > 0 {
 		d.UpdateManifests(ctx, update.Spec{Type: update.Auto, Spec: changes})
@@ -104,4 +74,42 @@ func (d *Daemon) getAllowedAutomatedResources(ctx context.Context) (resources, e
 		}
 	}
 	return result, nil
+}
+
+func calculateChanges(logger log.Logger, candidateWorkloads resources, workloads []cluster.Workload, imageRepos update.ImageRepos) *update.Automated {
+	changes := &update.Automated{}
+
+	for _, workload := range workloads {
+		var p policy.Set
+		if resource, ok := candidateWorkloads[workload.ID]; ok {
+			p = resource.Policies()
+		}
+	containers:
+		for _, container := range workload.ContainersOrNil() {
+			currentImageID := container.Image
+			pattern := policy.GetTagPattern(p, container.Name)
+			repo := currentImageID.Name
+			logger := log.With(logger, "workload", workload.ID, "container", container.Name, "repo", repo, "pattern", pattern, "current", currentImageID)
+
+			images := imageRepos.GetRepoImages(repo)
+			filteredImages := images.FilterAndSort(pattern)
+
+			if latest, ok := filteredImages.Latest(); ok && latest.ID != currentImageID {
+				if latest.ID.Tag == "" {
+					logger.Log("warning", "untagged image in available images", "action", "skip container")
+					continue containers
+				}
+				current := images.FindWithRef(currentImageID)
+				if current.CreatedAt.IsZero() || latest.CreatedAt.IsZero() {
+					logger.Log("warning", "image with zero created timestamp", "current", fmt.Sprintf("%s (%s)", current.ID, current.CreatedAt), "latest", fmt.Sprintf("%s (%s)", latest.ID, latest.CreatedAt), "action", "skip container")
+					continue containers
+				}
+				newImage := currentImageID.WithNewTag(latest.ID.Tag)
+				changes.Add(workload.ID, container, newImage)
+				logger.Log("info", "added update to automation run", "new", newImage, "reason", fmt.Sprintf("latest %s (%s) > current %s (%s)", latest.ID.Tag, latest.CreatedAt, currentImageID.Tag, current.CreatedAt))
+			}
+		}
+	}
+
+	return changes
 }

--- a/daemon/images_test.go
+++ b/daemon/images_test.go
@@ -1,0 +1,210 @@
+package daemon
+
+import (
+	"github.com/weaveworks/flux/policy"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/weaveworks/flux"
+	"github.com/weaveworks/flux/cluster"
+	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/registry"
+	registryMock "github.com/weaveworks/flux/registry/mock"
+	"github.com/weaveworks/flux/resource"
+	"github.com/weaveworks/flux/update"
+)
+
+const (
+	container1 = "container1"
+	container2 = "container2"
+
+	currentContainer1Image = "container1/application:current"
+	newContainer1Image     = "container1/application:new"
+
+	currentContainer2Image = "container2/application:current"
+	newContainer2Image     = "container2/application:new"
+	noTagContainer2Image   = "container2/application"
+)
+
+type candidate struct {
+	resourceID flux.ResourceID
+	policies   policy.Set
+}
+
+func (c candidate) ResourceID() flux.ResourceID {
+	return c.resourceID
+}
+
+func (c candidate) Policies() policy.Set {
+	return c.policies
+}
+
+func (candidate) Source() string {
+	return ""
+}
+
+func (candidate) Bytes() []byte {
+	return []byte{}
+}
+
+func TestCalculateChanges_Automated(t *testing.T) {
+	logger := log.NewNopLogger()
+	resourceID := flux.MakeResourceID(ns, "deployment", "application")
+	candidateWorkloads := resources{
+		resourceID: candidate{
+			resourceID: resourceID,
+			policies: policy.Set{
+				policy.Automated: "true",
+			},
+		},
+	}
+	workloads := []cluster.Workload{
+		cluster.Workload{
+			ID: resourceID,
+			Containers: cluster.ContainersOrExcuse{
+				Containers: []resource.Container{
+					{
+						Name:  container1,
+						Image: mustParseImageRef(currentContainer1Image),
+					},
+				},
+			},
+		},
+	}
+	var imageRegistry registry.Registry
+	{
+		current := makeImageInfo(currentContainer1Image, time.Now())
+		new := makeImageInfo(newContainer1Image, time.Now().Add(1*time.Second))
+		imageRegistry = &registryMock.Registry{
+			Images: []image.Info{
+				current,
+				new,
+			},
+		}
+	}
+	imageRepos, err := update.FetchImageRepos(imageRegistry, clusterContainers(workloads), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes := calculateChanges(logger, candidateWorkloads, workloads, imageRepos)
+
+	if len := len(changes.Changes); len != 1 {
+		t.Errorf("Expected exactly 1 change, got %d changes", len)
+	} else if newImage := changes.Changes[0].ImageID.String(); newImage != newContainer1Image {
+		t.Errorf("Expected changed image to be %s, got %s", newContainer1Image, newImage)
+	}
+}
+func TestCalculateChanges_UntaggedImage(t *testing.T) {
+	logger := log.NewNopLogger()
+	resourceID := flux.MakeResourceID(ns, "deployment", "application")
+	candidateWorkloads := resources{
+		resourceID: candidate{
+			resourceID: resourceID,
+			policies: policy.Set{
+				policy.Automated: "true",
+			},
+		},
+	}
+	workloads := []cluster.Workload{
+		cluster.Workload{
+			ID: resourceID,
+			Containers: cluster.ContainersOrExcuse{
+				Containers: []resource.Container{
+					{
+						Name:  container1,
+						Image: mustParseImageRef(currentContainer1Image),
+					},
+					{
+						Name:  container2,
+						Image: mustParseImageRef(currentContainer2Image),
+					},
+				},
+			},
+		},
+	}
+	var imageRegistry registry.Registry
+	{
+		current1 := makeImageInfo(currentContainer1Image, time.Now())
+		new1 := makeImageInfo(newContainer1Image, time.Now().Add(1*time.Second))
+		current2 := makeImageInfo(currentContainer2Image, time.Now())
+		noTag2 := makeImageInfo(noTagContainer2Image, time.Now().Add(1*time.Second))
+		imageRegistry = &registryMock.Registry{
+			Images: []image.Info{
+				current1,
+				new1,
+				current2,
+				noTag2,
+			},
+		}
+	}
+	imageRepos, err := update.FetchImageRepos(imageRegistry, clusterContainers(workloads), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes := calculateChanges(logger, candidateWorkloads, workloads, imageRepos)
+
+	if len := len(changes.Changes); len != 1 {
+		t.Errorf("Expected exactly 1 change, got %d changes", len)
+	} else if newImage := changes.Changes[0].ImageID.String(); newImage != newContainer1Image {
+		t.Errorf("Expected changed image to be %s, got %s", newContainer1Image, newImage)
+	}
+}
+func TestCalculateChanges_ZeroTimestamp(t *testing.T) {
+	logger := log.NewNopLogger()
+	resourceID := flux.MakeResourceID(ns, "deployment", "application")
+	candidateWorkloads := resources{
+		resourceID: candidate{
+			resourceID: resourceID,
+			policies: policy.Set{
+				policy.Automated: "true",
+			},
+		},
+	}
+	workloads := []cluster.Workload{
+		cluster.Workload{
+			ID: resourceID,
+			Containers: cluster.ContainersOrExcuse{
+				Containers: []resource.Container{
+					{
+						Name:  container1,
+						Image: mustParseImageRef(currentContainer1Image),
+					},
+					{
+						Name:  container2,
+						Image: mustParseImageRef(currentContainer2Image),
+					},
+				},
+			},
+		},
+	}
+	var imageRegistry registry.Registry
+	{
+		current1 := makeImageInfo(currentContainer1Image, time.Now())
+		new1 := makeImageInfo(newContainer1Image, time.Now().Add(1*time.Second))
+		zeroTimestampCurrent2 := image.Info{ID: mustParseImageRef(currentContainer2Image)}
+		new2 := makeImageInfo(newContainer2Image, time.Now().Add(1*time.Second))
+		imageRegistry = &registryMock.Registry{
+			Images: []image.Info{
+				current1,
+				new1,
+				zeroTimestampCurrent2,
+				new2,
+			},
+		}
+	}
+	imageRepos, err := update.FetchImageRepos(imageRegistry, clusterContainers(workloads), logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	changes := calculateChanges(logger, candidateWorkloads, workloads, imageRepos)
+
+	if len := len(changes.Changes); len != 1 {
+		t.Errorf("Expected exactly 1 change, got %d changes", len)
+	} else if newImage := changes.Changes[0].ImageID.String(); newImage != newContainer1Image {
+		t.Errorf("Expected changed image to be %s, got %s", newContainer1Image, newImage)
+	}
+}


### PR DESCRIPTION
Fixes #1817 

In the following circumstances:

* A registry experiences a fault where it fails to enumerate all
  tags when asked without signalling an error condition
* The tag for an image in an automated workload is not returned
  by the registry API
* Older image tags are returned

Flux would roll back the image to an older version, because it
couldn't tell the current image is newer. Instead, Flux now refuses
to automate unless it has timestamp information for the current and
new version, as this assures the made comparison is valid.
