### PR TITLE
Improve fluxctl connection error

### DIFF
--- a/cmd/fluxctl/portforward.go
+++ b/cmd/fluxctl/portforward.go
@@ -13,7 +13,7 @@ import (
 // Attempt to create PortForwards to fluxes that match the label selectors until a Flux
 // is found or an error is returned.
 func tryPortforwards(ns string, selectors ...metav1.LabelSelector) (p *portforward.PortForward, err error) {
-	message := fmt.Sprintf("Flux pod not found for labels in namespace %s:", ns)
+	message := fmt.Sprintf("No pod found in namespace %q using the following selectors:", ns)
 
 	for _, selector := range selectors {
 		p, err = tryPortforward(ns, selector)
@@ -27,7 +27,8 @@ func tryPortforwards(ns string, selectors ...metav1.LabelSelector) (p *portforwa
 			message = fmt.Sprintf("%s\n  %s", message, metav1.FormatLabelSelector(&selector))
 		}
 	}
-
+	message = fmt.Sprintf("%s\n\nMake sure Flux is running in namespace %q.\n"+
+		"If Flux is running in another different namespace, please supply it to --k8s-fwd-ns.", message, ns)
 	if err != nil {
 		err = errors.New(message)
 	}


### PR DESCRIPTION
It now looks like:

```
$ fluxctl
Error: No pod found in namespace "default" using the following selectors:
  app=flux
  name in (flux,fluxd,weave-flux-agent)

Make sure Flux is running in namespace "default".
If Flux is running in another namespace, please supply it to --k8s-fwd-ns.
Run 'fluxctl identity --help' for usage.
```