### PR TITLE
Add spaces to comment lines to fix helm chart lint

### DIFF
--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -202,7 +202,7 @@ kube:
     kind: Config
     preferences: {}
     users: []
-# for https://github.com/justinbarrick/fluxcloud/
+# For https://github.com/justinbarrick/fluxcloud/
 # additionalArgs:
 # - --connect=ws://fluxcloud
 

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -202,8 +202,8 @@ kube:
     kind: Config
     preferences: {}
     users: []
-#for https://github.com/justinbarrick/fluxcloud/
-#additionalArgs:
+# for https://github.com/justinbarrick/fluxcloud/
+# additionalArgs:
 # - --connect=ws://fluxcloud
 
 # Additional environment variables to set


### PR DESCRIPTION
`ct lint` fails at present because of missing spaces at the start of comment lines

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->