### PR TITLE
chart: add support for deploying a global Git configuration.

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -213,6 +213,9 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `git.pollInterval`                                | `5m`                                                 | Period at which to poll git repo for new commits
 | `git.timeout`                                     | `20s`                                                | Duration after which git operations time out
 | `git.secretName`                                  | `None`                                               | Kubernetes secret with the SSH private key. Superceded by `helmOperator.git.secretName` if set.
+| `git.config.enabled`                              | `false`                                              | Mount `$HOME/.gitconfig` via Secret into the Flux and HelmOperator Pods, allowing for custom global Git configuration
+| `git.config.secretName`                           | `Computed`                                           | Kubernetes secret with the global Git configuration
+| `git.config.data`                                 | `None`                                               | Global Git configuration per [git-config](https://git-scm.com/docs/git-config)
 | `gpgKeys.secretName`                              | `None`                                               | Kubernetes secret with GPG keys the Flux daemon should import
 | `ssh.known_hosts`                                 | `None`                                               | The contents of an SSH `known_hosts` file, if you need to supply host key(s)
 | `registry.pollInterval`                           | `5m`                                                 | Period at which to check for updated images

--- a/chart/flux/templates/_helpers.tpl
+++ b/chart/flux/templates/_helpers.tpl
@@ -60,3 +60,16 @@ repositories:
   username: "{{ .username | default "" }}"
 {{- end }}
 {{- end -}}
+
+{{/*
+Create the name of the Git config Secret.
+*/}}
+{{- define "git.config.secretName" -}}
+{{- if .Values.git.config.enabled }}
+    {{- if .Values.git.config.secretName -}}
+        {{ default "default" .Values.git.config.secretName }}
+    {{- else -}}
+        {{ default (printf "%s-git-config" (include "flux.fullname" .)) }}
+{{- end -}}
+{{- end }}
+{{- end }}

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -41,6 +41,11 @@ spec:
           name: {{ template "flux.fullname" . }}-ssh-config
           defaultMode: 0600
       {{- end }}
+      {{- if .Values.git.config }}
+      - name: gitconfig
+        configMap:
+          name: {{ template "flux.fullname" . }}-gitconfig
+      {{- end }}
       - name: git-key
         secret:
           {{- if .Values.git.secretName }}
@@ -93,6 +98,12 @@ spec:
           {{- if .Values.ssh.known_hosts }}
           - name: sshdir
             mountPath: /root/.ssh
+            readOnly: true
+          {{- end }}
+          {{- if .Values.git.config }}
+          - name: gitconfig
+            mountPath: /root/.gitconfig
+            subPath: .gitconfig
             readOnly: true
           {{- end }}
           - name: git-key

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -41,10 +41,11 @@ spec:
           name: {{ template "flux.fullname" . }}-ssh-config
           defaultMode: 0600
       {{- end }}
-      {{- if .Values.git.config }}
-      - name: gitconfig
-        configMap:
-          name: {{ template "flux.fullname" . }}-gitconfig
+      {{- if .Values.git.config.enabled }}
+      - name: git-config
+        secret:
+          secretName: {{ include "git.config.secretName" . }}
+          defaultMode: 0400
       {{- end }}
       - name: git-key
         secret:
@@ -100,10 +101,10 @@ spec:
             mountPath: /root/.ssh
             readOnly: true
           {{- end }}
-          {{- if .Values.git.config }}
-          - name: gitconfig
+          {{- if .Values.git.config.enabled }}
+          - name: git-config
             mountPath: /root/.gitconfig
-            subPath: .gitconfig
+            subPath: gitconfig
             readOnly: true
           {{- end }}
           - name: git-key

--- a/chart/flux/templates/gitconfig.yaml
+++ b/chart/flux/templates/gitconfig.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.git.config -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "flux.fullname" . }}-gitconfig
+data:
+  .gitconfig: |
+    {{- if contains "\n" .Values.git.config }}
+      {{- range $value := .Values.git.config | splitList "\n" }}
+        {{ print $value }}
+      {{- end }}
+    {{- else }}
+      {{ .Values.git.config }}
+    {{- end }}
+{{- end -}}

