### PR TITLE
Use FQRN to prevent errors when branch = label

### DIFF
--- a/git/working.go
+++ b/git/working.go
@@ -141,7 +141,7 @@ func (c *Checkout) CommitAndPush(ctx context.Context, commitAction CommitAction,
 	}
 
 	if note != nil {
-		rev, err := refRevision(ctx, c.dir, "HEAD")
+		rev, err := c.HeadRevision(ctx)
 		if err != nil {
 			return err
 		}
@@ -174,7 +174,7 @@ func (c *Checkout) HeadRevision(ctx context.Context) (string, error) {
 }
 
 func (c *Checkout) SyncRevision(ctx context.Context) (string, error) {
-	return refRevision(ctx, c.dir, c.config.SyncTag)
+	return refRevision(ctx, c.dir, "tags/"+c.config.SyncTag)
 }
 
 func (c *Checkout) MoveSyncTagAndPush(ctx context.Context, tagAction TagAction) error {


### PR DESCRIPTION
Fixes #1845 

If the label and branch were set to the same name, Flux would not
create the sync tag as the revision lookup for `HEAD` and `<tag>`
returned the same revision.

This is due to how git looks up symbolic ref names, giving priority
to heads over tags. Using the (almost) fully qualified ref name will
tell git to only look for matches of that type.

https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-emltrefnamegtemegemmasterememheadsmasterememrefsheadsmasterem