### PR TITLE
Move images to Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
           name: Maybe push master image
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
-              docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD" quay.io
-              docker push "quay.io/weaveworks/flux:$(docker/image-tag)"
-              docker push "quay.io/weaveworks/helm-operator:$(docker/image-tag)"
+              echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin 
+              docker push "docker.io/weaveworks/flux:$(docker/image-tag)"
+              docker push "docker.io/weaveworks/helm-operator:$(docker/image-tag)"
             fi
 
       - deploy:
@@ -31,13 +31,13 @@ jobs:
               go get github.com/weaveworks/github-release
               make release-bins
               bin/upload-binaries
-              docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD" quay.io
-              docker push "quay.io/weaveworks/flux:${CIRCLE_TAG}"
+              echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
+              docker push "docker.io/weaveworks/flux:${CIRCLE_TAG}"
             fi
             if echo "${CIRCLE_TAG}" | grep -Eq "helm-[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
-              docker login -u "$DOCKER_REGISTRY_USER" -p "$DOCKER_REGISTRY_PASSWORD" quay.io
+              echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
               RELEASE_TAG=$(echo "$CIRCLE_TAG" | cut -c 6-)
-              docker push "quay.io/weaveworks/helm-operator:${RELEASE_TAG}"
+              docker push "docker.io/weaveworks/helm-operator:${RELEASE_TAG}"
             fi
   e2e-testing:
     machine: true

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ test: test/bin/helm test/bin/kubectl
 build/.%.done: docker/Dockerfile.%
 	mkdir -p ./build/docker/$*
 	cp $^ ./build/docker/$*/
-	$(SUDO) docker build -t quay.io/weaveworks/$* -t quay.io/weaveworks/$*:$(IMAGE_TAG) \
+	$(SUDO) docker build -t docker.io/weaveworks/$* -t docker.io/weaveworks/$*:$(IMAGE_TAG) \
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg BUILD_DATE="$(BUILD_DATE)" \
 		-f build/docker/$*/Dockerfile.$* ./build/docker/$*

