### PR TITLE
Retry ssh-keyscan before bailing out

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,8 @@ build/.%.done: docker/Dockerfile.%
 		-f build/docker/$*/Dockerfile.$* ./build/docker/$*
 	touch $@
 
-build/.flux.done: build/fluxd build/kubectl docker/ssh_config docker/kubeconfig docker/verify_known_hosts.sh
-build/.helm-operator.done: build/helm-operator build/kubectl build/helm docker/ssh_config docker/verify_known_hosts.sh docker/helm-repositories.yaml
+build/.flux.done: build/fluxd build/kubectl docker/ssh_config docker/kubeconfig docker/ssh_keyscan.sh docker/verify_known_hosts.sh
+build/.helm-operator.done: build/helm-operator build/kubectl build/helm docker/ssh_config docker/ssh_keyscan.sh docker/verify_known_hosts.sh docker/helm-repositories.yaml
 
 build/fluxd: $(FLUXD_DEPS)
 build/fluxd: cmd/fluxd/*.go

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -6,10 +6,9 @@ RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0' gnupg
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
-ADD ./verify_known_hosts.sh /home/flux/verify_known_hosts.sh
-RUN ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com >> /etc/ssh/ssh_known_hosts && \
-    sh /home/flux/verify_known_hosts.sh /etc/ssh/ssh_known_hosts && \
-    rm /home/flux/verify_known_hosts.sh
+COPY ./ssh_keyscan.sh ./verify_known_hosts.sh /home/flux/
+RUN sh /home/flux/ssh_keyscan.sh github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com && \
+    rm /home/flux/verify_known_hosts.sh /home/flux/ssh_keyscan.sh
 
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -6,10 +6,9 @@ RUN apk add --no-cache openssh ca-certificates tini 'git>=2.3.0'
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
-ADD ./verify_known_hosts.sh /home/flux/verify_known_hosts.sh
-RUN ssh-keyscan github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com >> /etc/ssh/ssh_known_hosts && \
-    sh /home/flux/verify_known_hosts.sh /etc/ssh/ssh_known_hosts && \
-    rm /home/flux/verify_known_hosts.sh
+COPY ./ssh_keyscan.sh ./verify_known_hosts.sh /home/flux/
+RUN sh /home/flux/ssh_keyscan.sh github.com gitlab.com bitbucket.org ssh.dev.azure.com vs-ssh.visualstudio.com && \
+    rm /home/flux/verify_known_hosts.sh /home/flux/ssh_keyscan.sh
 
 # Add default SSH config, which points at the private key we'll mount
 COPY ./ssh_config /etc/ssh/ssh_config

--- a/docker/ssh_keyscan.sh
+++ b/docker/ssh_keyscan.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -eu
+
+hosts=${@}
+n=0
+max=5
+delay=10
+
+while true
+do
+    ssh-keyscan ${hosts} > /etc/ssh/ssh_known_hosts \
+        && sh ./verify_known_hosts.sh /etc/ssh/ssh_known_hosts \
+        && break
+
+    if [ $n -lt $max ]; then
+        n=$((n+1))
+        echo "Failed to gather and validate all SSH fingerprints. Attempt $n/$max."
+        sleep $delay
+    else
+        echo "Failed to gather and validate all SSH fingerprints after $n attempts." >&2
+        exit 1
+    fi
+done


### PR DESCRIPTION
This will (hopefully) help reduce the amount of failing CI tests due
to `ssh-keyscan` being unable to retrieve all SSH fingerprints on its
first try.

Fixes #1969 