### PR TITLE
Limit scope of flux and flux operator in helm chart.

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -197,6 +197,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `token`                                           | `None`                                               | Weave Cloud service token
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
+| `clusterScope`                                    | `true`                                               | If `false`, will only create rbac resources for the namespace where flux is deployed to and will set k8s-allow-namespace and allow-namespace arg in flux and helm operator to that namespace
 | `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
 | `serviceAccount.name`                             | `flux`                                               | Service account to be used
 | `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -131,6 +131,9 @@ spec:
           {{- if .Values.memcached.createClusterIP }}
           - --memcached-service=
           {{- end }}
+          {{- if not .Values.clusterScope }}
+          - --k8s-allow-namespace={{ .Release.Namespace }}
+          {{- end }}
           - --git-url={{ .Values.git.url }}
           - --git-branch={{ .Values.git.branch }}
           - --git-path={{ .Values.git.path }}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -109,8 +109,11 @@ spec:
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}
         - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}
-        {{- if .Values.helmOperator.allowNamespace }}
+        {{- if and .Values.helmOperator.allowNamespace .Values.clusterScope }}
         - --allow-namespace={{ .Values.helmOperator.allowNamespace }}
+        {{- end }}
+        {{- if not .Values.clusterScope }}
+        - --allow-namespace={{ .Release.Namespace }}
         {{- end }}
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}
         {{- if .Values.helmOperator.tls.enable }}

--- a/chart/flux/templates/rbac.yaml
+++ b/chart/flux/templates/rbac.yaml
@@ -1,8 +1,18 @@
+{{- $kind := "Role" -}}
+{{- $bind := "RoleBinding" -}}
+{{- if .Values.clusterScope -}}
+{{ $kind = "ClusterRole" }}
+{{ $bind = "ClusterRoleBinding" }}
+{{- end -}}
+
 {{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: {{ $kind }}
 metadata:
   name: {{ template "flux.fullname" . }}
+  {{- if not .Values.clusterScope }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
   labels:
     app: {{ template "flux.name" . }}
     chart: {{ template "flux.chart" . }}
@@ -21,7 +31,7 @@ rules:
       - '*'
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
+kind: {{ $bind }}
 metadata:
   name: {{ template "flux.fullname" . }}
   labels:
@@ -31,10 +41,50 @@ metadata:
     heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ $kind }}
   name: {{ template "flux.fullname" . }}
 subjects:
   - name: {{ template "flux.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
-{{- end -}}
+{{- if not .Values.clusterScope }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  # CRDs are defined at the cluster scope and Flux will complain if it cannot list or watch these
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: flux
+  namespace: flux-system
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "flux.fullname" . }}
+subjects:
+  - name: {{ template "flux.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end }}
+{{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -87,6 +87,10 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+# If `false`, will only create rbac resources for the namespace where flux is deployed to and
+# will set k8s-allow-namespace and allow-namespace arg in flux and helm operator to that namespace
+clusterScope: true
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
Allows you to set `clusterScope` to `false` in helm chart so that rbac resources and arguments to both flux and helm operator are scoped only to the namespace where flux is deployed.

Partly addresses https://github.com/weaveworks/flux/issues/1886 and https://github.com/weaveworks/flux/issues/1085