### PR TITLE
Fix `tag_all` pseudo policy on default-namespaced wokloads

### DIFF
--- a/cluster/kubernetes/manifests.go
+++ b/cluster/kubernetes/manifests.go
@@ -60,7 +60,7 @@ func getCRDScopes(manifests map[string]kresource.KubeManifest) ResourceScopes {
 	return result
 }
 
-func postProcess(manifests map[string]kresource.KubeManifest, nser namespacer) (map[string]resource.Resource, error) {
+func setEffectiveNamespaces(manifests map[string]kresource.KubeManifest, nser namespacer) (map[string]resource.Resource, error) {
 	knownScopes := getCRDScopes(manifests)
 	result := map[string]resource.Resource{}
 	for _, km := range manifests {
@@ -76,15 +76,15 @@ func postProcess(manifests map[string]kresource.KubeManifest, nser namespacer) (
 	return result, nil
 }
 
-func (c *Manifests) LoadManifests(base string, paths []string) (map[string]resource.Resource, error) {
+func (m *Manifests) LoadManifests(base string, paths []string) (map[string]resource.Resource, error) {
 	manifests, err := kresource.Load(base, paths)
 	if err != nil {
 		return nil, err
 	}
-	return postProcess(manifests, c.Namespacer)
+	return setEffectiveNamespaces(manifests, m.Namespacer)
 }
 
-func (c *Manifests) UpdateImage(def []byte, id flux.ResourceID, container string, image image.Ref) ([]byte, error) {
+func (m *Manifests) UpdateImage(def []byte, id flux.ResourceID, container string, image image.Ref) ([]byte, error) {
 	return updateWorkload(def, id, container, image)
 }
 

--- a/cluster/kubernetes/sync_test.go
+++ b/cluster/kubernetes/sync_test.go
@@ -319,7 +319,7 @@ metadata:
 		}
 
 		// Needed to get from KubeManifest to resource.Resource
-		resources, err := postProcess(resources0, namespacer)
+		resources, err := setEffectiveNamespaces(resources0, namespacer)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This fixes a regression introduced by #1442 in which applying the `tag_all` pseudo policy failed for workload manifests in which the namespace is omitted.

The effective namespace of the workload wasn't set after parsing, causing a mismatch in the resource identifier (the parsed resource identifier was cluster-scoped due to the lack of explicit namespace in the manifest).
