### PR TITLE
Make it possible to overwrite image TS with label

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -130,8 +130,8 @@ func (opts *imageListOpts) RunE(cmd *cobra.Command, args []string) error {
 				}
 				if printLine {
 					createdAt := ""
-					if !available.CreatedAt.IsZero() {
-						createdAt = available.CreatedAt.Format(time.RFC822)
+					if !available.CreatedTS().IsZero() {
+						createdAt = available.CreatedTS().Format(time.RFC822)
 					}
 					fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, tag, createdAt)
 				}

--- a/daemon/images.go
+++ b/daemon/images.go
@@ -103,13 +103,13 @@ func calculateChanges(logger log.Logger, candidateWorkloads resources, workloads
 					continue containers
 				}
 				current := repoMetadata.FindImageWithRef(currentImageID)
-				if current.CreatedAt.IsZero() || latest.CreatedAt.IsZero() {
-					logger.Log("warning", "image with zero created timestamp", "current", fmt.Sprintf("%s (%s)", current.ID, current.CreatedAt), "latest", fmt.Sprintf("%s (%s)", latest.ID, latest.CreatedAt), "action", "skip container")
+				if current.CreatedTS().IsZero() || latest.CreatedTS().IsZero() {
+					logger.Log("warning", "image with zero created timestamp", "current", fmt.Sprintf("%s (%s)", current.ID, current.CreatedTS()), "latest", fmt.Sprintf("%s (%s)", latest.ID, latest.CreatedTS()), "action", "skip container")
 					continue containers
 				}
 				newImage := currentImageID.WithNewTag(latest.ID.Tag)
 				changes.Add(workload.ID, container, newImage)
-				logger.Log("info", "added update to automation run", "new", newImage, "reason", fmt.Sprintf("latest %s (%s) > current %s (%s)", latest.ID.Tag, latest.CreatedAt, currentImageID.Tag, current.CreatedAt))
+				logger.Log("info", "added update to automation run", "new", newImage, "reason", fmt.Sprintf("latest %s (%s) > current %s (%s)", latest.ID.Tag, latest.CreatedTS(), currentImageID.Tag, current.CreatedTS()))
 			}
 		}
 	}

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -138,12 +138,47 @@ func TestRefSerialization(t *testing.T) {
 	}
 }
 
