### PR TITLE
Make `regex` an alias of `regexp` tag filter type

### DIFF
--- a/policy/pattern.go
+++ b/policy/pattern.go
@@ -1,17 +1,19 @@
 package policy
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/Masterminds/semver"
 	"github.com/ryanuber/go-glob"
 	"github.com/weaveworks/flux/image"
-	"strings"
-	"regexp"
 )
 
 const (
-	globPrefix   = "glob:"
-	semverPrefix = "semver:"
-	regexpPrefix = "regexp:"
+	globPrefix      = "glob:"
+	semverPrefix    = "semver:"
+	regexpPrefix    = "regexp:"
+	regexpAltPrefix = "regex:"
 )
 
 var (
@@ -43,8 +45,8 @@ type SemverPattern struct {
 
 // RegexpPattern matches by regular expression.
 type RegexpPattern struct {
-	pattern	string // pattern without prefix
-	regexp	*regexp.Regexp
+	pattern string // pattern without prefix
+	regexp  *regexp.Regexp
 }
 
 // NewPattern instantiates a Pattern according to the prefix
@@ -58,6 +60,10 @@ func NewPattern(pattern string) Pattern {
 		return SemverPattern{pattern, c}
 	case strings.HasPrefix(pattern, regexpPrefix):
 		pattern = strings.TrimPrefix(pattern, regexpPrefix)
+		r, _ := regexp.Compile(pattern)
+		return RegexpPattern{pattern, r}
+	case strings.HasPrefix(pattern, regexpAltPrefix):
+		pattern = strings.TrimPrefix(pattern, regexpAltPrefix)
 		r, _ := regexp.Compile(pattern)
 		return RegexpPattern{pattern, r}
 	default:

--- a/policy/pattern_test.go
+++ b/policy/pattern_test.go
@@ -1,9 +1,9 @@
 package policy
 
 import (
+	"fmt"
 	"testing"
 
-	"fmt"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -105,6 +105,12 @@ func TestRegexpPattern_Matches(t *testing.T) {
 			pattern: "regexp:^([a-zA-Z]+)$",
 			true:    []string{"foo", "BAR", "fooBAR"},
 			false:   []string{"1", "foo-1"},
+		},
+		{
+			name:    "regex",
+			pattern: `regex:^\w{7}(?:\w)?$`,
+			true:    []string{"af14eb2", "bb73ed94", "946427ff"},
+			false:   []string{"1", "foo", "946427ff-foo"},
 		},
 	} {
 		pattern := NewPattern(tt.pattern)

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -536,6 +536,7 @@ If your images have complex tags you can filter by regular expression:
 fluxctl policy --workload=default:deployment/helloworld --tag-all='regexp:^([a-zA-Z]+)$'
 ```
 
+Instead of `regexp` it is also possible to use its alias `regex`.
 Please bear in mind that if you want to match the whole tag,
 you must bookend your pattern with `^` and `$`.
 


### PR DESCRIPTION
The word `regex` seems to be a common alias of `regexp`, so people often use this and are left with confusion when Flux does not adhere to what they configured.

Make it an alias to better live up to people their expectations.