### PR TITLE
Tolerate empty GroupVersions when syncing

### DIFF
--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -211,8 +211,6 @@ func (c *Cluster) getAllowedResourcesBySelector(selector string) (map[string]*ku
 				return nil, err
 			}
 		}
-		c.logger.Log("warn", err,
-			"impact", "ignoring error, please check your cluster configuration, GroupVersions should not be empty")
 	}
 
 	result := map[string]*kuberesource{}

--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -21,7 +21,8 @@ import (
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/rest"
 
 	"github.com/weaveworks/flux"
 	"github.com/weaveworks/flux/cluster"
@@ -200,7 +201,18 @@ func (c *Cluster) getAllowedResourcesBySelector(selector string) (map[string]*ku
 
 	resources, err := c.client.discoveryClient.ServerResources()
 	if err != nil {
-		return nil, err
+		discErr, ok := err.(*discovery.ErrGroupDiscoveryFailed)
+		if !ok {
+			return nil, err
+		}
+		for gv, e := range discErr.Groups {
+			// Tolerate empty GroupVersions due to e.g. misconfigured custom metrics
+			if e.Error() != fmt.Sprintf("Got empty response for: %v", gv) {
+				return nil, err
+			}
+		}
+		c.logger.Log("warn", err,
+			"impact", "ignoring error, please check your cluster configuration, no GroupVersion should be empty")
 	}
 
 	result := map[string]*kuberesource{}

--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -199,7 +199,7 @@ func (c *Cluster) getAllowedResourcesBySelector(selector string) (map[string]*ku
 		listOptions.LabelSelector = selector
 	}
 
-	resources, err := c.client.discoveryClient.ServerResources()
+	_, resources, err := c.client.discoveryClient.ServerGroupsAndResources()
 	if err != nil {
 		discErr, ok := err.(*discovery.ErrGroupDiscoveryFailed)
 		if !ok {
@@ -212,7 +212,7 @@ func (c *Cluster) getAllowedResourcesBySelector(selector string) (map[string]*ku
 			}
 		}
 		c.logger.Log("warn", err,
-			"impact", "ignoring error, please check your cluster configuration, no GroupVersion should be empty")
+			"impact", "ignoring error, please check your cluster configuration, GroupVersions should not be empty")
 	}
 
 	result := map[string]*kuberesource{}

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -192,7 +192,10 @@ func main() {
 	logger.Log("version", version)
 
 	// Silence access errors logged internally by client-go
-	k8slog := log.With(logger, "type", "internal kubernetes error")
+	k8slog := log.With(logger,
+		"type", "internal kubernetes error",
+		"ts", log.DefaultTimestampUTC,
+		"caller", log.Caller(5)) // we want to log one level deeper than k8sruntime.HandleError
 	logErrorUnlessAccessRelated := func(err error) {
 		errLower := strings.ToLower(err.Error())
 		if k8serrors.IsForbidden(err) || k8serrors.IsNotFound(err) ||
@@ -203,7 +206,6 @@ func main() {
 		k8slog.Log("err", err)
 	}
 	k8sruntime.ErrorHandlers = []func(error){logErrorUnlessAccessRelated}
-
 	// Argument validation
 
 	// Sort out values for the git tag and notes ref. There are

--- a/daemon/loop.go
+++ b/daemon/loop.go
@@ -207,9 +207,9 @@ func (d *Daemon) doSync(logger log.Logger, lastKnownSyncTagRev *string, warnedAb
 
 	var resourceErrors []event.ResourceError
 	if err := fluxsync.Sync(syncSetName, allResources, d.Cluster); err != nil {
-		logger.Log("err", err)
 		switch syncerr := err.(type) {
 		case cluster.SyncError:
+			logger.Log("err", err)
 			for _, e := range syncerr {
 				resourceErrors = append(resourceErrors, event.ResourceError{
 					ID:    e.ResourceID,


### PR DESCRIPTION
Also:
* Improve error reporting
* Use ServerGroupsAndResources instead of ServerGroups (deprecated)

Fixes #1951 