### PR TITLE
Typo: 'workspace' -> 'workload'

### DIFF
--- a/cmd/fluxctl/automate_cmd.go
+++ b/cmd/fluxctl/automate_cmd.go
@@ -37,7 +37,7 @@ func (opts *workloadAutomateOpts) Command() *cobra.Command {
 
 	// Deprecated
 	cmd.Flags().StringVarP(&opts.controller, "controller", "c", "", "Controller to automate")
-	cmd.Flags().MarkDeprecated("controller", "changed to --workspace, use that instead")
+	cmd.Flags().MarkDeprecated("controller", "changed to --workload, use that instead")
 
 	return cmd
 }

--- a/cmd/fluxctl/deautomate_cmd.go
+++ b/cmd/fluxctl/deautomate_cmd.go
@@ -37,7 +37,7 @@ func (opts *workloadDeautomateOpts) Command() *cobra.Command {
 
 	// Deprecated
 	cmd.Flags().StringVarP(&opts.controller, "controller", "c", "", "Controller to deautomate")
-	cmd.Flags().MarkDeprecated("controller", "changed to --workspace, use that instead")
+	cmd.Flags().MarkDeprecated("controller", "changed to --workload, use that instead")
 
 	return cmd
 }

--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -42,7 +42,7 @@ func (opts *imageListOpts) Command() *cobra.Command {
 
 	// Deprecated
 	cmd.Flags().StringVarP(&opts.controller, "controller", "c", "", "Show images for this controller")
-	cmd.Flags().MarkDeprecated("controller", "changed to --workspace, use that instead")
+	cmd.Flags().MarkDeprecated("controller", "changed to --workload, use that instead")
 
 	return cmd
 }

--- a/cmd/fluxctl/lock_cmd.go
+++ b/cmd/fluxctl/lock_cmd.go
@@ -37,7 +37,7 @@ func (opts *workloadLockOpts) Command() *cobra.Command {
 
 	// Deprecated
 	cmd.Flags().StringVarP(&opts.workload, "controller", "c", "", "Controller to lock")
-	cmd.Flags().MarkDeprecated("controller", "changed to --workspace, use that instead")
+	cmd.Flags().MarkDeprecated("controller", "changed to --workload, use that instead")
 
 	return cmd
 }

--- a/cmd/fluxctl/policy_cmd.go
+++ b/cmd/fluxctl/policy_cmd.go
@@ -70,7 +70,7 @@ containers which aren't explicitly named.
 
 	// Deprecated
 	flags.StringVarP(&opts.controller, "controller", "c", "", "Controller to modify")
-	flags.MarkDeprecated("controller", "changed to --workspace, use that instead")
+	flags.MarkDeprecated("controller", "changed to --workload, use that instead")
 
 	return cmd
 }


### PR DESCRIPTION
Part of this was fixed in #1988 but this PR is blocked until the next major Flux release.