### PR TITLE
Fix hardcoded docker config file

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -230,6 +230,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `registry.acr.hostPath`                           | `/etc/kubernetes/azure.json`                         | Alternative location of `azure.json` on the host
 | `registry.dockercfg.enabled`                      | `false`                                              | Mount `config.json` via Secret into the Flux Pod, enabling Flux to use a custom docker config file
 | `registry.dockercfg.secretName`                   | `None`                                               | Kubernetes secret with the docker config.json
+| `registry.dockercfg.configFileName`               | `/dockercfg/config.json`                             | Alternative path/name of the docker config.json
 | `memcached.verbose`                               | `false`                                              | Enable request logging in memcached
 | `memcached.maxItemSize`                           | `5m`                                                 | Maximum size for one item
 | `memcached.maxMemory`                             | `128`                                                | Maximum memory to use, in megabytes

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -163,7 +163,7 @@ spec:
           - --registry-require=ecr
           {{- end }}
           {{- if .Values.registry.dockercfg.enabled }}
-          - --docker-config=/dockercfg/config.json
+          - --docker-config={{ .Values.registry.dockercfg.configFileName }}
           {{- end }}
           {{- if .Values.token }}
           - --connect=wss://cloud.weave.works/api/flux

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -162,6 +162,7 @@ registry:
   dockercfg:
     enabled: false
     secretName: ""
+    configFileName: /dockercfg/config.json
 memcached:
   repository: memcached
   tag: 1.4.25


### PR DESCRIPTION
This is a small change to add flexibility to the flux chart template.

The deployment template in the flux chart currently hardcodes the file name of the docker config that contains the docker secret to:

` --docker-config=/dockercfg/config.json`

When running this on the IBM Cloud Kubernetes service that config filename ends up being different which requires to manually change the yaml post deployment.

This change creates a value parameter for it which defaults to current hardcoded value but allows changing this when we installing flux as per other value parameters.

Tested this by deploying flux to a Kubernetes cluster in IBM Cloud with kubernetes version 1.12, I did not manage to run 'make test' successfully not sure where/if there are docs or tips on running it.

