### PR TITLE
Adding init container, extra volumes and volume mounts to helm chart.

### DIFF
--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -69,6 +69,16 @@ spec:
           secretName: {{ .Values.gpgKeys.secretName }}
           defaultMode: 0400
       {{- end }}
+      {{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+      {{- end }}
+{{- if .Values.initContainers }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+        - name: {{ $key }}
+{{ toYaml $value | indent 10 }}
+{{- end }}
+{{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -104,6 +114,9 @@ spec:
           - name: gpg-keys
             mountPath: /root/gpg-import
             readOnly: true
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+{{ toYaml .Values.extraVolumeMounts | indent 10 }}
           {{- end }}
           env:
           - name: KUBECONFIG
@@ -158,9 +171,6 @@ spec:
           {{- end }}
           {{- if .Values.registry.ecr.excludeId }}
           - --registry-ecr-exclude-id={{ .Values.registry.ecr.excludeId }}
-          {{- end }}
-          {{- if .Values.registry.ecr.require }}
-          - --registry-require=ecr
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}
           - --docker-config=/dockercfg/config.json

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -100,6 +100,10 @@ tolerations: []
 
 affinity: {}
 
+extraVolumeMounts: []
+
+extraVolumes: []
+
 gpgKeys:
   # These keys will be imported into GPG in the Flux container.
   secretName: ""
@@ -154,7 +158,6 @@ registry:
     region:
     includeId:
     excludeId:
-    require: false
   # Azure ACR settings
   acr:
     enabled: false
@@ -162,6 +165,7 @@ registry:
   dockercfg:
     enabled: false
     secretName: ""
+
 memcached:
   repository: memcached
   tag: 1.4.25
@@ -215,3 +219,13 @@ extraEnvs: []
 
 prometheus:
   enabled: false
+
+# Add your own init container or uncomment and modify the given example.
+initContainers: {}
+#   flux-init:  # <- will be used as container name
+#     image: "busybox:1.30.1"
+#     imagePullPolicy: "IfNotPresent"
+#     command: ['sh', '-c', 'counter=0; until [ "$counter" -ge 30 ]; do if [ -f /tmp/flux-deploy-key/identity ]; then exit 0; else echo waiting for flux deploy key && sleep 1 && counter=$((counter+1)); fi; done; exit 1;']
+#     volumeMounts:
+#       - mountPath: /tmp/flux-deploy-key
+#         name: flux-deploy-key


### PR DESCRIPTION
This PR enables users to add extra volumes, volume mounts and initContainer's to the chart deployed to their cluster if required.