### PR TITLE
Initialize klog flags so it logs to stderr

### DIFF
--- a/cmd/helm-operator/main.go
+++ b/cmd/helm-operator/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -14,6 +13,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog"
 
 	"github.com/weaveworks/flux/checkpoint"
 	clientset "github.com/weaveworks/flux/integrations/client/clientset/versioned"
@@ -103,8 +103,9 @@ func init() {
 }
 
 func main() {
-	// set glog output to stderr
-	flag.CommandLine.Parse([]string{"-logtostderr"})
+	// Explicitly initialize klog to enable stderr logging,
+	// and parse our own flags.
+	klog.InitFlags(nil)
 	fs.Parse(os.Args)
 
 	if *versionFlag {


### PR DESCRIPTION
This got not caught in CircleCI as it does not perform a rebase
on-top of latest master before testing.

We bumped client-go a while ago (#1829) which included a switch to klog,
the klog flags need to be intialized before they can be set, as we did
not have this initialization in place, the operator was unable to
start. Simply initialize the flags and we are good to go.

---

I am tempted to add the following to the CircleCI config in a separate PR to prevent this in the future:

`if [[ "$CIRCLE_BRANCH" != "master"  && "$CIRCLE_BRANCH" != release*  ]]; then git fetch origin master && git rebase origin/master; fi`