### PR TITLE
add snapcraft.yaml for Linux packages of fluxctl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,14 @@ _testmain.go
 .ackrc
 .envrc
 
+### Package builds (e.g. snap of fluxctl)
+fluxctl_*_*.snap
+parts
+snap
+prime
+stage
+
+
 # Specific to this project
 vendor/*
 !vendor/manifest

--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,6 @@ _testmain.go
 ### Package builds (e.g. snap of fluxctl)
 fluxctl_*_*.snap
 parts
-snap
 prime
 stage
 

--- a/snap/local/fluxctl-launch
+++ b/snap/local/fluxctl-launch
@@ -1,3 +1,3 @@
 #!/bin/sh
 real_home=$(getent passwd "$(id -u)" | cut -d ':' -f 6)
-cd "$real_home" && fluxctl "$@"
+HOME=$real_home fluxctl.real "$@"

--- a/snap/local/fluxctl-launch
+++ b/snap/local/fluxctl-launch
@@ -1,0 +1,3 @@
+#!/bin/sh
+real_home=$(getent passwd "$(id -u)" | cut -d ':' -f 6)
+cd "$real_home" && fluxctl "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -32,15 +32,8 @@ parts:
     source: .
     plugin: go
     go-importpath: github.com/weaveworks/flux
-    override-pull: |
-      snapcraftctl pull
-      export GOPATH=$(dirname $SNAPCRAFT_PART_INSTALL)/go
-      export PATH=$GOPATH/bin:$PATH
-      cd $GOPATH/src/github.com/weaveworks/flux
-      dep ensure
     build-packages:
       - gcc
-      - go-dep
     stage:
       - -bin/fluxd
       - -bin/helm-operator

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -62,3 +62,4 @@ apps:
     plugs:
       - personal-files
       - network
+      - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,11 +17,6 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict
 base: core18
 
-plugs:
-  personal-files:
-    read:
-      - $HOME/.kube/config
-
 parts:
   launcher:
     source: snap/local
@@ -53,10 +48,19 @@ parts:
       bin/fluxctl: bin/fluxctl.real
     after: [launcher]
 
+plugs:
+  kube-config:
+    interface: personal-files
+    read:
+    - $HOME/.kube/config
+    - $HOME/.minikube/client.key
+    - $HOME/.minikube/client.crt
+    - $HOME/.minikube/ca.crt
+
 apps:
   fluxctl:
     command: bin/fluxctl-launch
     plugs:
-      - personal-files
-      - network
-      - network-bind
+    - kube-config
+    - network
+    - network-bind

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,9 +21,6 @@ plugs:
   personal-files:
     read:
       - $HOME/.kube/config
-      - $HOME/.minikube/client.key
-      - $HOME/.minikube/client.crt
-      - $HOME/.minikube/ca.crt
 
 parts:
   launcher:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,8 +52,13 @@ parts:
     stage:
       - -bin/fluxd
       - -bin/helm-operator
+    organize:
+      bin/fluxctl: bin/fluxctl.real
     after: [launcher]
 
 apps:
   fluxctl:
     command: bin/fluxctl-launch
+    plugs:
+      - personal-files
+      - network

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -26,6 +26,16 @@ plugs:
       - $HOME/.minikube/ca.crt
 
 parts:
+  launcher:
+    source: snap/local
+    source-type: local
+    plugin: dump
+    organize:
+      '*': bin/
+    override-stage: |
+      cd $SNAPCRAFT_PART_INSTALL
+      chmod +x bin/fluxctl-launch
+      snapcraftctl stage
   fluxctl:
     source: .
     plugin: go
@@ -39,9 +49,11 @@ parts:
     build-packages:
       - gcc
       - go-dep
-    prime:
-      - bin/fluxctl
+    stage:
+      - -bin/fluxd
+      - -bin/helm-operator
+    after: [launcher]
 
 apps:
   fluxctl:
-    command: bin/fluxctl
+    command: bin/fluxctl-launch

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -8,6 +8,7 @@ version-script: |
     GIT_REV="$(git rev-parse --short HEAD)"
     echo "$FLUX_TAG+$GIT_REV"
   fi
+  # XXX: Look into https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617
 version: git
 summary: fluxctl talks to Weave Flux and helps you deploy your code
 description: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: fluxctl
 version-script: |
-  FLUX_TAG="$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort -V | tail -n1)"
+  FLUX_TAG="$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort --version-sort | tail -n1)"
   if [ "$SNAPCRAFT_PROJECT_GRADE" = "stable" ]
   then
     echo "$FLUX_TAG"
@@ -8,7 +8,6 @@ version-script: |
     GIT_REV="$(git rev-parse --short HEAD)"
     echo "$FLUX_TAG+$GIT_REV"
   fi
-  # XXX: Look into https://forum.snapcraft.io/t/selective-checkout-check-out-the-tagged-release-revision-if-it-isnt-promoted-to-the-stable-channel/10617
 version: git
 summary: fluxctl talks to Weave Flux and helps you deploy your code
 description: |

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,8 +14,14 @@ description: |
   fluxctl talks to your Weave Flux instance and exposes all its
   functionality to an easy to use command line interface.
 grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: classic
+confinement: strict
 base: core18
+
+plugs:
+  system-files:
+    read: [/etc/kube/config]
+  personal-files:
+    read: [$HOME/.kube/config]
 
 parts:
   fluxctl:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
   fluxctl talks to your Weave Flux instance and exposes all its
   functionality to an easy to use command line interface.
 grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: classic
+confinement: devmode
 base: core18
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,9 +1,9 @@
 name: fluxctl
 version-script: |
-  FLUX_TAG="$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort -n | tail -n1)"
+  FLUX_TAG="$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort -V | tail -n1)"
   if [ "$SNAPCRAFT_PROJECT_GRADE" = "stable" ]
   then
-    echo $FLUX_TAG
+    echo "$FLUX_TAG"
   else
     GIT_REV="$(git rev-parse --short HEAD)"
     echo "$FLUX_TAG+$GIT_REV"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -14,7 +14,7 @@ description: |
   fluxctl talks to your Weave Flux instance and exposes all its
   functionality to an easy to use command line interface.
 grade: devel # must be 'stable' to release into candidate/stable channels
-confinement: devmode
+confinement: classic
 base: core18
 
 parts:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -18,10 +18,12 @@ confinement: strict
 base: core18
 
 plugs:
-  system-files:
-    read: [/etc/kube/config]
   personal-files:
-    read: [$HOME/.kube/config]
+    read:
+      - $HOME/.kube/config
+      - $HOME/.minikube/client.key
+      - $HOME/.minikube/client.crt
+      - $HOME/.minikube/ca.crt
 
 parts:
   fluxctl:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -1,0 +1,39 @@
+name: fluxctl
+version-script: |
+  FLUX_TAG="$(git tag -l | egrep -v '^(chart-|helm-|master-|pre-split)' | sort -n | tail -n1)"
+  if [ "$SNAPCRAFT_PROJECT_GRADE" = "stable" ]
+  then
+    echo $FLUX_TAG
+  else
+    GIT_REV="$(git rev-parse --short HEAD)"
+    echo "$FLUX_TAG+$GIT_REV"
+  fi
+version: git
+summary: fluxctl talks to Weave Flux and helps you deploy your code
+description: |
+  fluxctl talks to your Weave Flux instance and exposes all its
+  functionality to an easy to use command line interface.
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: classic
+base: core18
+
+parts:
+  fluxctl:
+    source: .
+    plugin: go
+    go-importpath: github.com/weaveworks/flux
+    override-pull: |
+      snapcraftctl pull
+      export GOPATH=$(dirname $SNAPCRAFT_PART_INSTALL)/go
+      export PATH=$GOPATH/bin:$PATH
+      cd $GOPATH/src/github.com/weaveworks/flux
+      dep ensure
+    build-packages:
+      - gcc
+      - go-dep
+    prime:
+      - bin/fluxctl
+
+apps:
+  fluxctl:
+    command: bin/fluxctl


### PR DESCRIPTION
This creates a snap of `fluxctl`, prerequisite is:

```console
sudo snap install snapcraft --classic
sudo snap install multipass --beta --classic
snapcraft
```

Next step would be 

- [x] register on Snap store
- [x] push initial snap of 'edge' release (current HEAD)
- [x] ask for ~~classic~~ `personal-files` permissions (https://forum.snapcraft.io/c/store-requests)
- [x] get package ~~and classic permissions~~ approved
- [x] ~~hook this up with the build infrastructure~~ → moving this to a new issue/OR