### PR TITLE
Release chart v0.7.0

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ### Improvements
 
- - Updated Flux to `1.11.0`
-   [weaveworks/flux#1814](https://github.com/weaveworks/flux/pull/1814)
- - Updated Helm operator to `0.7.1`
-   [weaveworks/flux#1868](https://github.com/weaveworks/flux/pull/1868)
-
+ - Updated Flux to `1.11.0` and Helm operator to `0.7.1`
+   [weaveworks/flux#1871](https://github.com/weaveworks/flux/pull/1871)
+ - Allow mounting of docker credentials file
+   [weaveworks/flux#1762](https://github.com/weaveworks/flux/pull/1762)
+  - Increase memcached memory defaults
+    [weaveworks/flux#1780](https://github.com/weaveworks/flux/pull/1780)
+  - GPG Git commit signing
+    [weaveworks/flux#1394](https://github.com/weaveworks/flux/pull/1394)
 
 ## 0.6.3 (2019-02-14)
 

--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.7.0 (2019-03-27)
+
+### Improvements
+
+ - Updated Flux to `1.11.0`
+   [weaveworks/flux#1814](https://github.com/weaveworks/flux/pull/1814)
+ - Updated Helm operator to `0.7.1`
+   [weaveworks/flux#1868](https://github.com/weaveworks/flux/pull/1868)
+
+
 ## 0.6.3 (2019-02-14)
 
 ### Improvements

--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -6,10 +6,10 @@
    [weaveworks/flux#1871](https://github.com/weaveworks/flux/pull/1871)
  - Allow mounting of docker credentials file
    [weaveworks/flux#1762](https://github.com/weaveworks/flux/pull/1762)
-  - Increase memcached memory defaults
-    [weaveworks/flux#1780](https://github.com/weaveworks/flux/pull/1780)
-  - GPG Git commit signing
-    [weaveworks/flux#1394](https://github.com/weaveworks/flux/pull/1394)
+ - Increase memcached memory defaults
+   [weaveworks/flux#1780](https://github.com/weaveworks/flux/pull/1780)
+ - GPG Git commit signing
+   [weaveworks/flux#1394](https://github.com/weaveworks/flux/pull/1394)
 
 ## 0.6.3 (2019-02-14)
 

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
-appVersion: "1.10.1"
-version: 0.6.3
+appVersion: "1.11.0"
+version: 0.7.0
 kubeVersion: ">=1.9.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/weaveworks/flux
-  tag: 1.10.1
+  tag: 1.11.0
   pullPolicy: IfNotPresent
   pullSecret:
 
@@ -20,7 +20,7 @@ helmOperator:
   create: false
   createCRD: true
   repository: quay.io/weaveworks/helm-operator
-  tag: 0.6.0
+  tag: 0.7.1
   pullPolicy: IfNotPresent
   pullSecret:
   # Limit the operator scope to a single namespace


### PR DESCRIPTION
Update the chart to use flux v1.11.0 and Helm operator v0.7.1.

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
