### PR TITLE
Be more tolerant towards missing image manifests

### DIFF
--- a/api/v6/container.go
+++ b/api/v6/container.go
@@ -27,8 +27,8 @@ type Container struct {
 }
 
 // NewContainer creates a Container given a list of images and the current image
-func NewContainer(name string, images update.ImageInfos, currentImage image.Info, tagPattern policy.Pattern, fields []string) (Container, error) {
-	sorted := images.Sort(tagPattern)
+func NewContainer(name string, images []image.Info, currentImage image.Info, tagPattern policy.Pattern, fields []string) (Container, error) {
+	sorted := update.SortImages(images, tagPattern)
 
 	// All images
 	imagesCount := len(sorted)
@@ -44,8 +44,8 @@ func NewContainer(name string, images update.ImageInfos, currentImage image.Info
 	}
 	newImagesCount := len(newImages)
 
-	// Filtered images
-	filteredImages := sorted.Filter(tagPattern)
+	// Filtered images (which respects sorting)
+	filteredImages := update.SortedImageInfos(update.FilterImages(sorted, tagPattern))
 	filteredImagesCount := len(filteredImages)
 	var newFilteredImages update.SortedImageInfos
 	for _, img := range filteredImages {

--- a/api/v6/container_test.go
+++ b/api/v6/container_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
-	"github.com/weaveworks/flux/update"
 )
 
 func TestNewContainer(t *testing.T) {
@@ -21,7 +20,7 @@ func TestNewContainer(t *testing.T) {
 
 	type args struct {
 		name         string
-		images       update.ImageInfos
+		images       []image.Info
 		currentImage image.Info
 		tagPattern   policy.Pattern
 		fields       []string
@@ -36,7 +35,7 @@ func TestNewContainer(t *testing.T) {
 			name: "Simple",
 			args: args{
 				name:         "container1",
-				images:       update.ImageInfos{testImage},
+				images:       []image.Info{testImage},
 				currentImage: testImage,
 				tagPattern:   policy.PatternAll,
 			},
@@ -56,7 +55,7 @@ func TestNewContainer(t *testing.T) {
 			name: "Semver filtering and sorting",
 			args: args{
 				name:         "container-semver",
-				images:       update.ImageInfos{currentSemver, newSemver, oldSemver, testImage},
+				images:       []image.Info{currentSemver, newSemver, oldSemver, testImage},
 				currentImage: currentSemver,
 				tagPattern:   policy.NewPattern("semver:*"),
 			},
@@ -114,7 +113,7 @@ func TestFilterContainerFields(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Filter",
+			name: "FilterImages",
 			args: args{
 				container: testContainer,
 				fields:    []string{"Name", "Available", "NewAvailableImagesCount", "NewFilteredImagesCount"},

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -571,7 +571,6 @@ func TestDaemon_JobStatusWithNoCache(t *testing.T) {
 
 func TestDaemon_Automated(t *testing.T) {
 	d, start, clean, k8s, _, _ := mockDaemon(t)
-	start()
 	defer clean()
 	w := newWait(t)
 
@@ -589,6 +588,7 @@ func TestDaemon_Automated(t *testing.T) {
 	k8s.SomeWorkloadsFunc = func([]flux.ResourceID) ([]cluster.Workload, error) {
 		return []cluster.Workload{workload}, nil
 	}
+	start()
 
 	// updates from helloworld:master-xxx to helloworld:2
 	w.ForImageTag(t, d, wl, container, "2")
@@ -596,12 +596,11 @@ func TestDaemon_Automated(t *testing.T) {
 
 func TestDaemon_Automated_semver(t *testing.T) {
 	d, start, clean, k8s, _, _ := mockDaemon(t)
-	start()
 	defer clean()
 	w := newWait(t)
 
 	resid := flux.MustParseResourceID("default:deployment/semver")
-	service := cluster.Workload{
+	workload := cluster.Workload{
 		ID: resid,
 		Containers: cluster.ContainersOrExcuse{
 			Containers: []resource.Container{
@@ -613,8 +612,9 @@ func TestDaemon_Automated_semver(t *testing.T) {
 		},
 	}
 	k8s.SomeWorkloadsFunc = func([]flux.ResourceID) ([]cluster.Workload, error) {
-		return []cluster.Workload{service}, nil
+		return []cluster.Workload{workload}, nil
 	}
+	start()
 
 	// helloworld:3 is older than helloworld:2 but semver orders by version
 	w.ForImageTag(t, d, resid.String(), container, "3")

--- a/image/image.go
+++ b/image/image.go
@@ -281,6 +281,43 @@ func (im *Info) UnmarshalJSON(b []byte) error {
 	return err
 }
 
+// RepositoryMetadata contains the image metadata information found in an
+// image repository.
+//
+// `Images` is indexed by `Tags`. Note that `Images` may be partial/incomplete,
+// (i.e. entries from `Tags` may not have a corresponding key in `Images`),
+// this indicates that the tag manifest was missing or corrupted in the
+// repository.
+type RepositoryMetadata struct {
+	Tags   []string        // all the tags found in the repository
+	Images map[string]Info // indexed by `Tags`, but may not include keys for all entries in `Tags`
+}
+
+// FindImageWithRef returns image.Info given an image ref. If the image cannot be
+// found, it returns the image.Info with the ID provided.
+func (rm RepositoryMetadata) FindImageWithRef(ref Ref) Info {
+	for _, img := range rm.Images {
+		if img.ID == ref {
+			return img
+		}
+	}
+	return Info{ID: ref}
+}
+
+// GetImageTagInfo gets the information of all image tags.
+// If there are tags missing information, an error is returned
+func (rm RepositoryMetadata) GetImageTagInfo() ([]Info, error) {
+	result := make([]Info, len(rm.Tags), len(rm.Tags))
+	for i, tag := range rm.Tags {
+		info, ok := rm.Images[tag]
+		if !ok {
+			return nil, fmt.Errorf("missing metadata for image tag %q", tag)
+		}
+		result[i] = info
+	}
+	return result, nil
+}
+
 func decodeTime(s string, t *time.Time) error {
 	if s == "" {
 		*t = time.Time{}

--- a/registry/cache/cache.go
+++ b/registry/cache/cache.go
@@ -39,14 +39,10 @@ func NewManifestKey(image image.CanonicalRef) Keyer {
 
 func (k *manifestKey) Key() string {
 	return strings.Join([]string{
-		"registryhistoryv3", // Just to version in case we need to change format later.
+		"registryhistoryv3", // Bump the version number if the cache format changes
 		k.fullRepositoryPath,
 		k.reference,
 	}, "|")
-}
-
-type tagKey struct {
-	fullRepositoryPath string
 }
 
 type repoKey struct {
@@ -59,7 +55,7 @@ func NewRepositoryKey(repo image.CanonicalName) Keyer {
 
 func (k *repoKey) Key() string {
 	return strings.Join([]string{
-		"registryrepov3",
+		"registryrepov4", // Bump the version number if the cache format changes
 		k.fullRepositoryPath,
 	}, "|")
 }

--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/registry"
@@ -69,27 +70,23 @@ Loop:
 		case <-timeout.C:
 			t.Fatal("Cache timeout")
 		case <-tick.C:
-			_, err := r.GetRepositoryImages(id.Name)
+			_, err := r.GetImageRespositoryMetadata(id.Name)
 			if err == nil {
 				break Loop
 			}
 		}
 	}
 
-	img, err := r.GetRepositoryImages(id.Name)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(img) == 0 {
-		t.Fatal("Length of returned images should be > 0")
-	}
-	// None of the images should have an empty ID or a creation time of zero
-	for _, i := range img {
-		if i.ID.String() == "" || i.ID.Tag == "" {
-			t.Fatalf("Image should not have empty name or tag. Got: %q", i.ID.String())
-		}
-		if i.CreatedAt.IsZero() {
-			t.Fatalf("Created time should not be zero for image %q", i.ID.String())
-		}
+	repoMetadata, err := r.GetImageRespositoryMetadata(id.Name)
+	assert.NoError(t, err)
+	assert.True(t, len(repoMetadata.Images) > 0, "Length of returned images should be > 0")
+	assert.Equal(t, len(repoMetadata.Images), len(repoMetadata.Tags), "the length of tags and images should match")
+
+	for _, tag := range repoMetadata.Tags {
+		i, ok := repoMetadata.Images[tag]
+		assert.True(t, ok, "tag doesn't have image information %s", tag)
+		// None of the images should have an empty ID or a creation time of zero
+		assert.True(t, i.ID.String() != "" && i.ID.Tag != "", "Image should not have empty name or tag. Got: %q", i.ID.String())
+		assert.NotZero(t, i.CreatedAt, "Created time should not be zero for image %q", i.ID.String())
 	}
 }

--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -70,14 +70,14 @@ Loop:
 		case <-timeout.C:
 			t.Fatal("Cache timeout")
 		case <-tick.C:
-			_, err := r.GetImageRespositoryMetadata(id.Name)
+			_, err := r.GetImageRepositoryMetadata(id.Name)
 			if err == nil {
 				break Loop
 			}
 		}
 	}
 
-	repoMetadata, err := r.GetImageRespositoryMetadata(id.Name)
+	repoMetadata, err := r.GetImageRepositoryMetadata(id.Name)
 	assert.NoError(t, err)
 	assert.True(t, len(repoMetadata.Images) > 0, "Length of returned images should be > 0")
 	assert.Equal(t, len(repoMetadata.Images), len(repoMetadata.Tags), "the length of tags and images should match")

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -31,35 +31,29 @@ type Cache struct {
 	Reader Reader
 }
 
-// GetRepositoryImages returns the list of image manifests in an image
+// GetImageRespositoryMetadata returns the metadata from an image
 // repository (e.g,. at "quay.io/weaveworks/flux")
-func (c *Cache) GetRepositoryImages(id image.Name) ([]image.Info, error) {
+func (c *Cache) GetImageRespositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
 	repoKey := NewRepositoryKey(id.CanonicalName())
 	bytes, _, err := c.Reader.GetKey(repoKey)
 	if err != nil {
-		return nil, err
+		return image.RepositoryMetadata{}, err
 	}
 	var repo ImageRepository
 	if err = json.Unmarshal(bytes, &repo); err != nil {
-		return nil, err
+		return image.RepositoryMetadata{}, err
 	}
 
 	// We only care about the error if we've never successfully
 	// updated the result.
 	if repo.LastUpdate.IsZero() {
 		if repo.LastError != "" {
-			return nil, errors.New(repo.LastError)
+			return image.RepositoryMetadata{}, errors.New(repo.LastError)
 		}
-		return nil, ErrNotCached
+		return image.RepositoryMetadata{}, ErrNotCached
 	}
 
-	images := make([]image.Info, len(repo.Images))
-	var i int
-	for _, im := range repo.Images {
-		images[i] = im
-		i++
-	}
-	return images, nil
+	return repo.RepositoryMetadata, nil
 }
 
 // GetImage gets the manifest of a specific image ref, from its
@@ -85,11 +79,11 @@ func (c *Cache) GetImage(id image.Ref) (image.Info, error) {
 // ImageRepository holds the last good information on an image
 // repository.
 //
-// Whenever we successfully fetch a full set of image info,
-// `LastUpdate` and `Images` shall each be assigned a value, and
+// Whenever we successfully fetch a set (partial or full) of image metadata,
+// `LastUpdate`, `Tags` and `Images` shall each be assigned a value, and
 // `LastError` will be cleared.
 //
-// If we cannot for any reason obtain a full set of image info,
+// If we cannot for any reason obtain the set of image metadata,
 // `LastError` shall be assigned a value, and the other fields left
 // alone.
 //
@@ -99,7 +93,7 @@ func (c *Cache) GetImage(id image.Ref) (image.Info, error) {
 // value (show the images, but also indicate there's a problem, for
 // example).
 type ImageRepository struct {
+	image.RepositoryMetadata
 	LastError  string
 	LastUpdate time.Time
-	Images     map[string]image.Info
 }

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -31,9 +31,9 @@ type Cache struct {
 	Reader Reader
 }
 
-// GetImageRespositoryMetadata returns the metadata from an image
+// GetImageRepositoryMetadata returns the metadata from an image
 // repository (e.g,. at "quay.io/weaveworks/flux")
-func (c *Cache) GetImageRespositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
+func (c *Cache) GetImageRepositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
 	repoKey := NewRepositoryKey(id.CanonicalName())
 	bytes, _, err := c.Reader.GetKey(repoKey)
 	if err != nil {

--- a/registry/cache/warming.go
+++ b/registry/cache/warming.go
@@ -317,8 +317,8 @@ func (w *Warmer) warm(ctx context.Context, now time.Time, logger log.Logger, id 
 						fetchMx.Lock()
 						manifestUnknownCount++
 						fetchMx.Unlock()
-						errorLogger.Log("warn", fmt.Sprintf("manifest for tag %s missing in registry %s", imageID.Tag, imageID.Name),
-							"impact", "flux will fail to auto-release workloads with matching images, ask the respository administrator to fix the inconsistency")
+						errorLogger.Log("warn", fmt.Sprintf("manifest for tag %s missing in repository %s", imageID.Tag, imageID.Name),
+							"impact", "flux will fail to auto-release workloads with matching images, ask the repository administrator to fix the inconsistency")
 					default:
 						errorLogger.Log("err", err, "ref", imageID)
 					}

--- a/registry/cache/warming_test.go
+++ b/registry/cache/warming_test.go
@@ -74,7 +74,7 @@ func TestWarmThenQuery(t *testing.T) {
 	warmer.warm(context.TODO(), now, logger, repo, registry.NoCredentials())
 
 	registry := &Cache{Reader: cache}
-	repoInfo, err := registry.GetImageRespositoryMetadata(ref.Name)
+	repoInfo, err := registry.GetImageRepositoryMetadata(ref.Name)
 	assert.NoError(t, err)
 
 	// Otherwise, we should get what we put in ...
@@ -115,7 +115,7 @@ func TestWarmManifestUnknown(t *testing.T) {
 	warmer.warm(context.TODO(), now, logger, repo, registry.NoCredentials())
 
 	registry := &Cache{Reader: cache}
-	repoInfo, err := registry.GetImageRespositoryMetadata(repo)
+	repoInfo, err := registry.GetImageRepositoryMetadata(repo)
 	assert.NoError(t, err)
 
 	assert.Len(t, repoInfo.Tags, 1)

--- a/registry/cache/warming_test.go
+++ b/registry/cache/warming_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 
@@ -73,12 +74,52 @@ func TestWarmThenQuery(t *testing.T) {
 	warmer.warm(context.TODO(), now, logger, repo, registry.NoCredentials())
 
 	registry := &Cache{Reader: cache}
-	repoInfo, err := registry.GetRepositoryImages(ref.Name)
+	repoInfo, err := registry.GetImageRespositoryMetadata(ref.Name)
 	assert.NoError(t, err)
 
 	// Otherwise, we should get what we put in ...
-	assert.Len(t, repoInfo, 1)
-	assert.Equal(t, ref.String(), repoInfo[0].ID.String())
+	assert.Len(t, repoInfo.Tags, 1)
+	assert.Equal(t, ref.String(), repoInfo.Images[repoInfo.Tags[0]].ID.String())
+}
+
+func TestWarmManifestUnknown(t *testing.T) {
+	tagWithMissingMetadata := "4.0.8-r3"
+	client := &mock.Client{
+		TagsFn: func() ([]string, error) {
+			println("asked for tags")
+			return []string{tagWithMissingMetadata}, nil
+		},
+		ManifestFn: func(tag string) (registry.ImageEntry, error) {
+			println("asked for manifest", tag)
+			err := errcode.Errors{
+				errcode.Error{Code: 1012,
+					Message: "manifest unknown",
+					Detail: map[string]interface{}{
+						"Name":     "bitnami/redis",
+						"Revision": "sha256:9c7f4a0958280a55a4337d74c22260bc338c26a0a2de493a8ad69dd73fd5c290",
+					},
+				},
+			}
+			return registry.ImageEntry{}, err
+		},
+	}
+	factory := &mock.ClientFactory{Client: client}
+	cache := &mem{}
+	warmer := &Warmer{clientFactory: factory, cache: cache, burst: 10}
+
+	logger := log.NewNopLogger()
+
+	now := time.Now()
+	redisRef, _ := image.ParseRef("bitnami/redis:5.0.2")
+	repo := redisRef.Name
+	warmer.warm(context.TODO(), now, logger, repo, registry.NoCredentials())
+
+	registry := &Cache{Reader: cache}
+	repoInfo, err := registry.GetImageRespositoryMetadata(repo)
+	assert.NoError(t, err)
+
+	assert.Len(t, repoInfo.Tags, 1)
+	assert.Equal(t, tagWithMissingMetadata, repoInfo.Tags[0])
 }
 
 func TestRefreshDeadline(t *testing.T) {

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -44,7 +44,7 @@ type Registry struct {
 	Err    error
 }
 
-func (m *Registry) GetImageRespositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
+func (m *Registry) GetImageRepositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
 	result := image.RepositoryMetadata{
 		Images: map[string]image.Info{},
 	}

--- a/registry/mock/mock.go
+++ b/registry/mock/mock.go
@@ -44,15 +44,19 @@ type Registry struct {
 	Err    error
 }
 
-func (m *Registry) GetRepositoryImages(id image.Name) ([]image.Info, error) {
-	var imgs []image.Info
+func (m *Registry) GetImageRespositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
+	result := image.RepositoryMetadata{
+		Images: map[string]image.Info{},
+	}
 	for _, i := range m.Images {
 		// include only if it's the same repository in the same place
 		if i.ID.Image == id.Image {
-			imgs = append(imgs, i)
+			tag := i.ID.Tag
+			result.Tags = append(result.Tags, tag)
+			result.Images[tag] = i
 		}
 	}
-	return imgs, m.Err
+	return result, m.Err
 }
 
 func (m *Registry) GetImage(id image.Ref) (image.Info, error) {

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -46,9 +46,9 @@ func NewInstrumentedRegistry(next Registry) Registry {
 	}
 }
 
-func (m *instrumentedRegistry) GetRepositoryImages(id image.Name) (res []image.Info, err error) {
+func (m *instrumentedRegistry) GetImageRespositoryMetadata(id image.Name) (res image.RepositoryMetadata, err error) {
 	start := time.Now()
-	res, err = m.next.GetRepositoryImages(id)
+	res, err = m.next.GetImageRespositoryMetadata(id)
 	registryDuration.With(
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())

--- a/registry/monitoring.go
+++ b/registry/monitoring.go
@@ -46,9 +46,9 @@ func NewInstrumentedRegistry(next Registry) Registry {
 	}
 }
 
-func (m *instrumentedRegistry) GetImageRespositoryMetadata(id image.Name) (res image.RepositoryMetadata, err error) {
+func (m *instrumentedRegistry) GetImageRepositoryMetadata(id image.Name) (res image.RepositoryMetadata, err error) {
 	start := time.Now()
-	res, err = m.next.GetImageRespositoryMetadata(id)
+	res, err = m.next.GetImageRepositoryMetadata(id)
 	registryDuration.With(
 		fluxmetrics.LabelSuccess, strconv.FormatBool(err == nil),
 	).Observe(time.Since(start).Seconds())

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -12,7 +12,7 @@ var (
 
 // Registry is a store of image metadata.
 type Registry interface {
-	GetRepositoryImages(image.Name) ([]image.Info, error)
+	GetImageRespositoryMetadata(image.Name) (image.RepositoryMetadata, error)
 	GetImage(image.Ref) (image.Info, error)
 }
 

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -12,7 +12,7 @@ var (
 
 // Registry is a store of image metadata.
 type Registry interface {
-	GetImageRespositoryMetadata(image.Name) (image.RepositoryMetadata, error)
+	GetImageRepositoryMetadata(image.Name) (image.RepositoryMetadata, error)
 	GetImage(image.Ref) (image.Info, error)
 }
 

--- a/remote/rpc/compat.go
+++ b/remote/rpc/compat.go
@@ -177,7 +177,7 @@ func listImagesWithOptions(ctx context.Context, client listImagesWithoutOptionsC
 			}
 			tagPattern := policy.GetTagPattern(p, container.Name)
 			// Create a new container using the same function used in v10
-			newContainer, err := v6.NewContainer(container.Name, update.ImageInfos(container.Available), container.Current, tagPattern, opts.OverrideContainerFields)
+			newContainer, err := v6.NewContainer(container.Name, container.Available, container.Current, tagPattern, opts.OverrideContainerFields)
 			if err != nil {
 				return statuses, err
 			}

--- a/update/images.go
+++ b/update/images.go
@@ -14,81 +14,72 @@ import (
 	"github.com/weaveworks/flux/resource"
 )
 
-type imageReposMap map[image.CanonicalName]ImageInfos
+type imageReposMap map[image.CanonicalName]image.RepositoryMetadata
 
-// ImageRepos contains a map of image repositories to their images
+// ImageRepos contains a map of image repositories to their metadata
 type ImageRepos struct {
 	imageRepos imageReposMap
 }
 
-// GetRepoImages returns image.Info entries for all the images in the
+// GetRepositoryMetadata returns the metadata for all the images in the
 // named image repository.
-func (r ImageRepos) GetRepoImages(repo image.Name) ImageInfos {
-	if canon, ok := r.imageRepos[repo.CanonicalName()]; ok {
-		infos := make([]image.Info, len(canon))
-		for i := range canon {
-			infos[i] = canon[i]
-			infos[i].ID = repo.ToRef(infos[i].ID.Tag)
+func (r ImageRepos) GetRepositoryMetadata(repo image.Name) image.RepositoryMetadata {
+	if metadata, ok := r.imageRepos[repo.CanonicalName()]; ok {
+		// copy tags
+		tagsCopy := make([]string, len(metadata.Tags))
+		copy(tagsCopy, metadata.Tags)
+		// copy images
+		imagesCopy := make(map[string]image.Info, len(metadata.Images))
+		for tag, info := range metadata.Images {
+			// The registry (cache) stores metadata with canonical image
+			// names (e.g., `index.docker.io/library/alpine`). We rewrite the
+			// names based on how we were queried (repo), which could
+			// be non-canonical representation (e.g. `alpine`).
+			info.ID = repo.ToRef(info.ID.Tag)
+			imagesCopy[tag] = info
 		}
-		return infos
+		return image.RepositoryMetadata{tagsCopy, imagesCopy}
 	}
-	return nil
+	return image.RepositoryMetadata{}
 }
-
-// ImageInfos is a list of image.Info which can be filtered.
-type ImageInfos []image.Info
 
 // SortedImageInfos is a list of sorted image.Info
 type SortedImageInfos []image.Info
 
-// Filter returns only the images that match the pattern, in a new list.
-func (ii ImageInfos) Filter(pattern policy.Pattern) ImageInfos {
-	return filterImages(ii, pattern)
+// FilterImages returns only the images that match the pattern, in a new list.
+func FilterImages(images []image.Info, pattern policy.Pattern) []image.Info {
+	return filterImages(images, pattern)
 }
 
-// Sort orders the images according to the pattern order in a new list.
-func (ii ImageInfos) Sort(pattern policy.Pattern) SortedImageInfos {
-	return sortImages(ii, pattern)
+// SortImages orders the images according to the pattern order in a new list.
+func SortImages(images []image.Info, pattern policy.Pattern) SortedImageInfos {
+	return sortImages(images, pattern)
 }
 
-// FilterAndSort is an optimized helper function to compose filtering and sorting.
-func (ii ImageInfos) FilterAndSort(pattern policy.Pattern) SortedImageInfos {
-	filtered := ii.Filter(pattern)
-	// Do not call sortImages() here which will clone the list that we already
-	// cloned in ImageInfos.Filter()
-	image.Sort(filtered, pattern.Newer)
-	return SortedImageInfos(filtered)
-}
-
-// FindWithRef returns image.Info given an image ref. If the image cannot be
-// found, it returns the image.Info with the ID provided.
-func (ii ImageInfos) FindWithRef(ref image.Ref) image.Info {
-	for _, img := range ii {
-		if img.ID == ref {
-			return img
-		}
+// FilterAndSortRepositoryMetadata obtains all the image information from the metadata
+// after filtering and sorting. Filtering happens in the metadata directly to minimize
+// problems with tag inconsistencies (i.e. tags without matching image information)
+func FilterAndSortRepositoryMetadata(rm image.RepositoryMetadata, pattern policy.Pattern) (SortedImageInfos, error) {
+	// Do the filtering
+	filteredMetadata := image.RepositoryMetadata{
+		Tags:   filterTags(rm.Tags, pattern),
+		Images: rm.Images,
 	}
-	return image.Info{ID: ref}
+	filteredImages, err := filteredMetadata.GetImageTagInfo()
+	if err != nil {
+		return nil, err
+	}
+	return SortImages(filteredImages, pattern), nil
 }
 
 // Latest returns the latest image from SortedImageInfos. If no such image exists,
 // returns a zero value and `false`, and the caller can decide whether
 // that's an error or not.
-func (is SortedImageInfos) Latest() (image.Info, bool) {
-	if len(is) > 0 {
-		return is[0], true
+func (sii SortedImageInfos) Latest() (image.Info, bool) {
+	if len(sii) > 0 {
+		return sii[0], true
 	}
 	return image.Info{}, false
-}
-
-// Filter returns only the images that match the pattern, in a new list.
-func (is SortedImageInfos) Filter(pattern policy.Pattern) SortedImageInfos {
-	return SortedImageInfos(filterImages(is, pattern))
-}
-
-// Sort orders the images according to the pattern order in a new list.
-func (is SortedImageInfos) Sort(pattern policy.Pattern) SortedImageInfos {
-	return sortImages(is, pattern)
 }
 
 func sortImages(images []image.Info, pattern policy.Pattern) SortedImageInfos {
@@ -100,16 +91,29 @@ func sortImages(images []image.Info, pattern policy.Pattern) SortedImageInfos {
 	return sorted
 }
 
-// filterImages keeps the sort order pristine.
-func filterImages(images []image.Info, pattern policy.Pattern) ImageInfos {
-	var filtered ImageInfos
+func matchWithLatest(pattern policy.Pattern, tag string) bool {
+	// Ignore latest if and only if it's not what the user wants.
+	if pattern != policy.PatternLatest && strings.EqualFold(tag, "latest") {
+		return false
+	}
+	return pattern.Matches(tag)
+}
+
+func filterTags(tags []string, pattern policy.Pattern) []string {
+	var filtered []string
+	for _, tag := range tags {
+		if matchWithLatest(pattern, tag) {
+			filtered = append(filtered, tag)
+		}
+	}
+	return filtered
+}
+
+func filterImages(images []image.Info, pattern policy.Pattern) []image.Info {
+	var filtered []image.Info
 	for _, i := range images {
 		tag := i.ID.Tag
-		// Ignore latest if and only if it's not what the user wants.
-		if pattern != policy.PatternLatest && strings.EqualFold(tag, "latest") {
-			continue
-		}
-		if pattern.Matches(tag) {
+		if matchWithLatest(pattern, tag) {
 			filtered = append(filtered, i)
 		}
 	}
@@ -144,11 +148,11 @@ func FetchImageRepos(reg registry.Registry, cs containers, logger log.Logger) (I
 	imageRepos := imageReposMap{}
 	for i := 0; i < cs.Len(); i++ {
 		for _, container := range cs.Containers(i) {
-			imageRepos[container.Image.CanonicalName()] = nil
+			imageRepos[container.Image.CanonicalName()] = image.RepositoryMetadata{}
 		}
 	}
 	for repo := range imageRepos {
-		images, err := reg.GetRepositoryImages(repo.Name)
+		images, err := reg.GetImageRespositoryMetadata(repo.Name)
 		if err != nil {
 			// Not an error if missing. Use empty images.
 			if !fluxerr.IsMissing(err) {
@@ -173,7 +177,12 @@ func exactImageRepos(reg registry.Registry, images []image.Ref) (ImageRepos, err
 		if !exist {
 			return ImageRepos{}, errors.Wrap(image.ErrInvalidImageID, fmt.Sprintf("image %q does not exist", id))
 		}
-		m[id.CanonicalName()] = []image.Info{{ID: id}}
+		m[id.CanonicalName()] = image.RepositoryMetadata{
+			Tags: []string{id.Tag},
+			Images: map[string]image.Info{
+				id.Tag: {ID: id},
+			},
+		}
 	}
 	return ImageRepos{m}, nil
 }

--- a/update/images.go
+++ b/update/images.go
@@ -152,7 +152,7 @@ func FetchImageRepos(reg registry.Registry, cs containers, logger log.Logger) (I
 		}
 	}
 	for repo := range imageRepos {
-		images, err := reg.GetImageRespositoryMetadata(repo.Name)
+		images, err := reg.GetImageRepositoryMetadata(repo.Name)
 		if err != nil {
 			// Not an error if missing. Use empty images.
 			if !fluxerr.IsMissing(err) {

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -21,7 +21,7 @@ var (
 
 func buildImageRepos(t *testing.T) ImageRepos {
 	registry := mock.Registry{Images: infos}
-	repoMetadata, err := registry.GetImageRespositoryMetadata(name.Name)
+	repoMetadata, err := registry.GetImageRepositoryMetadata(name.Name)
 	assert.NoError(t, err)
 	return ImageRepos{
 		imageRepos: imageReposMap{name.Name.CanonicalName(): repoMetadata},

--- a/update/images_test.go
+++ b/update/images_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/weaveworks/flux/image"
 	"github.com/weaveworks/flux/policy"
+	"github.com/weaveworks/flux/registry/mock"
 )
 
 var (
@@ -18,32 +19,46 @@ var (
 	}
 )
 
+func buildImageRepos(t *testing.T) ImageRepos {
+	registry := mock.Registry{Images: infos}
+	repoMetadata, err := registry.GetImageRespositoryMetadata(name.Name)
+	assert.NoError(t, err)
+	return ImageRepos{
+		imageRepos: imageReposMap{name.Name.CanonicalName(): repoMetadata},
+	}
+}
+
+func getFilteredAndSortedImagesFromRepos(t *testing.T, imageName string, repos ImageRepos) SortedImageInfos {
+	metadata := repos.GetRepositoryMetadata(mustParseName(imageName))
+	images, err := FilterAndSortRepositoryMetadata(metadata, policy.PatternAll)
+	assert.NoError(t, err)
+	return images
+}
+
 // TestDecanon checks that we return appropriate image names when
 // asked for images. The registry (cache) stores things with canonical
 // names (e.g., `index.docker.io/library/alpine`), but we ask
 // questions in terms of everyday names (e.g., `alpine`).
 func TestDecanon(t *testing.T) {
-	m := ImageRepos{imageReposMap{
-		name: infos,
-	}}
+	imageRepos := buildImageRepos(t)
 
-	filteredImages := m.GetRepoImages(mustParseName("weaveworks/helloworld")).FilterAndSort(policy.PatternAll)
-	latest, ok := filteredImages.Latest()
+	images := getFilteredAndSortedImagesFromRepos(t, "weaveworks/helloworld", imageRepos)
+	latest, ok := images.Latest()
 	if !ok {
 		t.Error("did not find latest image")
 	} else if latest.ID.Name != mustParseName("weaveworks/helloworld") {
 		t.Error("name did not match what was asked")
 	}
 
-	filteredImages = m.GetRepoImages(mustParseName("index.docker.io/weaveworks/helloworld")).FilterAndSort(policy.PatternAll)
-	latest, ok = filteredImages.Latest()
+	images = getFilteredAndSortedImagesFromRepos(t, "index.docker.io/weaveworks/helloworld", imageRepos)
+	latest, ok = images.Latest()
 	if !ok {
 		t.Error("did not find latest image")
 	} else if latest.ID.Name != mustParseName("index.docker.io/weaveworks/helloworld") {
 		t.Error("name did not match what was asked")
 	}
 
-	avail := m.GetRepoImages(mustParseName("weaveworks/helloworld"))
+	avail := getFilteredAndSortedImagesFromRepos(t, "weaveworks/helloworld", imageRepos)
 	if len(avail) != len(infos) {
 		t.Errorf("expected %d available images, got %d", len(infos), len(avail))
 	}
@@ -54,6 +69,25 @@ func TestDecanon(t *testing.T) {
 	}
 }
 
+func TestMetadataInConsistencyTolerance(t *testing.T) {
+	imageRepos := buildImageRepos(t)
+	metadata := imageRepos.GetRepositoryMetadata(mustParseName("weaveworks/helloworld"))
+	images, err := FilterAndSortRepositoryMetadata(metadata, policy.NewPattern("semver:*"))
+	assert.NoError(t, err)
+
+	// Let's make the metadata inconsistent by adding a non-semver tag
+	metadata.Tags = append(metadata.Tags, "latest")
+	// Filtering and sorting should still work
+	images2, err := FilterAndSortRepositoryMetadata(metadata, policy.NewPattern("semver:*"))
+	assert.NoError(t, err)
+	assert.Equal(t, images, images2)
+
+	// However, an inconsistency in a semver tag should make filtering and sorting fail
+	metadata.Tags = append(metadata.Tags, "v9")
+	_, err = FilterAndSortRepositoryMetadata(metadata, policy.NewPattern("semver:*"))
+	assert.Error(t, err)
+}
+
 func TestImageInfos_Filter_latest(t *testing.T) {
 	latest := image.Info{
 		ID: image.Ref{Name: image.Name{Image: "flux"}, Tag: "latest"},
@@ -61,11 +95,11 @@ func TestImageInfos_Filter_latest(t *testing.T) {
 	other := image.Info{
 		ID: image.Ref{Name: image.Name{Image: "moon"}, Tag: "v0"},
 	}
-	ii := ImageInfos{latest, other}
-	assert.Equal(t, SortedImageInfos{latest}, ii.FilterAndSort(policy.PatternLatest))
-	assert.Equal(t, SortedImageInfos{latest}, ii.FilterAndSort(policy.NewPattern("latest")))
-	assert.Equal(t, SortedImageInfos{other}, ii.FilterAndSort(policy.PatternAll))
-	assert.Equal(t, SortedImageInfos{other}, ii.FilterAndSort(policy.NewPattern("*")))
+	images := []image.Info{latest, other}
+	assert.Equal(t, []image.Info{latest}, filterImages(images, policy.PatternLatest))
+	assert.Equal(t, []image.Info{latest}, filterImages(images, policy.NewPattern("latest")))
+	assert.Equal(t, []image.Info{other}, filterImages(images, policy.PatternAll))
+	assert.Equal(t, []image.Info{other}, filterImages(images, policy.NewPattern("*")))
 }
 
 func TestImageInfos_Filter_semver(t *testing.T) {
@@ -73,14 +107,18 @@ func TestImageInfos_Filter_semver(t *testing.T) {
 	semver0 := image.Info{ID: image.Ref{Name: image.Name{Image: "moon"}, Tag: "v0.0.1"}}
 	semver1 := image.Info{ID: image.Ref{Name: image.Name{Image: "earth"}, Tag: "1.0.0"}}
 
-	ii := ImageInfos{latest, semver0, semver1}
-	assert.Equal(t, SortedImageInfos{semver1, semver0}, ii.FilterAndSort(policy.NewPattern("semver:*")))
-	assert.Equal(t, SortedImageInfos{semver1}, ii.FilterAndSort(policy.NewPattern("semver:~1")))
+	filterAndSort := func(images []image.Info, pattern policy.Pattern) SortedImageInfos {
+		filtered := FilterImages(images, pattern)
+		return SortImages(filtered, pattern)
+	}
+	images := []image.Info{latest, semver0, semver1}
+	assert.Equal(t, SortedImageInfos{semver1, semver0}, filterAndSort(images, policy.NewPattern("semver:*")))
+	assert.Equal(t, SortedImageInfos{semver1}, filterAndSort(images, policy.NewPattern("semver:~1")))
 }
 
 func TestAvail(t *testing.T) {
-	m := ImageRepos{imageReposMap{name: infos}}
-	avail := m.GetRepoImages(mustParseName("weaveworks/goodbyeworld"))
+	imageRepos := buildImageRepos(t)
+	avail := getFilteredAndSortedImagesFromRepos(t, "weaveworks/goodbyeworld", imageRepos)
 	if len(avail) > 0 {
 		t.Errorf("did not expect available images, but got %#v", avail)
 	}

--- a/update/release_image.go
+++ b/update/release_image.go
@@ -234,8 +234,14 @@ func (s ReleaseImageSpec) calculateImageUpdates(rc ReleaseContext, candidates []
 				}
 			}
 
-			filteredImages := imageRepos.GetRepoImages(currentImageID.Name).FilterAndSort(tagPattern)
-			latestImage, ok := filteredImages.Latest()
+			metadata := imageRepos.GetRepositoryMetadata(currentImageID.Name)
+			sortedImages, err := FilterAndSortRepositoryMetadata(metadata, tagPattern)
+			if err != nil {
+				// missing image repository metadata
+				ignoredOrSkipped = ReleaseStatusUnknown
+				continue
+			}
+			latestImage, ok := sortedImages.Latest()
 			if !ok {
 				if currentImageID.CanonicalName() != singleRepo {
 					ignoredOrSkipped = ReleaseStatusIgnored


### PR DESCRIPTION
Before this change, we only accepted image repository metadata if a manifest was present for all image tags (which is to be expected without inconsistencies).

However, enforcing fully consistent repository is a bit too strict, since:
1. Popular repositories may actually miss tag manifests (e.g. `bitnami/redis`),  which has been broken for months.
2. Users may not be able to enforce such consistency.
3. The offending image tags can be ignored if filtered out by container image annotation patterns.

This change allows for the repository cache warmer to accept partial repository information. Consistency is only enforced after tags are filtered by the container image pattern annotations.

In particular, this change adds:
* A new storage format in the repository cache, splitting the information into tags and image metadata.
* More tolerance towards tags missing metadata when listing images (e.g. `fluxctl list-images`).
* Tolerance towards tags missing metadata during auto-releases, provided that those tags are not matched by container image pattern annotations.

It's worth noting that we can do better for `semver` patterns, since they don't depend on image metadata for sorting (just on the tags themselves). `semver` patterns could tolerate tags without metadata, even after filtering. This however, is not provided by this change.

Fixes #1701 