### PR TITLE
 Add a timeout to all registry requests

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -170,7 +170,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:ce6b49c97a4d3d6f401b956c32bceab12c96a6cd724512fa21774fedc8876d1d"
+  digest = "1:44fa5dc9f471d5285648d966808fe191cde2c80d337683886d9b7aa5091b39dc"
   name = "github.com/docker/distribution"
   packages = [
     ".",
@@ -191,7 +191,8 @@
     "registry/storage/cache/memory",
   ]
   pruneopts = ""
-  revision = "6d62eb1d4a3515399431b713fde3ce5a9b40e8d5"
+  revision = "6c9727e5e5ded4589f2d653a2e523b41619af05c"
+  source = "github.com/2opremio/distribution"
 
 [[projects]]
   branch = "master"
@@ -310,14 +311,6 @@
   packages = ["httputil/header"]
   pruneopts = ""
   revision = "5a2505f3dbf049b47a091040906b7b2856339099"
-
-[[projects]]
-  branch = "master"
-  digest = "1:107b233e45174dbab5b1324201d092ea9448e58243ab9f039e4c0f332e121e3a"
-  name = "github.com/golang/glog"
-  packages = ["."]
-  pruneopts = ""
-  revision = "23def4e6c14b4da8ac2ed8007337bc5eb5007998"
 
 [[projects]]
   branch = "master"
@@ -1361,7 +1354,6 @@
     "github.com/go-kit/kit/metrics",
     "github.com/go-kit/kit/metrics/prometheus",
     "github.com/golang/gddo/httputil/header",
-    "github.com/golang/glog",
     "github.com/golang/protobuf/ptypes/any",
     "github.com/google/go-cmp/cmp",
     "github.com/gorilla/mux",
@@ -1427,6 +1419,7 @@
     "k8s.io/helm/pkg/releaseutil",
     "k8s.io/helm/pkg/repo",
     "k8s.io/helm/pkg/tlsutil",
+    "k8s.io/klog",
   ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -11,6 +11,7 @@ required = ["k8s.io/code-generator/cmd/client-gen"]
 [[constraint]]
   name = "github.com/docker/distribution"
   branch = "master"
+  source = "github.com/2opremio/distribution"
 
 # Pin to master branch until there is a more recent stable release:
 #   https://github.com/prometheus/client_golang/issues/375

--- a/registry/cache/repocachemanager_test.go
+++ b/registry/cache/repocachemanager_test.go
@@ -1,0 +1,59 @@
+package cache
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaveworks/flux/image"
+	"github.com/weaveworks/flux/registry"
+	"github.com/weaveworks/flux/registry/middleware"
+)
+
+func Test_ClientTimeouts(t *testing.T) {
+	timeout := 2 * time.Millisecond
+	server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		// make sure we exceed the timeout
+		time.Sleep(timeout * 10)
+	}))
+	defer server.Close()
+	url, err := url.Parse(server.URL)
+	assert.NoError(t, err)
+	logger := log.NewLogfmtLogger(os.Stdout)
+	cf := &registry.RemoteClientFactory{
+		Logger: log.NewLogfmtLogger(os.Stdout),
+		Limiters: &middleware.RateLimiters{
+			RPS:    100,
+			Burst:  100,
+			Logger: logger,
+		},
+		Trace:         false,
+		InsecureHosts: []string{url.Host},
+	}
+	name := image.Name{
+		Domain: url.Host,
+		Image:  "foo/bar",
+	}
+	rcm, err := newRepoCacheManager(
+		time.Now(),
+		name,
+		cf,
+		registry.NoCredentials(),
+		timeout,
+		100,
+		false,
+		logger,
+		nil,
+	)
+	assert.NoError(t, err)
+	_, err = rcm.getTags(context.Background())
+	assert.Error(t, err)
+	assert.Equal(t, "client timeout (2ms) exceeded", err.Error())
+}


### PR DESCRIPTION
(Hopefully) fixes #1940 and #1808 

Registry request could get stuck indefinitely due to a combination of:

1. The repository client we use:
    * Completely ignores the contexts being passed. For instance, [for the tag request](https://github.com/docker/distribution/blob/6d62eb1d4a3515399431b713fde3ce5a9b40e8d5/registry/client/repository.go#L187-L251), the context parameter isn't used.
    * [Sets an implicit timeout of zero in the client it uses](https://github.com/docker/distribution/blob/6d62eb1d4a3515399431b713fde3ce5a9b40e8d5/registry/client/repository.go#L140-L144)

   This has been addressed by https://github.com/docker/distribution/pull/2905 , prompting me to replace https://github.com/docker/distribution by https://github.com/2opremio/distribution until the PR is merged.

2. We didn't set  any context deadline [we just set the context `Background()`](https://github.com/weaveworks/flux/blob/fefb216c1d2c415aa3adf00265c0a6ad0fecf7f5/registry/cache/warming.go#L86-L89)