--- a/api/v9/change_test.go
+++ b/api/v9/change_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestChangeEncoding(t *testing.T) {
-	ref, _ := image.ParseRef("quay.io/weaveworks/flux")
+	ref, _ := image.ParseRef("docker.io/weaveworks/flux")
 	name := ref.Name
 
 	for _, update := range []Change{

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -183,7 +183,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 
 | Parameter                                         | Default                                              | Description
 | -----------------------------------------------   | ---------------------------------------------------- | ---
-| `image.repository`                                | `quay.io/weaveworks/flux`                            | Image repository
+| `image.repository`                                | `docker.io/weaveworks/flux`                          | Image repository
 | `image.tag`                                       | `<VERSION>`                                          | Image tag
 | `replicaCount`                                    | `1`                                                  | Number of Flux pods to deploy, more than one is not desirable.
 | `image.pullPolicy`                                | `IfNotPresent`                                       | Image pull policy
@@ -239,7 +239,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `memcached.resources`                             | `None`                                               | CPU/memory resource requests/limits for memcached
 | `helmOperator.create`                             | `false`                                              | If `true`, install the Helm operator
 | `helmOperator.createCRD`                          | `true`                                               | Create the `v1beta1` and `v1alpha2` Flux CRDs. Dependent on `helmOperator.create=true`
-| `helmOperator.repository`                         | `quay.io/weaveworks/helm-operator`                   | Helm operator image repository
+| `helmOperator.repository`                         | `docker.io/weaveworks/helm-operator`                 | Helm operator image repository
 | `helmOperator.tag`                                | `<VERSION>`                                          | Helm operator image tag
 | `helmOperator.replicaCount`                       | `1`                                                  | Number of helm operator pods to deploy, more than one is not desirable.
 | `helmOperator.pullPolicy`                         | `IfNotPresent`                                       | Helm operator image pull policy

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -6,7 +6,7 @@ token: ""
 replicaCount: 1
 
 image:
-  repository: quay.io/weaveworks/flux
+  repository: docker.io/weaveworks/flux
   tag: 1.12.0
   pullPolicy: IfNotPresent
   pullSecret:
@@ -19,7 +19,7 @@ helmOperator:
   replicaCount: 1
   create: false
   createCRD: true
-  repository: quay.io/weaveworks/helm-operator
+  repository: docker.io/weaveworks/helm-operator
   tag: 0.8.0
   pullPolicy: IfNotPresent
   pullSecret:

--- a/deploy-helm/helm-operator-deployment.yaml
+++ b/deploy-helm/helm-operator-deployment.yaml
@@ -60,9 +60,9 @@ spec:
       containers:
       - name: flux-helm-operator
         # There are no ":latest" images for helm-operator. Find the most recent
-        # release or image version at https://quay.io/weaveworks/helm-operator
+        # release or image version at https://hub.docker.com/r/weaveworks/helm-operator/tags
         # and replace the tag here.
-        image: quay.io/weaveworks/helm-operator:0.8.0
+        image: docker.io/weaveworks/helm-operator:0.8.0
         imagePullPolicy: IfNotPresent
         ports:
         - name: http

--- a/deploy-helm/weave-cloud-helm-operator-deployment.yaml
+++ b/deploy-helm/weave-cloud-helm-operator-deployment.yaml
@@ -27,7 +27,7 @@ spec:
             secretName: flux-git-deploy
       containers:
         - name: flux-helm-operator
-          image: quay.io/weaveworks/helm-operator:0.8.0
+          image: docker.io/weaveworks/helm-operator:0.8.0
           imagePullPolicy: IfNotPresent
           args:
             - --git-timeout=20s

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -52,9 +52,9 @@ spec:
       containers:
       - name: flux
         # There are no ":latest" images for flux. Find the most recent
-        # release or image version at https://quay.io/weaveworks/flux
+        # release or image version at https://hub.docker.com/r/weaveworks/flux/tags
         # and replace the tag here.
-        image: quay.io/weaveworks/flux:1.12.0
+        image: docker.io/weaveworks/flux:1.12.0
         imagePullPolicy: IfNotPresent
         resources:
           requests:

--- a/image/image.go
+++ b/image/image.go
@@ -33,7 +33,7 @@ var (
 // Examples (stringified):
 //   * alpine
 //   * library/alpine
-//   * quay.io/weaveworks/flux
+//   * docker.io/weaveworks/flux
 //   * localhost:5000/arbitrary/path/to/repo
 type Name struct {
 	Domain, Image string
@@ -107,7 +107,7 @@ func (i Name) ToRef(tag string) Ref {
 // Examples (stringified):
 //  * alpine:3.5
 //  * library/alpine:3.5
-//  * quay.io/weaveworks/flux:1.1.0
+//  * docker.io/weaveworks/flux:1.1.0
 //  * localhost:5000/arbitrary/path/to/repo:revision-sha1
 type Ref struct {
 	Name

--- a/internal_docs/releasing.md
+++ b/internal_docs/releasing.md
@@ -3,7 +3,7 @@
 The release process needs to do these things:
 
  - create a new release on GitHub, with a tag
- - push Docker image(s) to quay.io
+ - push Docker image(s) to Docker Hub
  - possibly upload the [`fluxctl` binaries](/site/fluxctl.md#binary-releases) to the GitHub release
  - make sure the version is entered into the checkpoint database so that up-to-date checks report back accurate information
 

--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -34,7 +34,11 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 	// This repo has a stable number of images in the low tens (just
 	// <20); more than `burst` below, but not so many that timing out
 	// is likely.
-	id, _ := image.ParseRef("quay.io/weaveworks/kured")
+	// TODO(hidde): I temporary switched this to one of our images on
+	// Docker Hub due to Quay.io outage. It is however not guaranteed
+	// the amount of tags for this image stays stable and in the low
+	// tens.
+	id, _ := image.ParseRef("docker.io/weaveworks/flagger-loadtester")
 
 	logger := log.NewLogfmtLogger(os.Stderr)
 

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -32,7 +32,7 @@ type Cache struct {
 }
 
 // GetImageRepositoryMetadata returns the metadata from an image
-// repository (e.g,. at "quay.io/weaveworks/flux")
+// repository (e.g,. at "docker.io/weaveworks/flux")
 func (c *Cache) GetImageRepositoryMetadata(id image.Name) (image.RepositoryMetadata, error) {
 	repoKey := NewRepositoryKey(id.CanonicalName())
 	bytes, _, err := c.Reader.GetKey(repoKey)

--- a/registry/client.go
+++ b/registry/client.go
@@ -56,7 +56,7 @@ func (entry *ImageEntry) UnmarshalJSON(bytes []byte) error {
 }
 
 // Client is a remote registry client for a particular image
-// repository (e.g., for quay.io/weaveworks/flux). It is an interface
+// repository (e.g., for docker.io/weaveworks/flux). It is an interface
 // so we can wrap it in instrumentation, write fake implementations,
 // and so on.
 type Client interface {

--- a/registry/imageentry_test.go
+++ b/registry/imageentry_test.go
@@ -22,7 +22,7 @@ func TestImageEntryRoundtrip(t *testing.T) {
 		assert.Equal(t, entry, entry2)
 	}
 
-	ref, err := image.ParseRef("quay.io/weaveworks/flux:1.0.0")
+	ref, err := image.ParseRef("docker.io/weaveworks/flux:1.0.0")
 	assert.NoError(t, err)
 
 	info := image.Info{
@@ -44,7 +44,7 @@ func TestImageEntryRoundtrip(t *testing.T) {
 // Check that existing entries, which are image.Info, will parse into
 // the ImageEntry struct.
 func TestImageInfoParsesAsEntry(t *testing.T) {
-	ref, err := image.ParseRef("quay.io/weaveworks/flux:1.0.0")
+	ref, err := image.ParseRef("docker.io/weaveworks/flux:1.0.0")
 	assert.NoError(t, err)
 	info := image.Info{
 		ID:        ref,

--- a/site/faq.md
+++ b/site/faq.md
@@ -84,9 +84,9 @@ example. We may return to the matter of staged deployments.
 ### Are there nightly builds I can run?
 
 There are builds from CI for each merge to master branch. See
-[quay.io/weaveworks/flux](https://quay.io/repository/weaveworks/flux?tab=tags)
+[weaveworks/flux](https://hub.docker.com/r/weaveworks/flux/tags)
 and
-[quay.io/weaveworks/helm-operator](https://quay.io/repository/weaveworks/helm-operator?tag=latest&tab=tags).
+[weaveworks/helm-operator](https://hub.docker.com/r/weaveworks/helm-operator/tags).
 
 ## Technical questions
 

--- a/site/get-started-developing.md
+++ b/site/get-started-developing.md
@@ -7,7 +7,7 @@ This guide shows a workflow for making a small (actually, tiny) change to Flux, 
 > From a very high level, there are at least 3 ways you can develop on Flux once you have your environment set up:
 > 1. The "minimalist" approach (only requires and `kubectl`):
 >    1. `make`
->    1. copy the specific image tag (e.g. `quay.io/weaveworks/flux:master-a86167e4`) for what you just built and paste it into `/deploy/flux-deployment.yaml` as the image you're targeting to deploy
+>    1. copy the specific image tag (e.g. `docker.io/weaveworks/flux:master-a86167e4`) for what you just built and paste it into `/deploy/flux-deployment.yaml` as the image you're targeting to deploy
 >    1. deploy the resources in `/develop/*.yaml` manually with `kubectl apply`
 >    1. make a change to the code
 >    1. see your code changes have been deployed
@@ -85,19 +85,19 @@ Now that we know everything is working with `flux-getting-started`, we're going 
     In the same terminal you ran `eval $(minikube docker-env)`, run `dep ensure` followed by `make` from the root directory of the Flux repo.  You'll see docker's usual output as it builds the image layers.  Once it's done, you should see something like this in the middle of the output:
     ```
     Successfully built 606610e0f4ef
-    Successfully tagged quay.io/weaveworks/flux:latest
-    Successfully tagged quay.io/weaveworks/flux:master-a86167e4
+    Successfully tagged docker.io/weaveworks/flux:latest
+    Successfully tagged docker.io/weaveworks/flux:master-a86167e4
     ```
     This confirms that a new docker image was tagged for your image.
 
-1. Open up [`deploy/flux-deployment.yaml`](deploy/flux-deployment.yaml) and update the image at `spec.template.spec.containers[0].image` to be simply `quay.io/weaveworks/flux`.  While we're here, also change the `git-url` to point towards your fork.  It will look something like this in the yaml:
+1. Open up [`deploy/flux-deployment.yaml`](deploy/flux-deployment.yaml) and update the image at `spec.template.spec.containers[0].image` to be simply `docker.io/weaveworks/flux`.  While we're here, also change the `git-url` to point towards your fork.  It will look something like this in the yaml:
     ```yaml
     spec:
       template:
         spec:
           containers:
           - name: flux
-            image: quay.io/weaveworks/flux
+            image: docker.io/weaveworks/flux
             imagePullPolicy: IfNotPresent
             args:
               - --git-url=git@github.com:<YOUR-GITHUB-USERNAME>/flux-getting-started
@@ -144,8 +144,8 @@ Now that we know everything is working with `flux-getting-started`, we're going 
 
     You should see an output that looks something like this:
     ```
-    ts=2019-02-28T18:58:45.091531939Z caller=warming.go:268 component=warmer info="refreshing image" image=quay.io/ weaveworks/flux tag_count=60 to_update=60 of_which_refresh=0 of_which_missing=60
-    ts=2019-02-28T18:58:46.233723421Z caller=warming.go:364 component=warmer updated=quay.io/weaveworks/flux    successful=60 attempted=60
+    ts=2019-02-28T18:58:45.091531939Z caller=warming.go:268 component=warmer info="refreshing image" image=docker.io/weaveworks/flux tag_count=60 to_update=60 of_which_refresh=0 of_which_missing=60
+    ts=2019-02-28T18:58:46.233723421Z caller=warming.go:364 component=warmer updated=docker.io/weaveworks/flux    successful=60 attempted=60
     ts=2019-02-28T18:58:46.234086642Z caller=images.go:17 component=sync-loop msg="polling images"
     ts=2019-02-28T18:58:46.234125646Z caller=images.go:27 component=sync-loop msg="no automated services"
     ts=2019-02-28T18:58:46.749598558Z caller=warming.go:268 component=warmer info="refreshing image" image=memcached    tag_count=66 to_update=66 of_which_refresh=0 of_which_missing=66
@@ -173,9 +173,9 @@ Now that we know everything is working with `flux-getting-started`, we're going 
     flux-6f7fd5bbc-6j9d5   1/1     Running   0          10s
     ```
 
-    This pod was deployed even though we didn't run any `kubectl` commands or interact with Kubernetes directly because of the `freshpod` Minikube addon that we enabled earlier.  Freshpod saw that a new Docker image was tagged for `quay.io/weaveworks/flux:latest` and it went ahead and redeployed that pod for us.
+    This pod was deployed even though we didn't run any `kubectl` commands or interact with Kubernetes directly because of the `freshpod` Minikube addon that we enabled earlier.  Freshpod saw that a new Docker image was tagged for `docker.io/weaveworks/flux:latest` and it went ahead and redeployed that pod for us.
 
-    Consider that simply applying the `flux-deployment.yaml` file again wouldn't do anything since the actual image we're targeting (which is actually `quay.io/weaveworks/flux` with no `:latest` tag, but it's the same difference) hasn't changed.  The Kubernetes api server will get that JSON request from kubectl and go: "right... so nothing has changed in the file so I have nothing to do... IGNORE!".
+    Consider that simply applying the `flux-deployment.yaml` file again wouldn't do anything since the actual image we're targeting (which is actually `docker.io/weaveworks/flux` with no `:latest` tag, but it's the same difference) hasn't changed.  The Kubernetes api server will get that JSON request from kubectl and go: "right... so nothing has changed in the file so I have nothing to do... IGNORE!".
 
     There is another way to do this, of course.  Remember that before when we ran `make` that we did _also_ get an image tagged with the `:<branch>-<commit hash>` syntax (in our specific example above it was `:master-a86167e4`).  We could, in theory, grab that tag every time we `make`, and then paste it into `spec.template.spec.containers[0].image` of our deployment.  That's tedious and error prone.  Instead, `freshpod` cuts this step out for us and accomplishes the same end goal.
 

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -111,7 +111,7 @@ happen:
    ```yaml
     spec:
       containers:
-        image: quay.io/weaveworks/flux
+        image: docker.io/weaveworks/flux
         ...
         volumeMounts:
         - name: acr-credentials

--- a/test/bin/test-flux
+++ b/test/bin/test-flux
@@ -22,7 +22,7 @@ minikube start --profile "$PROFILE" --keep-context
 MINIKUBE_IP=$(minikube --profile "$PROFILE" ip)
 
 # Copy the latest Flux image into the minikube VM
-docker save quay.io/weaveworks/flux:latest | (eval $(minikube --profile "$PROFILE" docker-env) && docker load)
+docker save "docker.io/weaveworks/flux:latest" | (eval $(minikube --profile "$PROFILE" docker-env) && docker load)
 
 # Create a central git repo inside the minikube VM and get the host key for ssh access
 minikube --profile "$PROFILE" ssh -- git init --bare /home/docker/flux.git

--- a/test/e2e/e2e-flux-chart.sh
+++ b/test/e2e/e2e-flux-chart.sh
@@ -7,8 +7,8 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 KNOWN_HOSTS=$(cat ${REPO_ROOT}/test/e2e/known_hosts)
 
 echo ">>> Loading $(docker/image-tag) into the cluster"
-kind load docker-image "quay.io/weaveworks/flux:$(docker/image-tag)"
-kind load docker-image "quay.io/weaveworks/helm-operator:$(docker/image-tag)"
+kind load docker-image "docker.io/weaveworks/flux:$(docker/image-tag)"
+kind load docker-image "docker.io/weaveworks/helm-operator:$(docker/image-tag)"
 
 echo ">>> Installing Flux with Helm"
 helm install --name flux --wait \

--- a/test/flux-deploy-all.yaml
+++ b/test/flux-deploy-all.yaml
@@ -76,7 +76,7 @@ spec:
       containers:
       - name: flux
         # Require locally built image
-        image: quay.io/weaveworks/flux:latest
+        image: docker.io/weaveworks/flux:latest
         imagePullPolicy: Never
         ports:
         - containerPort: 3030 # informational


### PR DESCRIPTION
I choose to use the Fully Qualified Registry Name everywhere (`docker.io/weaveworks/flux`) instead of using the shorthand (`weaveworks/flux`) so it gets picked up when someone is for example excluding `docker.io` images using `--registry-exclude-image=docker.io/*`.