--- a/chart/flux/templates/gitconfig.yaml
+++ b/chart/flux/templates/gitconfig.yaml
@@ -1,15 +1,9 @@
-{{- if .Values.git.config -}}
+{{- if .Values.git.config.enabled -}}
 apiVersion: v1
-kind: ConfigMap
+kind: Secret
 metadata:
-  name: {{ template "flux.fullname" . }}-gitconfig
+  name: {{ include "git.config.secretName" . }}
+type: Opaque
 data:
-  .gitconfig: |
-    {{- if contains "\n" .Values.git.config }}
-      {{- range $value := .Values.git.config | splitList "\n" }}
-        {{ print $value }}
-      {{- end }}
-    {{- else }}
-      {{ .Values.git.config }}
-    {{- end }}
+  gitconfig: {{ .Values.git.config.data | b64enc }}
 {{- end -}}

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -41,10 +41,11 @@ spec:
           name: {{ template "flux.fullname" . }}-ssh-config
           defaultMode: 0600
       {{- end }}
-      {{- if .Values.git.config }}
-      - name: gitconfig
-        configMap:
-          name: {{ template "flux.fullname" . }}-gitconfig
+      {{- if .Values.git.config.enabled }}
+      - name: git-config
+        secret:
+          secretName: {{ include "git.config.secretName" . }}
+          defaultMode: 0400
       {{- end }}
       - name: git-key
         secret:
@@ -89,10 +90,10 @@ spec:
           subPath: known_hosts
           readOnly: true
         {{- end }}
-        {{- if .Values.git.config }}
-        - name: gitconfig
+        {{- if .Values.git.config.enabled }}
+        - name: git-config
           mountPath: /root/.gitconfig
-          subPath: .gitconfig
+          subPath: gitconfig
           readOnly: true
         {{- end }}
         - name: git-key

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -41,6 +41,11 @@ spec:
           name: {{ template "flux.fullname" . }}-ssh-config
           defaultMode: 0600
       {{- end }}
+      {{- if .Values.git.config }}
+      - name: gitconfig
+        configMap:
+          name: {{ template "flux.fullname" . }}-gitconfig
+      {{- end }}
       - name: git-key
         secret:
           {{- if .Values.helmOperator.git.secretName }}
@@ -82,6 +87,12 @@ spec:
         - name: sshdir
           mountPath: /root/.ssh/known_hosts
           subPath: known_hosts
+          readOnly: true
+        {{- end }}
+        {{- if .Values.git.config }}
+        - name: gitconfig
+          mountPath: /root/.gitconfig
+          subPath: .gitconfig
           readOnly: true
         {{- end }}
         - name: git-key

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -137,6 +137,11 @@ git:
   # add ./identity.pub as a deployment key with write access in your Git repo
   # set the secret name (flux-ssh) below
   secretName: ""
+  # Global Git configuration See https://git-scm.com/docs/git-config for more details.
+  config: ""
+  # config: |
+  #   [credential "https://github.com"]
+  #           username = foo
 
 registry:
   # Period at which to check for updated images

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -138,10 +138,13 @@ git:
   # set the secret name (flux-ssh) below
   secretName: ""
   # Global Git configuration See https://git-scm.com/docs/git-config for more details.
-  config: ""
-  # config: |
-  #   [credential "https://github.com"]
-  #           username = foo
+  config:
+    enabled: false
+    secretName: ""
+    data: ""
+    # data: |
+    #   [credential "https://github.com"]
+    #           username = foo
 
 registry:
   # Period at which to check for updated images

--- a/test/e2e/gitconfig
+++ b/test/e2e/gitconfig
@@ -1,0 +1,2 @@
+[core]
+    editor = vim


### PR DESCRIPTION
<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->

Hi,

The following PR adds the ability to deploy a custom Git configuration from a ConfigMap that flux and helm-operator will use during any Git operations. This PR is part of forthcoming PR that adds AWS CodeCommit IAM auth support via a configured Git credential helper. Aternatively it might make more sense to store the configuration as secret.

As this is my first time submitting a PR for this project I am not entirely sure how these changes are meant to be tested. I looked for Helm tests but did not find any. Any pointers in this regard are appreciated.

Thanks,

-ben 
