### PR TITLE
Support lists of all resource kinds

### DIFF
--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -187,6 +187,41 @@ items:
 	}
 }
 
+func TestUnmarshalDeploymentList(t *testing.T) {
+	doc := `---
+kind: DeploymentList
+metadata:
+  name: list
+items:
+- kind: Deployment
+  metadata:
+    name: foo
+    namespace: ns
+- kind: Deployment
+  metadata:
+    name: bar
+    namespace: ns
+`
+	res, err := unmarshalObject("", []byte(doc))
+	if err != nil {
+		t.Fatal(err)
+	}
+	list, ok := res.(*List)
+	if !ok {
+		t.Fatal("did not parse as a list")
+	}
+	if len(list.Items) != 2 {
+		t.Fatalf("expected two items, got %+v", list.Items)
+	}
+	for i, id := range []flux.ResourceID{
+		flux.MustParseResourceID("ns:deployment/foo"),
+		flux.MustParseResourceID("ns:deployment/bar")} {
+		if list.Items[i].ResourceID() != id {
+			t.Errorf("At %d, expected %q, got %q", i, id, list.Items[i].ResourceID())
+		}
+	}
+}
+
 func debyte(r resource.Resource) resource.Resource {
 	if res, ok := r.(interface {
 		debyte()

--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -151,6 +151,12 @@ func unmarshalKind(base baseObject, bytes []byte) (KubeManifest, error) {
 		}
 		return &ss, nil
 	case strings.HasSuffix(base.Kind, "List"):
+		// All resource kinds ending with `List` are understood as
+		// a list of resources. This is not bullet proof since
+		// CustomResourceDefinitions can define a custom ListKind
+		// (see CustomResourceDefinition.Spec.Names.ListKind) but
+		// we cannot do better without involving API discovery during
+		// parsing.
 		var raw rawList
 		if err := yaml.Unmarshal(bytes, &raw); err != nil {
 			return nil, err

--- a/cluster/kubernetes/resource/resource.go
+++ b/cluster/kubernetes/resource/resource.go
@@ -119,38 +119,38 @@ func unmarshalObject(source string, bytes []byte) (KubeManifest, error) {
 }
 
 func unmarshalKind(base baseObject, bytes []byte) (KubeManifest, error) {
-	switch base.Kind {
-	case "CronJob":
+	switch {
+	case base.Kind == "CronJob":
 		var cj = CronJob{baseObject: base}
 		if err := yaml.Unmarshal(bytes, &cj); err != nil {
 			return nil, err
 		}
 		return &cj, nil
-	case "DaemonSet":
+	case base.Kind == "DaemonSet":
 		var ds = DaemonSet{baseObject: base}
 		if err := yaml.Unmarshal(bytes, &ds); err != nil {
 			return nil, err
 		}
 		return &ds, nil
-	case "Deployment":
+	case base.Kind == "Deployment":
 		var dep = Deployment{baseObject: base}
 		if err := yaml.Unmarshal(bytes, &dep); err != nil {
 			return nil, err
 		}
 		return &dep, nil
-	case "Namespace":
+	case base.Kind == "Namespace":
 		var ns = Namespace{baseObject: base}
 		if err := yaml.Unmarshal(bytes, &ns); err != nil {
 			return nil, err
 		}
 		return &ns, nil
-	case "StatefulSet":
+	case base.Kind == "StatefulSet":
 		var ss = StatefulSet{baseObject: base}
 		if err := yaml.Unmarshal(bytes, &ss); err != nil {
 			return nil, err
 		}
 		return &ss, nil
-	case "List":
+	case strings.HasSuffix(base.Kind, "List"):
 		var raw rawList
 		if err := yaml.Unmarshal(bytes, &raw); err != nil {
 			return nil, err
@@ -158,13 +158,13 @@ func unmarshalKind(base baseObject, bytes []byte) (KubeManifest, error) {
 		var list List
 		unmarshalList(base, &raw, &list)
 		return &list, nil
-	case "FluxHelmRelease", "HelmRelease":
+	case base.Kind == "FluxHelmRelease" || base.Kind == "HelmRelease":
 		var fhr = FluxHelmRelease{baseObject: base}
 		if err := yaml.Unmarshal(bytes, &fhr); err != nil {
 			return nil, err
 		}
 		return &fhr, nil
-	case "":
+	case base.Kind == "":
 		// If there is an empty resource (due to eg an introduced comment),
 		// we are returning nil for the resource and nil for an error
 		// (as not really an error). We are not, at least at the moment,


### PR DESCRIPTION
Flux supported heterogeneous resource `List`s, however it didn't support
resource-kind specific lists such as `RoleList` unlike `kubectl`.

This changes parsing of lists to align `flux`'s behavior with `kubectl`'s.

Fixes #1860 