### PR TITLE
Allow to enable garbage collection in Helm chart

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -276,6 +276,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `helmOperator.affinity`                           | `{}`                                                 | Affinity properties for the helmOperator deployment
 | `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
+| `syncGarbageCollection.enabled`                   | `false`                                              | If enabled, fluxd will delete resources that it created, but are no longer present in git (experimental, see [garbage collection](/site/garbagecollection.md))
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -191,6 +191,9 @@ spec:
           - --connect=wss://cloud.weave.works/api/flux
           - --token={{ .Values.token }}
           {{- end }}
+          {{- if .Values.syncGarbageCollection.enabled }}
+          - --sync-garbage-collection={{ .Values.syncGarbageCollection.enabled }}
+          {{- end }}
           {{- if .Values.additionalArgs }}
 {{ toYaml .Values.additionalArgs | indent 10 }}
           {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -229,6 +229,9 @@ extraEnvs: []
 prometheus:
   enabled: false
 
+syncGarbageCollection:
+  enabled: false
+
 # Add your own init container or uncomment and modify the given example.
 initContainers: {}
 #   flux-init:  # <- will be used as container name


### PR DESCRIPTION
Following up https://github.com/weaveworks/flux/pull/1442 .
This small change allows to enable garbage collection when installing Flux via Helm chart.
