### PR TITLE
Update helm chart to use 1.11.1 as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ syncs to fail when adding a CRD and instance(s) from that CRD at the same time.
 
 - Obtain scope of CRD instances from its manifest as a fallback
   [weaveworks/flux#1876][#1876]
+- Updated tag in helm chart to 1.11.1 to match static manifests
+  [weaveworks/flux#1892][#1892]
   
 [#1876]: https://github.com/weaveworks/flux/pull/1876
 

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.11.0"
+appVersion: "1.11.1"
 version: 0.7.0
 kubeVersion: ">=1.9.0-0"
 name: flux

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/weaveworks/flux
-  tag: 1.11.0
+  tag: 1.11.1
   pullPolicy: IfNotPresent
   pullSecret:
 


### PR DESCRIPTION
Commit https://github.com/weaveworks/flux/commit/ba3e794a59e588eaaafa7bee07c8a0fb322e166e updated the flux/deploy static yaml files, but not the helm template.

This PR adjusts the helm chart's value.yaml file to also use tag 1.11.1.