### PR TITLE
Exclude Helm manifests in get-started guide

### DIFF
--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -105,6 +105,9 @@ spec:
         # replace or remove the following URL
         - --git-url=git@github.com:weaveworks/flux-get-started
         - --git-branch=master
+        # include this if you want to restrict the manifests considered by flux
+        # to those under the following relative paths in the git repository
+        # - --git-paths=subdir1,subdir2
 
         # include these next two to connect to an "upstream" service
         # (e.g., Weave Cloud). The token is particular to the service.

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -63,7 +63,10 @@ $EDITOR deploy/flux-deployment.yaml
 In our example we are going to use
 [flux-get-started](https://github.com/weaveworks/flux-get-started). If you
 want to use that too, be sure to create a fork of it on GitHub and
-add the git URL to the config file above.
+add the git URL to the config file above. After that, set the `--git-path` 
+flag to `--git-path=namespaces,workloads`, this is meant to exclude Helm 
+manifests. Again, if you want to get started with Helm, please refer to the 
+[Helm section](./helm-get-started.md).
 
 ## Deploying Flux to the cluster
 
@@ -146,4 +149,5 @@ very straight-forward and are a quite natural work-flow.
 As a next step, you might want to dive deeper into [how to
 control Flux](./fluxctl.md), check out [more sophisticated
 setups](./standalone-setup.md) or go through our hands-on
-tutorial about driving Flux, e.g. [automations, annotations and locks](annotations-tutorial.md).
+tutorial about driving Flux, e.g. 
+[automations, annotations and locks](annotations-tutorial.md).


### PR DESCRIPTION
The get started guide uses repo github.com/weaveworks/flux-get-started
which contains HelmRelease manifests, but the guide didn't instruct
the reader to deploy the Helm operator.

Fixes #1898 
