### PR TITLE
Warn user about non-existing configured branch

### DIFF
--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -485,7 +485,7 @@ func main() {
 		SkipMessage: *gitSkipMessage,
 	}
 
-	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.Timeout(*gitTimeout))
+	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.Timeout(*gitTimeout), git.Branch(*gitBranch))
 	{
 		shutdownWg.Add(1)
 		go func() {

--- a/git/operations.go
+++ b/git/operations.go
@@ -78,9 +78,12 @@ func checkout(ctx context.Context, workingDir, ref string) error {
 // checkPush sanity-checks that we can write to the upstream repo
 // (being able to `clone` is an adequate check that we can read the
 // upstream).
-func checkPush(ctx context.Context, workingDir, upstream string) error {
+func checkPush(ctx context.Context, workingDir, upstream, branch string) error {
 	// --force just in case we fetched the tag from upstream when cloning
 	args := []string{"tag", "--force", CheckPushTag}
+	if branch != "" {
+		args = append(args, branch)
+	}
 	if err := execGitCmd(ctx, args, gitCmdConfig{dir: workingDir}); err != nil {
 		return errors.Wrap(err, "tag for write check")
 	}

--- a/git/operations_test.go
+++ b/git/operations_test.go
@@ -213,7 +213,7 @@ func TestCheckPush(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = checkPush(context.Background(), working, upstreamDir)
+	err = checkPush(context.Background(), working, upstreamDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When a user tried to configure Flux against an empty repository or a
branch that did not exist we would report a bogus status and left the
user confused.

This commit makes it possible to configure a branch that should be
checked for existence on creation of a new repository. In case there
is no HEAD found for this branch, it does not exist in git terms, and
we report back a meaningful error message to the user.

As a bonus we also use this configured branch when we create a tag for
our write check, so we do not touch anything the user has not told us
to.

Fixes #904, bonus fixes #1885