### PR TITLE
Define custom Helm repositories in the Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -181,95 +181,96 @@ You should also remove the deploy key from your GitHub repository.
 
 The following tables lists the configurable parameters of the Weave Flux chart and their default values.
 
-| Parameter                                       | Default                                              | Description
-| ----------------------------------------------- | ---------------------------------------------------- | ---
-| `image.repository`                              | `quay.io/weaveworks/flux`                            | Image repository
-| `image.tag`                                     | `<VERSION>`                                          | Image tag
-| `replicaCount`                                  | `1`                                                  | Number of Flux pods to deploy, more than one is not desirable.
-| `image.pullPolicy`                              | `IfNotPresent`                                       | Image pull policy
-| `image.pullSecret`                              | `None`                                               | Image pull secret
-| `resources.requests.cpu`                        | `50m`                                                | CPU resource requests for the Flux deployment
-| `resources.requests.memory`                     | `64Mi`                                               | Memory resource requests for the Flux deployment
-| `resources.limits`                              | `None`                                               | CPU/memory resource limits for the Flux deployment
-| `nodeSelector`                                  | `{}`                                                 | Node Selector properties for the Flux deployment
-| `tolerations`                                   | `[]`                                                 | Tolerations properties for the Flux deployment
-| `affinity`                                      | `{}`                                                 | Affinity properties for the Flux deployment
-| `token`                                         | `None`                                               | Weave Cloud service token
-| `extraEnvs`                                     | `[]`                                                 | Extra environment variables for the Flux pod(s)
-| `rbac.create`                                   | `true`                                               | If `true`, create and use RBAC resources
-| `serviceAccount.create`                         | `true`                                               | If `true`, create a new service account
-| `serviceAccount.name`                           | `flux`                                               | Service account to be used
-| `service.type`                                  | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
-| `service.port`                                  | `3030`                                               | Service port to be used
-| `git.url`                                       | `None`                                               | URL of git repo with Kubernetes manifests
-| `git.branch`                                    | `master`                                             | Branch of git repo to use for Kubernetes manifests
-| `git.path`                                      | `None`                                               | Path within git repo to locate Kubernetes manifests (relative path)
-| `git.user`                                      | `Weave Flux`                                         | Username to use as git committer
-| `git.email`                                     | `support@weave.works`                                | Email to use as git committer
-| `git.setAuthor`                                 | `false`                                              | If set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer.
-| `git.signingKey`                                | `None`                                               | If set, commits will be signed with this GPG key
-| `git.label`                                     | `flux-sync`                                          | Label to keep track of sync progress, used to tag the Git branch
-| `git.ciSkip`                                    | `false`                                              | Append "[ci skip]" to commit messages so that CI will skip builds
-| `git.pollInterval`                              | `5m`                                                 | Period at which to poll git repo for new commits
-| `git.timeout`                                   | `20s`                                                | Duration after which git operations time out
-| `git.secretName`                                | `None`                                               | Kubernetes secret with the SSH private key. Superceded by `helmOperator.git.secretName` if set.
-| `gpgKeys.secretName`                            | `None`                                               | Kubernetes secret with GPG keys the Flux daemon should import
-| `ssh.known_hosts`                               | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
-| `registry.pollInterval`                         | `5m`                                                 | Period at which to check for updated images
-| `registry.rps`                                  | `200`                                                | Maximum registry requests per second per host
-| `registry.burst`                                | `125`                                                | Maximum number of warmer connections to remote and memcache
-| `registry.trace`                                | `false`                                              |  Output trace of image registry requests to log
-| `registry.insecureHosts`                        | `None`                                               | Use HTTP rather than HTTPS for the image registry domains
-| `registry.cacheExpiry`                          | `None`                                               | Duration to keep cached image info (deprecated)
-| `registry.excludeImage`                         | `None`                                               | Do not scan images that match these glob expressions; if empty, 'k8s.gcr.io/*' images are excluded
-| `registry.ecr.region`                           | `None`                                               | Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned
-| `registry.ecr.includeId`                        | `None`                                               | Restrict ECR scanning to these AWS account IDs; if empty, all account IDs that aren't excluded may be scanned
-| `registry.ecr.excludeId`                        | `602401143452`                                       | Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account
-| `registry.acr.enabled`                          | `false`                                              | Mount `azure.json` via HostPath into the Flux Pod, enabling Flux to use AKS's service principal for ACR authentication
-| `registry.acr.hostPath`                         | `/etc/kubernetes/azure.json`                         | Alternative location of `azure.json` on the host
-| `registry.dockercfg.enabled`                    | `false`                                              | Mount `config.json` via Secret into the Flux Pod, enabling Flux to use a custom docker config file
-| `registry.dockercfg.secretName`                 | `None`                                               | Kubernetes secret with the docker config.json
-| `memcached.verbose`                             | `false`                                              | Enable request logging in memcached
-| `memcached.maxItemSize`                         | `5m`                                                 | Maximum size for one item
-| `memcached.maxMemory`                           | `128`                                                | Maximum memory to use, in megabytes
-| `memcached.pullSecret`                          | `None`                                               | Image pull secret
-| `memcached.repository`                          | `memcached`                                          | Image repository
-| `memcached.resources`                           | `None`                                               | CPU/memory resource requests/limits for memcached
-| `helmOperator.create`                           | `false`                                              | If `true`, install the Helm operator
-| `helmOperator.createCRD`                        | `true`                                               | Create the `v1beta1` and `v1alpha2` Flux CRDs. Dependent on `helmOperator.create=true`
-| `helmOperator.repository`                       | `quay.io/weaveworks/helm-operator`                   | Helm operator image repository
-| `helmOperator.tag`                              | `<VERSION>`                                          | Helm operator image tag
-| `helmOperator.replicaCount`                     | `1`                                                  | Number of helm operator pods to deploy, more than one is not desirable.
-| `helmOperator.pullPolicy`                       | `IfNotPresent`                                       | Helm operator image pull policy
-| `helmOperator.pullSecret`                       | `None`                                               | Image pull secret
-| `helmOperator.updateChartDeps`                  | `true`                                               | Update dependencies for charts
-| `helmOperator.git.pollInterval`                 | `git.pollInterval`                                   | Period at which to poll git repo for new commits
-| `helmOperator.git.timeout`                      | `git.timeout`                                        | Duration after which git operations time out
-| `helmOperator.git.secretName`                   | `None`                                               | The name of the kubernetes secret with the SSH private key, supercedes `git.secretName`
-| `helmOperator.chartsSyncInterval`               | `3m`                                                 | Interval at which to check for changed charts
-| `helmOperator.extraEnvs`                        | `[]`                                                 | Extra environment variables for the Helm operator pod
-| `helmOperator.logReleaseDiffs`                  | `false`                                              | Helm operator should log the diff when a chart release diverges (possibly insecure)
-| `helmOperator.allowNamespace`                   | `None`                                               | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched
-| `helmOperator.tillerNamespace`                  | `kube-system`                                        | Namespace in which the Tiller server can be found
-| `helmOperator.tls.enable`                       | `false`                                              | Enable TLS for communicating with Tiller
-| `helmOperator.tls.verify`                       | `false`                                              | Verify the Tiller certificate, also enables TLS when set to true
-| `helmOperator.tls.secretName`                   | `helm-client-certs`                                  | Name of the secret containing the TLS client certificates for communicating with Tiller
-| `helmOperator.tls.keyFile`                      | `tls.key`                                            | Name of the key file within the k8s secret
-| `helmOperator.tls.certFile`                     | `tls.crt`                                            | Name of the certificate file within the k8s secret
-| `helmOperator.tls.caContent`                    | `None`                                               | Certificate Authority content used to validate the Tiller server certificate
-| `helmOperator.tls.hostname`                     | `None`                                               | The server name used to verify the hostname on the returned certificates from the Tiller server
-| `helmOperator.configureRepositories.enable`     | `false`                                              | Enable volume mount for a `repositories.yaml` configuration file and respository cache
-| `helmOperator.configureRepositories.volumeName` | `repositories-yaml`                                  | Name of the volume for the `repositories.yaml` file
-| `helmOperator.configureRepositories.secretName` | `flux-helm-repositories`                             | Name of the secret containing the contents of the `repositories.yaml` file
-| `helmOperator.configureRepositories.cacheName`  | `repositories-cache`                                 | Name for the repository cache volume
-| `helmOperator.resources.requests.cpu`           | `50m`                                                | CPU resource requests for the helmOperator deployment
-| `helmOperator.resources.requests.memory`        | `64Mi`                                               | Memory resource requests for the helmOperator deployment
-| `helmOperator.resources.limits`                 | `None`                                               | CPU/memory resource limits for the helmOperator deployment
-| `helmOperator.nodeSelector`                     | `{}`                                                 | Node Selector properties for the helmOperator deployment
-| `helmOperator.tolerations`                      | `[]`                                                 | Tolerations properties for the helmOperator deployment
-| `helmOperator.affinity`                         | `{}`                                                 | Affinity properties for the helmOperator deployment
-| `kube.config`                                   | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
-| `prometheus.enabled`                            | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
+| Parameter                                         | Default                                              | Description
+| -----------------------------------------------   | ---------------------------------------------------- | ---
+| `image.repository`                                | `quay.io/weaveworks/flux`                            | Image repository
+| `image.tag`                                       | `<VERSION>`                                          | Image tag
+| `replicaCount`                                    | `1`                                                  | Number of Flux pods to deploy, more than one is not desirable.
+| `image.pullPolicy`                                | `IfNotPresent`                                       | Image pull policy
+| `image.pullSecret`                                | `None`                                               | Image pull secret
+| `resources.requests.cpu`                          | `50m`                                                | CPU resource requests for the Flux deployment
+| `resources.requests.memory`                       | `64Mi`                                               | Memory resource requests for the Flux deployment
+| `resources.limits`                                | `None`                                               | CPU/memory resource limits for the Flux deployment
+| `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the Flux deployment
+| `tolerations`                                     | `[]`                                                 | Tolerations properties for the Flux deployment
+| `affinity`                                        | `{}`                                                 | Affinity properties for the Flux deployment
+| `token`                                           | `None`                                               | Weave Cloud service token
+| `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
+| `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
+| `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
+| `serviceAccount.name`                             | `flux`                                               | Service account to be used
+| `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
+| `service.port`                                    | `3030`                                               | Service port to be used
+| `git.url`                                         | `None`                                               | URL of git repo with Kubernetes manifests
+| `git.branch`                                      | `master`                                             | Branch of git repo to use for Kubernetes manifests
+| `git.path`                                        | `None`                                               | Path within git repo to locate Kubernetes manifests (relative path)
+| `git.user`                                        | `Weave Flux`                                         | Username to use as git committer
+| `git.email`                                       | `support@weave.works`                                | Email to use as git committer
+| `git.setAuthor`                                   | `false`                                              | If set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer.
+| `git.signingKey`                                  | `None`                                               | If set, commits will be signed with this GPG key
+| `git.label`                                       | `flux-sync`                                          | Label to keep track of sync progress, used to tag the Git branch
+| `git.ciSkip`                                      | `false`                                              | Append "[ci skip]" to commit messages so that CI will skip builds
+| `git.pollInterval`                                | `5m`                                                 | Period at which to poll git repo for new commits
+| `git.timeout`                                     | `20s`                                                | Duration after which git operations time out
+| `git.secretName`                                  | `None`                                               | Kubernetes secret with the SSH private key. Superceded by `helmOperator.git.secretName` if set.
+| `gpgKeys.secretName`                              | `None`                                               | Kubernetes secret with GPG keys the Flux daemon should import
+| `ssh.known_hosts`                                 | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
+| `registry.pollInterval`                           | `5m`                                                 | Period at which to check for updated images
+| `registry.rps`                                    | `200`                                                | Maximum registry requests per second per host
+| `registry.burst`                                  | `125`                                                | Maximum number of warmer connections to remote and memcache
+| `registry.trace`                                  | `false`                                              |  Output trace of image registry requests to log
+| `registry.insecureHosts`                          | `None`                                               | Use HTTP rather than HTTPS for the image registry domains
+| `registry.cacheExpiry`                            | `None`                                               | Duration to keep cached image info (deprecated)
+| `registry.excludeImage`                           | `None`                                               | Do not scan images that match these glob expressions; if empty, 'k8s.gcr.io/*' images are excluded
+| `registry.ecr.region`                             | `None`                                               | Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned
+| `registry.ecr.includeId`                          | `None`                                               | Restrict ECR scanning to these AWS account IDs; if empty, all account IDs that aren't excluded may be scanned
+| `registry.ecr.excludeId`                          | `602401143452`                                       | Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account
+| `registry.acr.enabled`                            | `false`                                              | Mount `azure.json` via HostPath into the Flux Pod, enabling Flux to use AKS's service principal for ACR authentication
+| `registry.acr.hostPath`                           | `/etc/kubernetes/azure.json`                         | Alternative location of `azure.json` on the host
+| `registry.dockercfg.enabled`                      | `false`                                              | Mount `config.json` via Secret into the Flux Pod, enabling Flux to use a custom docker config file
+| `registry.dockercfg.secretName`                   | `None`                                               | Kubernetes secret with the docker config.json
+| `memcached.verbose`                               | `false`                                              | Enable request logging in memcached
+| `memcached.maxItemSize`                           | `5m`                                                 | Maximum size for one item
+| `memcached.maxMemory`                             | `128`                                                | Maximum memory to use, in megabytes
+| `memcached.pullSecret`                            | `None`                                               | Image pull secret
+| `memcached.repository`                            | `memcached`                                          | Image repository
+| `memcached.resources`                             | `None`                                               | CPU/memory resource requests/limits for memcached
+| `helmOperator.create`                             | `false`                                              | If `true`, install the Helm operator
+| `helmOperator.createCRD`                          | `true`                                               | Create the `v1beta1` and `v1alpha2` Flux CRDs. Dependent on `helmOperator.create=true`
+| `helmOperator.repository`                         | `quay.io/weaveworks/helm-operator`                   | Helm operator image repository
+| `helmOperator.tag`                                | `<VERSION>`                                          | Helm operator image tag
+| `helmOperator.replicaCount`                       | `1`                                                  | Number of helm operator pods to deploy, more than one is not desirable.
+| `helmOperator.pullPolicy`                         | `IfNotPresent`                                       | Helm operator image pull policy
+| `helmOperator.pullSecret`                         | `None`                                               | Image pull secret
+| `helmOperator.updateChartDeps`                    | `true`                                               | Update dependencies for charts
+| `helmOperator.git.pollInterval`                   | `git.pollInterval`                                   | Period at which to poll git repo for new commits
+| `helmOperator.git.timeout`                        | `git.timeout`                                        | Duration after which git operations time out
+| `helmOperator.git.secretName`                     | `None`                                               | The name of the kubernetes secret with the SSH private key, supercedes `git.secretName`
+| `helmOperator.chartsSyncInterval`                 | `3m`                                                 | Interval at which to check for changed charts
+| `helmOperator.extraEnvs`                          | `[]`                                                 | Extra environment variables for the Helm operator pod
+| `helmOperator.logReleaseDiffs`                    | `false`                                              | Helm operator should log the diff when a chart release diverges (possibly insecure)
+| `helmOperator.allowNamespace`                     | `None`                                               | If set, this limits the scope to a single namespace. If not specified, all namespaces will be watched
+| `helmOperator.tillerNamespace`                    | `kube-system`                                        | Namespace in which the Tiller server can be found
+| `helmOperator.tls.enable`                         | `false`                                              | Enable TLS for communicating with Tiller
+| `helmOperator.tls.verify`                         | `false`                                              | Verify the Tiller certificate, also enables TLS when set to true
+| `helmOperator.tls.secretName`                     | `helm-client-certs`                                  | Name of the secret containing the TLS client certificates for communicating with Tiller
+| `helmOperator.tls.keyFile`                        | `tls.key`                                            | Name of the key file within the k8s secret
+| `helmOperator.tls.certFile`                       | `tls.crt`                                            | Name of the certificate file within the k8s secret
+| `helmOperator.tls.caContent`                      | `None`                                               | Certificate Authority content used to validate the Tiller server certificate
+| `helmOperator.tls.hostname`                       | `None`                                               | The server name used to verify the hostname on the returned certificates from the Tiller server
+| `helmOperator.configureRepositories.enable`       | `false`                                              | Enable volume mount for a `repositories.yaml` configuration file and respository cache
+| `helmOperator.configureRepositories.volumeName`   | `repositories-yaml`                                  | Name of the volume for the `repositories.yaml` file
+| `helmOperator.configureRepositories.secretName`   | `flux-helm-repositories`                             | Name of the secret containing the contents of the `repositories.yaml` file
+| `helmOperator.configureRepositories.cacheName`    | `repositories-cache`                                 | Name for the repository cache volume
+| `helmOperator.configureRepositories.repositories` | `None`                                               | List of custom Helm repositories to add. If non empty, the corresponding secret with a `repositories.yaml` will be created
+| `helmOperator.resources.requests.cpu`             | `50m`                                                | CPU resource requests for the helmOperator deployment
+| `helmOperator.resources.requests.memory`          | `64Mi`                                               | Memory resource requests for the helmOperator deployment
+| `helmOperator.resources.limits`                   | `None`                                               | CPU/memory resource limits for the helmOperator deployment
+| `helmOperator.nodeSelector`                       | `{}`                                                 | Node Selector properties for the helmOperator deployment
+| `helmOperator.tolerations`                        | `[]`                                                 | Tolerations properties for the helmOperator deployment
+| `helmOperator.affinity`                           | `{}`                                                 | Affinity properties for the helmOperator deployment
+| `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
+| `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/_helpers.tpl
+++ b/chart/flux/templates/_helpers.tpl
@@ -41,3 +41,22 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a custom repositories.yaml for Helm
+*/}}
+{{- define "flux.customRepositories" -}}
+apiVersion: v1
+generated: 0001-01-01T00:00:00Z
+repositories:
+{{- range .Values.helmOperator.configureRepositories.repositories }}
+- name: {{ required "Please specify a name for the Helm repo" .name }}
+  url: {{ required "Please specify a URL for the Helm repo" .url }}
+  cache: /var/fluxd/helm/repository/cache/{{ .name }}-index.yaml
+  caFile: ""
+  certFile: ""
+  keyFile: ""
+  password: "{{ .password | default "" }}"
+  username: "{{ .username | default "" }}"
+{{- end }}
+{{- end -}}

--- a/chart/flux/templates/flux-helm-repositories.yaml
+++ b/chart/flux/templates/flux-helm-repositories.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.helmOperator.configureRepositories.repositories -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.helmOperator.configureRepositories.secretName }}
+type: Opaque
+data:
+  repositories.yaml: {{ include "flux.customRepositories" . | b64enc }}
+{{- end -}}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -47,6 +47,11 @@ helmOperator:
     volumeName: repositories-yaml
     secretName: flux-helm-repositories
     cacheVolumeName: repositories-cache
+    repositories:
+      # - name: bitnami
+      #   url: https://charts.bitnami.com
+      #   username:
+      #   password:
   # Override Flux git settings
   git:
     pollInterval: ""


### PR DESCRIPTION
This simplifies using custom Helm repositories and generates a
`repositories.yaml` for the Helm operator.

Relates to #1862

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
