### PR TITLE
Fix instructions for observing colour change

### DIFF
--- a/site/get-started.md
+++ b/site/get-started.md
@@ -133,9 +133,10 @@ run:
 
 ```sh
 kubectl -n demo port-forward deployment/podinfo 9898:9898 &
+curl localhost:9898
 ```
 
-Open your browser and navigate to `http://localhost:9898`.
+Notice the updated `color` value in the JSON reply.
 
 ## Conclusion
 


### PR DESCRIPTION
	In #1902 it was discovered that the part of the tutorial where
	PODINFO_UI_COLOR was changed didn't actually work. So we're
	using the same instructions as in the Helm tutorial now, modulo
	the namespace (default vs flux) change.
