### PR TITLE
Fix error shadowing when parsing manifests

### DIFF
--- a/cluster/kubernetes/resource/load.go
+++ b/cluster/kubernetes/resource/load.go
@@ -140,7 +140,7 @@ func ParseMultidoc(multidoc []byte, source string) (map[string]KubeManifest, err
 		// NOTE: gopkg.in/yaml.v3 supports round tripping comments
 		//       by using `gopkg.in/yaml.v3.Node`.
 		var val interface{}
-		if err := decoder.Decode(&val); err != nil {
+		if err = decoder.Decode(&val); err != nil {
 			break
 		}
 		bytes, err := yaml.Marshal(val)

--- a/cluster/kubernetes/resource/load_test.go
+++ b/cluster/kubernetes/resource/load_test.go
@@ -142,6 +142,18 @@ metadata:
 	assert.Len(t, resources, 1)
 }
 
+func TestParseError(t *testing.T) {
+	doc := `---
+kind: ConfigMap
+metadata:
+	name: bigmap # contains a tab at the beginning
+`
+	buffer := bytes.NewBufferString(doc)
+
+	_, err := ParseMultidoc(buffer.Bytes(), "test")
+	assert.Error(t, err)
+}
+
 func TestParseCronJob(t *testing.T) {
 	doc := `---
 apiVersion: batch/v1beta1


### PR DESCRIPTION
This caused parsing errors in YAML files to go unnoticed (the files where simply
not included in the result)