+func TestImageLabelsSerialisation(t *testing.T) {
+	t0 := time.Now().UTC() // UTC so it has nil location, otherwise it won't compare
+	t1 := time.Now().Add(5 * time.Minute).UTC()
+	labels := Labels{Created: t0, BuildDate: t1}
+	bytes, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var labels1 Labels
+	if err = json.Unmarshal(bytes, &labels1); err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, labels, labels1)
+}
+
+func TestImageLabelsZeroTime(t *testing.T) {
+	labels := Labels{}
+	bytes, err := json.Marshal(labels)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var labels1 map[string]interface{}
+	if err = json.Unmarshal(bytes, &labels1); err != nil {
+		t.Fatal(err)
+	}
+	if lc := len(labels1); lc >= 1 {
+		t.Errorf("serialised Labels contains %v fields; expected it to contain none\n%v", lc, labels1)
+	}
+}
+
 func mustMakeInfo(ref string, created time.Time) Info {
 	r, err := ParseRef(ref)
 	if err != nil {
 		panic(err)
 	}
 	return Info{ID: r, CreatedAt: created}
+}
+
+func (im Info) setLabels(labels Labels) Info {
+	im.Labels = labels
+	return im
 }
 
 func TestImageInfoSerialisation(t *testing.T) {
@@ -184,10 +219,10 @@ func TestImage_OrderByCreationDate(t *testing.T) {
 	time0 := testTime.Add(time.Second)
 	time2 := testTime.Add(-time.Second)
 	imA := mustMakeInfo("my/Image:2", testTime)
-	imB := mustMakeInfo("my/Image:0", time0)
-	imC := mustMakeInfo("my/Image:3", time2)
+	imB := mustMakeInfo("my/Image:0", time.Time{}).setLabels(Labels{Created: time0})
+	imC := mustMakeInfo("my/Image:3", time.Time{}).setLabels(Labels{BuildDate: time2})
 	imD := mustMakeInfo("my/Image:4", time.Time{}) // test nil
-	imE := mustMakeInfo("my/Image:1", testTime)    // test equal
+	imE := mustMakeInfo("my/Image:1", time.Time{}).setLabels(Labels{Created: testTime}) // test equal
 	imF := mustMakeInfo("my/Image:5", time.Time{}) // test nil equal
 	imgs := []Info{imA, imB, imC, imD, imE, imF}
 	Sort(imgs, NewerByCreated)
@@ -204,7 +239,7 @@ func checkSorted(t *testing.T, imgs []Info) {
 	for i, im := range imgs {
 		if strconv.Itoa(i) != im.ID.Tag {
 			for j, jim := range imgs {
-				t.Logf("%v: %v %s", j, jim.ID.String(), jim.CreatedAt)
+				t.Logf("%v: %v %s", j, jim.ID.String(), jim.CreatedTS())
 			}
 			t.Fatalf("Not sorted in expected order: %#v", imgs)
 		}

--- a/registry/client.go
+++ b/registry/client.go
@@ -133,6 +133,9 @@ interpret:
 			Created time.Time `json:"created"`
 			OS      string    `json:"os"`
 			Arch    string    `json:"architecture"`
+			Config  struct {
+				Labels image.Labels `json:"labels"`
+			} `json:"config"`
 		}
 
 		if err = json.Unmarshal([]byte(man.History[0].V1Compatibility), &v1); err != nil {
@@ -142,6 +145,7 @@ interpret:
 		// identify the image as it's the topmost layer.
 		info.ImageID = v1.ID
 		info.CreatedAt = v1.Created
+		info.Labels = v1.Config.Labels
 	case *schema2.DeserializedManifest:
 		var man schema2.Manifest = deserialised.Manifest
 		configBytes, err := repository.Blobs(ctx).Get(ctx, man.Config.Digest)
@@ -153,6 +157,9 @@ interpret:
 			Arch    string    `json:"architecture"`
 			Created time.Time `json:"created"`
 			OS      string    `json:"os"`
+			ContainerConfig struct {
+				Labels image.Labels `json:"labels"`
+			} `json:"container_config"`
 		}
 		if err = json.Unmarshal(configBytes, &config); err != nil {
 			return ImageEntry{}, err
@@ -160,6 +167,7 @@ interpret:
 		// This _is_ what Docker uses as its Image ID.
 		info.ImageID = man.Config.Digest.String()
 		info.CreatedAt = config.Created
+		info.Labels = config.ContainerConfig.Labels
 	case *manifestlist.DeserializedManifestList:
 		var list manifestlist.ManifestList = deserialised.ManifestList
 		// TODO(michael): is it valid to just pick the first one that matches?

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -15,7 +15,7 @@ menu_order: 40
     + [2. Specify a key to use](#2-specify-a-key-to-use)
 - [Workloads](#workloads)
   * [What is a Workload?](#what-is-a-workload)
-  *  [Viewing Workloads](#viewing-workloads)
+  * [Viewing Workloads](#viewing-workloads)
   * [Inspecting the Version of a Container](#inspecting-the-version-of-a-container)
   * [Releasing a Workload](#releasing-a-workload)
   * [Turning on Automation](#turning-on-automation)
@@ -27,9 +27,11 @@ menu_order: 40
   * [Recording user and message with the triggered action](#recording-user-and-message-with-the-triggered-action)
 - [Image Tag Filtering](#image-tag-filtering)
   * [Filter pattern types](#filter-pattern-types)
-  * [Glob](#glob)
-  * [Semver](#semver)
-  *  [Regexp](#regexp)
+    + [Glob](#glob)
+    + [Semver](#semver)
+    + [Regexp](#regexp)
+  * [Controlling image timestamps with labels](#controlling-image-timestamps-with-labels)
+    + [Supported label formats](#supported-label-formats)
 - [Actions triggered through `fluxctl`](#actions-triggered-through-fluxctl)
   * [Errors due to author customization](#errors-due-to-author-customization)
 - [Using Annotations](#using-annotations)
@@ -497,11 +499,11 @@ fluxctl release --workload=default:deployment/helloworld --update-all-images --f
 
 Please note that automation might immediately undo this.
 
-# Filter pattern types
+## Filter pattern types
 
 Flux currently offers support for `glob`, `semver` and `regexp` based filtering.
 
-## Glob
+### Glob
 
 The glob (`*`) filter is the simplest filter Flux supports, a filter can contain
 multiple globs:
@@ -510,7 +512,7 @@ multiple globs:
 fluxctl policy --workload=default:deployment/helloworld --tag-all='glob:master-v1.*.*'
 ```
 
-## Semver
+### Semver
 
 If your images use [semantic versioning](https://semver.org) you can filter by image tags
 that adhere to certain constraints:
@@ -528,7 +530,7 @@ fluxctl policy --workload=default:deployment/helloworld --tag-all='semver:*'
 Using a semver filter will also affect how Flux sorts images, so
 that the higher versions will be considered newer.
 
-## Regexp
+### Regexp
 
 If your images have complex tags you can filter by regular expression:
 
@@ -539,6 +541,23 @@ fluxctl policy --workload=default:deployment/helloworld --tag-all='regexp:^([a-z
 Instead of `regexp` it is also possible to use its alias `regex`.
 Please bear in mind that if you want to match the whole tag,
 you must bookend your pattern with `^` and `$`.
+
+## Controlling image timestamps with labels
+
+Some image registries do not expose a reliable creation timestamp for
+image tags, which could pose a problem for the automated roll-out of
+images.
+
+To overcome this problem you can define one of the supported labels in
+your `Dockerfile`. Flux will prioritize labels over the timestamp it
+retrieves from the registry.
+
+### Supported label formats
+
+- [`org.opencontainers.image.created`](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys)
+  date and time on which the image was built (string, date-time as defined by RFC 3339).
+- [`org.label-schema.build-date`](http://label-schema.org/rc1/#build-time-labels)
+  date and time on which the image was built (string, date-time as defined by RFC 3339).
 
 # Actions triggered through `fluxctl`
 


### PR DESCRIPTION
This adds support for overwriting the image created at timestamp with labels which are set during build. Supported labels (for now) are the [Open Container Image (OCI) spec](https://github.com/opencontainers/image-spec/blob/master/annotations.md#pre-defined-annotation-keys) and the [(legacy) Label Schema (LS) spec](http://label-schema.org/rc1/#build-time-labels).

We prioritize OCI over LS, with a fallback to the CreatedAt from the registry.

Fixes #891, addresses #1799, #1797, #746