### PR TITLE
Release Helm operator v0.7.1

### DIFF
--- a/CHANGELOG-helmop.md
+++ b/CHANGELOG-helmop.md
@@ -1,4 +1,12 @@
-## 0.7.0 (2019-03-05)
+## 0.7.1 (2019-03-27)
+
+### Bug fixes
+
+ - Prevent panic on `.spec.values` in `HelmRelease` due to merge
+   attempt on uninitialized value
+   [weaveworks/flux#1867](https://github.com/weaveworks/flux/pull/1867)
+
+## 0.7.0 (2019-03-25)
 
 ### Bug fixes
 

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -62,7 +62,7 @@ spec:
         # There are no ":latest" images for helm-operator. Find the most recent
         # release or image version at https://quay.io/weaveworks/helm-operator
         # and replace the tag here.
-        image: quay.io/weaveworks/helm-operator:0.7.0
+        image: quay.io/weaveworks/helm-operator:0.7.1
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy-helm/weave-cloud-helm-operator-deployment.yaml
+++ b/deploy-helm/weave-cloud-helm-operator-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             secretName: flux-git-deploy
       containers:
         - name: flux-helm-operator
-          image: quay.io/weaveworks/helm-operator:0.7.0
+          image: quay.io/weaveworks/helm-operator:0.7.1
           imagePullPolicy: IfNotPresent
           args:
             - --git-timeout=20s

--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -276,7 +276,7 @@ func fhrResourceID(fhr flux_v1beta1.HelmRelease) flux.ResourceID {
 // values tries to resolve all given value file sources and merges
 // them into one Values struct. It returns the merged Values.
 func values(corev1 k8sclientv1.CoreV1Interface, ns string, valuesFromSource []flux_v1beta1.ValuesFromSource, values chartutil.Values) (chartutil.Values, error) {
-	var result chartutil.Values
+	result := chartutil.Values{}
 
 	for _, v := range valuesFromSource {
 		var valueFile chartutil.Values


### PR DESCRIPTION
This is `release/helm-0.7.x` with `6cb246ac4e7e79415386fb4674828b76dce41ce6` cherry-picked from `master`.