### PR TITLE
Inline shell function to avoid CI incompatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,19 +33,14 @@ BUILD_DATE:=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
 all: $(GOPATH)/bin/fluxctl $(GOPATH)/bin/fluxd $(GOPATH)/bin/helm-operator build/.flux.done build/.helm-operator.done
 
 release-bins:
-	function do_build() { \
-		os=$$1 \
-		arch=$$2 \
-		CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -o "build/fluxctl_"$$os"_$$arch" $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" ./cmd/fluxctl/; \
-	};\
 	for arch in amd64; do \
 		for os in linux darwin windows; do \
-			do_build "$$os" "$$arch"; \
+			CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -o "build/fluxctl_"$$os"_$$arch" $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" ./cmd/fluxctl/; \
 		done; \
-	done; \
+	done;
 	for arch in arm arm64; do \
 		for os in linux; do \
-			do_build "$$os" "$$arch"; \
+			CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -o "build/fluxctl_"$$os"_$$arch" $(LDFLAGS) -ldflags "-X main.version=$(shell ./docker/image-tag)" ./cmd/fluxctl/; \
 		done; \
 	done;
 


### PR DESCRIPTION
CircleCI doesn't like the shell function defined in the Makefile;
inline the contents into the two call sites, so we don't have to worry
about that.
