### PR TITLE
Verify scanned keys in same build step as scan

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -6,11 +6,10 @@ RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0' gnupg
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
-RUN ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com >> /etc/ssh/ssh_known_hosts
-
-# Verify newly added known_hosts (man-in-middle mitigation)
 ADD ./verify_known_hosts.sh /home/flux/verify_known_hosts.sh
-RUN sh /home/flux/verify_known_hosts.sh /etc/ssh/ssh_known_hosts && rm /home/flux/verify_known_hosts.sh
+RUN ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com >> /etc/ssh/ssh_known_hosts && \
+    sh /home/flux/verify_known_hosts.sh /etc/ssh/ssh_known_hosts && \
+    rm /home/flux/verify_known_hosts.sh
 
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -6,13 +6,13 @@ RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
-RUN ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com >> /etc/ssh/ssh_known_hosts
+ADD ./verify_known_hosts.sh /home/flux/verify_known_hosts.sh
+RUN ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com >> /etc/ssh/ssh_known_hosts && \
+    sh /home/flux/verify_known_hosts.sh /etc/ssh/ssh_known_hosts && \
+    rm /home/flux/verify_known_hosts.sh
+
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config
-
-# Verify newly added known_hosts (man-in-middle mitigation)
-ADD ./verify_known_hosts.sh /home/flux/verify_known_hosts.sh
-RUN sh /home/flux/verify_known_hosts.sh /etc/ssh/ssh_known_hosts && rm /home/flux/verify_known_hosts.sh
 
 COPY ./kubectl /usr/local/bin/
 # The Helm client is included as a convenience for troubleshooting


### PR DESCRIPTION
ssh-keyscan can get keys which then fail verification (e.g., if it misses out a host for some reason), but nonetheless Docker will cache the intermediate image, which will cause subsequent builds to fail. This is a pain to recover from.

This commit changes the Dockerfiles such the verification is done in the same step as the keyscan -- so if it fails, the intermediate image won't be cached, and subsequent builds will do the keyscan again.
