### PR TITLE
Exclude resources if we cannot find their scope

### DIFF
--- a/cluster/kubernetes/doc.go
+++ b/cluster/kubernetes/doc.go
@@ -1,6 +1,6 @@
 /*
 Package kubernetes provides implementations of `Cluster` and
-`Manifests` that interact with the Kubernetes API (using kubectl or
+`manifests` that interact with the Kubernetes API (using kubectl or
 the k8s API client).
 */
 package kubernetes

--- a/cluster/kubernetes/manifests_test.go
+++ b/cluster/kubernetes/manifests_test.go
@@ -1,21 +1,25 @@
 package kubernetes
 
 import (
+	"bytes"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/weaveworks/flux/cluster/kubernetes/testfiles"
 )
 
-func TestKnownCRDScope(t *testing.T) {
+func TestLocalCRDScope(t *testing.T) {
 	coreClient := makeFakeClient()
 
 	nser, err := NewNamespacer(coreClient.Discovery())
-	if err != nil {
-		t.Fatal(err)
-	}
-	manifests := Manifests{nser}
+	assert.NoError(t, err)
+	manifests := NewManifests(nser, log.NewLogfmtLogger(os.Stdout))
 
 	dir, cleanup := testfiles.TempDir(t)
 	defer cleanup()
@@ -46,17 +50,81 @@ metadata:
   namespace: bar
 `
 
-	if err = ioutil.WriteFile(filepath.Join(dir, "test.yaml"), []byte(defs), 0600); err != nil {
-		t.Fatal(err)
-	}
+	err = ioutil.WriteFile(filepath.Join(dir, "test.yaml"), []byte(defs), 0600)
+	assert.NoError(t, err)
 
 	resources, err := manifests.LoadManifests(dir, []string{dir})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if _, ok := resources["bar:foo/fooinstance"]; !ok {
-		t.Fatal("couldn't find crd instance")
-	}
+	assert.Contains(t, resources, "bar:foo/fooinstance")
+}
 
+func TestUnKnownCRDScope(t *testing.T) {
+	coreClient := makeFakeClient()
+
+	nser, err := NewNamespacer(coreClient.Discovery())
+	assert.NoError(t, err)
+	logBuffer := bytes.NewBuffer(nil)
+	manifests := NewManifests(nser, log.NewLogfmtLogger(logBuffer))
+
+	dir, cleanup := testfiles.TempDir(t)
+	defer cleanup()
+	const defs = `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: mynamespace
+---
+apiVersion: foo.example.com/v1beta1
+kind: Foo
+metadata:
+  name: fooinstance
+  namespace: bar
+`
+
+	err = ioutil.WriteFile(filepath.Join(dir, "test.yaml"), []byte(defs), 0600)
+	assert.NoError(t, err)
+
+	resources, err := manifests.LoadManifests(dir, []string{dir})
+	assert.NoError(t, err)
+
+	// can't contain the CRD since we cannot figure out its scope
+	assert.NotContains(t, resources, "bar:foo/fooinstance")
+
+	// however, it should contain the namespace
+	assert.Contains(t, resources, "<cluster>:namespace/mynamespace")
+
+	savedLog := logBuffer.String()
+	// and we should had logged a warning about it
+	assert.Contains(t, savedLog, "cannot find scope of resource foo/fooinstance")
+
+	// loading again shouldn't result in more warnings
+	resources, err = manifests.LoadManifests(dir, []string{dir})
+	assert.NoError(t, err)
+	assert.Equal(t, logBuffer.String(), savedLog)
+
+	// But getting the scope of the CRD should result in a log saying we found the scope
+	apiResourcesWithoutFoo := coreClient.Resources
+	apiResource := &metav1.APIResourceList{
+		GroupVersion: "foo.example.com/v1beta1",
+		APIResources: []metav1.APIResource{
+			{Name: "foos", SingularName: "foo", Namespaced: true, Kind: "Foo"},
+		},
+	}
+	coreClient.Resources = append(coreClient.Resources, apiResource)
+
+	logBuffer.Reset()
+	resources, err = manifests.LoadManifests(dir, []string{dir})
+	assert.NoError(t, err)
+	assert.Len(t, resources, 2)
+	assert.Contains(t, logBuffer.String(), "found scope of resource bar:foo/fooinstance")
+
+	// and missing the scope information again should result in another warning
+	coreClient.Resources = apiResourcesWithoutFoo
+	logBuffer.Reset()
+	resources, err = manifests.LoadManifests(dir, []string{dir})
+	assert.NoError(t, err)
+	assert.Contains(t, savedLog, "cannot find scope of resource foo/fooinstance")
 }

--- a/cluster/kubernetes/mock.go
+++ b/cluster/kubernetes/mock.go
@@ -1,0 +1,9 @@
+package kubernetes
+
+import kresource "github.com/weaveworks/flux/cluster/kubernetes/resource"
+
+type ConstNamespacer string
+
+func (ns ConstNamespacer) EffectiveNamespace(manifest kresource.KubeManifest, _ ResourceScopes) (string, error) {
+	return string(ns), nil
+}

--- a/cluster/kubernetes/namespacer.go
+++ b/cluster/kubernetes/namespacer.go
@@ -97,5 +97,6 @@ func (n *namespaceViaDiscovery) lookupNamespacedInCluster(groupVersion, kind str
 			return resource.Namespaced, nil
 		}
 	}
+
 	return false, fmt.Errorf("resource not found for API %s, kind %s", groupVersion, kind)
 }

--- a/cluster/kubernetes/policies.go
+++ b/cluster/kubernetes/policies.go
@@ -11,7 +11,7 @@ import (
 	"github.com/weaveworks/flux/resource"
 )
 
-func (m *Manifests) UpdatePolicies(def []byte, id flux.ResourceID, update policy.Update) ([]byte, error) {
+func (m *manifests) UpdatePolicies(def []byte, id flux.ResourceID, update policy.Update) ([]byte, error) {
 	ns, kind, name := id.Components()
 	add, del := update.Add, update.Remove
 
@@ -48,7 +48,7 @@ func (m *Manifests) UpdatePolicies(def []byte, id flux.ResourceID, update policy
 	return (KubeYAML{}).Annotate(def, ns, kind, name, args...)
 }
 
-func (m *Manifests) extractWorkloadContainers(def []byte, id flux.ResourceID) ([]resource.Container, error) {
+func (m *manifests) extractWorkloadContainers(def []byte, id flux.ResourceID) ([]resource.Container, error) {
 	kresources, err := kresource.ParseMultidoc(def, "stdin")
 	if err != nil {
 		return nil, err
@@ -58,7 +58,7 @@ func (m *Manifests) extractWorkloadContainers(def []byte, id flux.ResourceID) ([
 	// We could get out of our way to fix this (or give a better error) but:
 	// 1. With the exception of HelmReleases CRD instances are not workloads anyways.
 	// 2. The problem is eventually fixed by the first successful sync.
-	resources, err := setEffectiveNamespaces(kresources, m.Namespacer)
+	resources, err := m.setEffectiveNamespaces(kresources)
 	if err != nil {
 		return nil, err
 	}

--- a/cluster/kubernetes/sync_test.go
+++ b/cluster/kubernetes/sync_test.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"testing"
@@ -313,6 +314,7 @@ metadata:
 		if err != nil {
 			t.Fatal(err)
 		}
+		manifests := NewManifests(namespacer, log.NewLogfmtLogger(os.Stdout))
 
 		resources0, err := kresource.ParseMultidoc([]byte(defs), "before")
 		if err != nil {
@@ -320,7 +322,7 @@ metadata:
 		}
 
 		// Needed to get from KubeManifest to resource.Resource
-		resources, err := setEffectiveNamespaces(resources0, namespacer)
+		resources, err := manifests.setEffectiveNamespaces(resources0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -271,7 +271,7 @@ func main() {
 	var clusterVersion string
 	var sshKeyRing ssh.KeyRing
 	var k8s cluster.Cluster
-	var k8sManifests *kubernetes.Manifests
+	var k8sManifests cluster.Manifests
 	var imageCreds func() registry.ImageCreds
 	{
 		restClientConfig, err := rest.InClusterConfig()
@@ -369,13 +369,12 @@ func main() {
 		imageCreds = k8sInst.ImagesToFetch
 		// There is only one way we currently interpret a repo of
 		// files as manifests, and that's as Kubernetes yamels.
-		k8sManifests = &kubernetes.Manifests{}
-		k8sManifests.Namespacer, err = kubernetes.NewNamespacer(discoClientset)
-
+		namespacer, err := kubernetes.NewNamespacer(discoClientset)
 		if err != nil {
 			logger.Log("err", err)
 			os.Exit(1)
 		}
+		k8sManifests = kubernetes.NewManifests(namespacer, logger)
 	}
 
 	// Wrap the procedure for collecting images to scan

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -731,12 +731,14 @@ func mockDaemon(t *testing.T) (*Daemon, func(), func(), *cluster.Mock, *mockEven
 	// Jobs queue (starts itself)
 	jobs := job.NewQueue(jshutdown, jwg)
 
+	manifests := kubernetes.NewManifests(alwaysDefault, log.NewLogfmtLogger(os.Stdout))
+
 	// Finally, the daemon
 	d := &Daemon{
 		Repo:           repo,
 		GitConfig:      params,
 		Cluster:        k8s,
-		Manifests:      &kubernetes.Manifests{Namespacer: alwaysDefault},
+		Manifests:      manifests,
 		Registry:       imageRegistry,
 		V:              testVersion,
 		Jobs:           jobs,

--- a/daemon/loop_test.go
+++ b/daemon/loop_test.go
@@ -60,10 +60,12 @@ func daemon(t *testing.T) (*Daemon, func()) {
 		UserEmail: gitEmail,
 	}
 
+	manifests := kubernetes.NewManifests(alwaysDefault, log.NewLogfmtLogger(os.Stdout))
+
 	jobs := job.NewQueue(shutdown, wg)
 	d := &Daemon{
 		Cluster:        k8s,
-		Manifests:      &kubernetes.Manifests{Namespacer: alwaysDefault},
+		Manifests:      manifests,
 		Registry:       &registryMock.Registry{},
 		Repo:           repo,
 		GitConfig:      gitConfig,

--- a/sync/sync_test.go
+++ b/sync/sync_test.go
@@ -1,8 +1,10 @@
 package sync
 
 import (
+	"os"
 	"testing"
 
+	"github.com/go-kit/kit/log"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/weaveworks/flux/cluster"
@@ -19,7 +21,7 @@ func TestSync(t *testing.T) {
 	defer cleanup()
 
 	// Start with nothing running. We should be told to apply all the things.
-	manifests := &kubernetes.Manifests{}
+	manifests := kubernetes.NewManifests(kubernetes.ConstNamespacer("default"), log.NewLogfmtLogger(os.Stdout))
 	clus := &syncCluster{map[string]string{}}
 
 	dirs := checkout.ManifestDirs()


### PR DESCRIPTION
Fixes #1941 

This is aiming at custom resources whose scope is unknown because its CRD is included in a helm chart Flux won't inspect (since it's the helm operator's responsibility to do it).

This allows Flux to move forward and create the `HelmRelease` supplying the CRD. In a subsequent sync, once we know its scope, the custom resources will be created.

I was on the fence on whether I should revert #1876 but I decided against it, since it's not a lot of code (mostly reusable test-code) and it's less confusing for the user to obtain the custom resource scope locally if we have it.
