### PR TITLE
Admit "<cluster>" when parsing ResourceIDs

### DIFF
--- a/flux.go
+++ b/flux.go
@@ -14,12 +14,12 @@ var (
 	ErrInvalidServiceID = errors.New("invalid service ID")
 
 	LegacyServiceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_-]+)$")
-	// The namespace and name commponents are (apparently
+	// The namespace and name components are (apparently
 	// non-normatively) defined in
 	// https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/identifiers.md
 	// In practice, more punctuation is used than allowed there;
 	// specifically, people use underscores as well as dashes and dots, and in names, colons.
-	ResourceIDRegexp            = regexp.MustCompile("^([a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.:-]+)$")
+	ResourceIDRegexp            = regexp.MustCompile("^(<cluster>|[a-zA-Z0-9_-]+):([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.:-]+)$")
 	UnqualifiedResourceIDRegexp = regexp.MustCompile("^([a-zA-Z0-9_-]+)/([a-zA-Z0-9_.:-]+)$")
 )
 

--- a/resourceid_test.go
+++ b/resourceid_test.go
@@ -14,6 +14,7 @@ func TestResourceIDParsing(t *testing.T) {
 		{"dots", "namespace:kind/name.with.dots"},
 		{"colons", "namespace:kind/name:with:colons"},
 		{"punctuation in general", "name-space:ki_nd/punc_tu:a.tion-rules"},
+		{"cluster-scope resource", "<cluster>:namespace/foo"},
 	}
 	invalid := []test{
 		{"unqualified", "justname"},


### PR DESCRIPTION
The PR #1442 introduce code to determine which namespace, if any, each
manifest belongs to. To distinguish between resources that need a
namespace but don't have one, and resources that are cluster-scoped,
it introduced the sentinel value `<cluster>` for the latter.

Regrettably, I didn't accompany this with code for _parsing_ those
sentinel values, since I reasoned that it would only be used
internally. But the sync events generated by fluxd include a list of
changed resources, and those inevitably will include things like
namespaces that are cluster-scoped. The result is that fluxd will
generate events that cannot then be parsed by the receiver.

This commit fixes that by recognising `<cluster>` as a namespace when
parsing resource IDs.
