### PR TITLE
 Reimplement `--git-poll-interval` in Helm operator

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -243,7 +243,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.pullPolicy`                         | `IfNotPresent`                                       | Helm operator image pull policy
 | `helmOperator.pullSecret`                         | `None`                                               | Image pull secret
 | `helmOperator.updateChartDeps`                    | `true`                                               | Update dependencies for charts
-| `helmOperator.git.pollInterval`                   | `git.pollInterval`                                   | Period at which to poll git repo for new commits
+| `helmOperator.git.pollInterval`                   | `git.pollInterval`                                   | Period on which to poll git chart sources for changes
 | `helmOperator.git.timeout`                        | `git.timeout`                                        | Duration after which git operations time out
 | `helmOperator.git.secretName`                     | `None`                                               | The name of the kubernetes secret with the SSH private key, supercedes `git.secretName`
 | `helmOperator.chartsSyncInterval`                 | `3m`                                                 | Interval at which to check for changed charts

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -1,4 +1,5 @@
 {{- $gitTimeout := default .Values.git.timeout .Values.helmOperator.git.timeout }}
+{{- $gitPollInterval := default .Values.git.pollInterval .Values.helmOperator.git.pollInterval }}
 {{- if .Values.helmOperator.create -}}
 apiVersion: apps/v1
 kind: Deployment
@@ -104,6 +105,7 @@ spec:
         {{- end }}
         args:
         - --git-timeout={{ $gitTimeout }}
+        - --git-poll-interval={{ $gitPollInterval }}
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}
         - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}

--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -50,7 +50,8 @@ var (
 	logReleaseDiffs    *bool
 	updateDependencies *bool
 
-	gitTimeout *time.Duration
+	gitTimeout      *time.Duration
+	gitPollInterval *time.Duration
 
 	listenAddr *string
 )
@@ -97,6 +98,7 @@ func init() {
 	updateDependencies = fs.Bool("update-chart-deps", true, "update chart dependencies before installing/upgrading a release")
 
 	gitTimeout = fs.Duration("git-timeout", 20*time.Second, "duration after which git operations time out")
+	gitPollInterval = fs.Duration("git-poll-interval", 5*time.Minute, "period on which to poll git chart sources for changes")
 }
 
 func main() {
@@ -174,7 +176,7 @@ func main() {
 		chartsync.Polling{Interval: *chartsSyncInterval},
 		chartsync.Clients{KubeClient: *kubeClient, IfClient: *ifClient},
 		rel,
-		chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, GitTimeout: *gitTimeout},
+		chartsync.Config{LogDiffs: *logReleaseDiffs, UpdateDeps: *updateDependencies, GitTimeout: *gitTimeout, GitPollInterval: *gitPollInterval},
 		*namespace,
 		statusUpdater,
 	)

--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -85,10 +85,11 @@ type Clients struct {
 }
 
 type Config struct {
-	ChartCache string
-	LogDiffs   bool
-	UpdateDeps bool
-	GitTimeout time.Duration
+	ChartCache      string
+	LogDiffs        bool
+	UpdateDeps      bool
+	GitTimeout      time.Duration
+	GitPollInterval time.Duration
 }
 
 func (c Config) WithDefaults() Config {
@@ -268,7 +269,10 @@ func mirrorName(chartSource *fluxv1beta1.GitChartSource) string {
 func (chs *ChartChangeSync) maybeMirror(fhr fluxv1beta1.HelmRelease) {
 	chartSource := fhr.Spec.ChartSource.GitChartSource
 	if chartSource != nil {
-		if ok := chs.mirrors.Mirror(mirrorName(chartSource), git.Remote{chartSource.GitURL}, git.Timeout(chs.config.GitTimeout), git.ReadOnly); !ok {
+		if ok := chs.mirrors.Mirror(
+			mirrorName(chartSource),
+			git.Remote{chartSource.GitURL}, git.Timeout(chs.config.GitTimeout), git.PollInterval(chs.config.GitPollInterval), git.ReadOnly,
+		); !ok {
 			chs.logger.Log("info", "started mirroring repo", "repo", chartSource.GitURL)
 		}
 	}

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -26,6 +26,7 @@ helm-operator requires setup and offers customization though a multitude of flag
 | **repo chart changes** (none of these need overriding, usually)
 | --charts-sync-interval    | `3m`                          | Interval at which to check for changed charts.
 | --git-timeout             | `20s`                         | Duration after which git operations time out.
+| --git-poll-interval       | `5m`                          | Period on which to poll git chart sources for changes.
 | --log-release-diffs       | `false`                       | Log the diff when a chart release diverges. **Potentially insecure.**
 | --update-chart-deps       | `true`                        | Update chart dependencies before installing or upgrading a release.
 

--- a/test/e2e/e2e-flux-chart.sh
+++ b/test/e2e/e2e-flux-chart.sh
@@ -8,6 +8,7 @@ KNOWN_HOSTS=$(cat ${REPO_ROOT}/test/e2e/known_hosts)
 
 echo ">>> Loading $(docker/image-tag) into the cluster"
 kind load docker-image "quay.io/weaveworks/flux:$(docker/image-tag)"
+kind load docker-image "quay.io/weaveworks/helm-operator:$(docker/image-tag)"
 
 echo ">>> Installing Flux with Helm"
 helm install --name flux --wait \
@@ -16,6 +17,7 @@ helm install --name flux --wait \
 --set git.url=ssh://git@gitsrv/git-server/repos/cluster.git \
 --set git.secretName=ssh-git \
 --set git.pollInterval=30s \
+--set helmOperator.tag=$(docker/image-tag) \
 --set helmOperator.create=true \
 --set helmOperator.createCRD=true \
 --set helmOperator.git.secretName=ssh-git \


### PR DESCRIPTION
This got removed a while ago, and was told to be replaced by `--charts-sync-interval`. The `--charts-sync-interval` flag is however _not_ used to control the polling of git repositories, but to control how often we should look if any mutations have occurred to Helm releases.

Add it back to restore the feature and regain control over git polling again.