### PR TITLE
Fix flaky cached discovery test

### DIFF
--- a/cluster/kubernetes/cached_disco_test.go
+++ b/cluster/kubernetes/cached_disco_test.go
@@ -65,7 +65,7 @@ func TestCachedDiscovery(t *testing.T) {
 		},
 	}
 	makeHandler := func(d discovery.CachedDiscoveryInterface) toolscache.ResourceEventHandler {
-		return chainHandler{first: addHandler, next: makeInvalidatingHandler(d)}
+		return chainHandler{first: makeInvalidatingHandler(d), next: addHandler}
 	}
 
 	cachedDisco, store, _ := makeCachedDiscovery(coreClient.Discovery(), crdClient, shutdown, makeHandler)


### PR DESCRIPTION
The synchronization handle needs to be called last, to make sure the invalidation
handle is called before invoking `lookupNamespaced()`
