### PR TITLE
Fix insecure-host-checking for repos with an explicit port

### DIFF
--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -99,8 +99,8 @@ func (f *RemoteClientFactory) ClientFor(repo image.CanonicalName, creds Credenti
 	}
 	insecure := false
 	for _, h := range f.InsecureHosts {
+		// allow the insecure hosts list to contain hosts with or without the port
 		if repoHost == h || repo.Domain == h {
-			// allow host with out without the port in the insecure hosts list
 			insecure = true
 			break
 		}

--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
 	"net/url"
 	"sync"
@@ -92,9 +93,13 @@ attemptChallenge:
 }
 
 func (f *RemoteClientFactory) ClientFor(repo image.CanonicalName, creds Credentials) (Client, error) {
+	repoHost, _, err := net.SplitHostPort(repo.Domain)
+	if err != nil {
+		return nil, err
+	}
 	insecure := false
 	for _, h := range f.InsecureHosts {
-		if repo.Domain == h {
+		if repoHost == h {
 			insecure = true
 			break
 		}

--- a/registry/client_factory.go
+++ b/registry/client_factory.go
@@ -99,7 +99,8 @@ func (f *RemoteClientFactory) ClientFor(repo image.CanonicalName, creds Credenti
 	}
 	insecure := false
 	for _, h := range f.InsecureHosts {
-		if repoHost == h {
+		if repoHost == h || repo.Domain == h {
+			// allow host with out without the port in the insecure hosts list
 			insecure = true
 			break
 		}


### PR DESCRIPTION
Before this change we included the repository port when comparing against the list of insecure hosts.