### PR TITLE
Ensure release has not changed before upgrade run

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -171,7 +171,6 @@ func main() {
 	rel := release.New(log.With(logger, "component", "release"), helmClient)
 	chartSync := chartsync.New(
 		log.With(logger, "component", "chartsync"),
-		chartsync.Polling{Interval: *chartsSyncInterval},
 		chartsync.Clients{KubeClient: *kubeClient, IfClient: *ifClient},
 		rel,
 		chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, GitTimeout: *gitTimeout},
@@ -181,7 +180,7 @@ func main() {
 	chartSync.Run(shutdown, errc, shutdownWg)
 
 	nsOpt := ifinformers.WithNamespace(*namespace)
-	ifInformerFactory := ifinformers.NewSharedInformerFactoryWithOptions(ifClient, 30*time.Second, nsOpt)
+	ifInformerFactory := ifinformers.NewSharedInformerFactoryWithOptions(ifClient, *chartsSyncInterval, nsOpt)
 	fhrInformer := ifInformerFactory.Flux().V1beta1().HelmReleases()
 
 	// start FluxRelease informer

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -75,10 +75,6 @@ const (
 	ReasonSuccess          = "HelmSuccess"
 )
 
-type Polling struct {
-	Interval time.Duration
-}
-
 type Clients struct {
 	KubeClient kubernetes.Clientset
 	IfClient   ifclientset.Clientset
@@ -106,7 +102,6 @@ type clone struct {
 }
 
 type ChartChangeSync struct {
-	Polling
 	logger     log.Logger
 	kubeClient kubernetes.Clientset
 	ifClient   ifclientset.Clientset
@@ -121,10 +116,9 @@ type ChartChangeSync struct {
 	namespace string
 }
 
-func New(logger log.Logger, polling Polling, clients Clients, release *release.Release, config Config, namespace string, statusUpdater *status.Updater) *ChartChangeSync {
+func New(logger log.Logger, clients Clients, release *release.Release, config Config, namespace string, statusUpdater *status.Updater) *ChartChangeSync {
 	return &ChartChangeSync{
 		logger:     logger,
-		Polling:    polling,
 		kubeClient: clients.KubeClient,
 		ifClient:   clients.IfClient,
 		release:    release,
@@ -147,9 +141,6 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 			chs.mirrors.StopAllAndWait()
 			wg.Done()
 		}()
-
-		ticker := time.NewTicker(chs.Polling.Interval)
-		defer ticker.Stop()
 
 		for {
 			select {
@@ -241,16 +232,6 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 
 					chs.reconcileReleaseDef(fhr)
 				}
-			case <-ticker.C:
-				// Re-release any chart releases that have apparently
-				// changed in the cluster.
-				chs.logger.Log("info", fmt.Sprint("Start of releasesync"))
-				err := chs.reapplyReleaseDefs()
-				if err != nil {
-					chs.logger.Log("error", fmt.Sprintf("Failure to do manual release sync: %s", err))
-				}
-				chs.logger.Log("info", fmt.Sprint("End of releasesync"))
-
 			case <-stopCh:
 				chs.logger.Log("stopping", "true")
 				return
@@ -394,22 +375,6 @@ func (chs *ChartChangeSync) reconcileReleaseDef(fhr fluxv1beta1.HelmRelease) {
 		}
 		return
 	}
-}
-
-// reapplyReleaseDefs goes through the resource definitions and
-// reconciles them with Helm releases. This is a "backstop" for the
-// other sync processes, to cover the case of a release being changed
-// out-of-band (e.g., by someone using `helm upgrade`).
-func (chs *ChartChangeSync) reapplyReleaseDefs() error {
-	resources, err := chs.getCustomResources()
-	if err != nil {
-		return fmt.Errorf("failed to get HelmRelease resources from the API server: %s", err.Error())
-	}
-
-	for _, fhr := range resources {
-		chs.reconcileReleaseDef(fhr)
-	}
-	return nil
 }
 
 // DeleteRelease deletes the helm release associated with a

--- a/integrations/helm/operator/operator.go
+++ b/integrations/helm/operator/operator.go
@@ -297,15 +297,13 @@ func (c *Controller) enqueueUpdateJob(old, new interface{}) {
 		return
 	}
 
-	if diff := cmp.Diff(oldFhr.Spec, newFhr.Spec); diff != "" {
-		c.logger.Log("info", "UPGRADING release")
-		if c.logDiffs {
-			c.logger.Log("info", "Custom Resource driven release upgrade", "diff", diff)
-		} else {
-			c.logger.Log("info", "Custom Resource driven release upgrade")
-		}
-		c.enqueueJob(new)
+	c.logger.Log("info", "UPGRADING release")
+	if diff := cmp.Diff(oldFhr.Spec, newFhr.Spec); c.logDiffs && diff != "" {
+		c.logger.Log("info", "Custom Resource driven release upgrade", "diff", diff)
+	} else {
+		c.logger.Log("info", "Custom Resource driven release upgrade")
 	}
+	c.enqueueJob(new)
 }
 
 func (c *Controller) deleteRelease(fhr flux_v1beta1.HelmRelease) {


### PR DESCRIPTION
It is possibile a release vanishes or is modified between the start
of a release and the actual upgrade itself, for example due to the
`HelmRelease` getting removed by fluxd's garbage collector.

Check if the release is still there and has not been modified in the
time we prepared for the upgrade.