### PR TITLE
Ignore discovery errors for metrics resources

### DIFF
--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -206,6 +206,11 @@ func (c *Cluster) getAllowedResourcesBySelector(selector string) (map[string]*ku
 			return nil, err
 		}
 		for gv, e := range discErr.Groups {
+			if strings.HasSuffix(gv.Group, "metrics.k8s.io") {
+				// The Metrics API tends to be misconfigured, causing errors.
+				// We just ignore them, since it doesn't make sense to sync metrics anyways.
+				continue
+			}
 			// Tolerate empty GroupVersions due to e.g. misconfigured custom metrics
 			if e.Error() != fmt.Sprintf("Got empty response for: %v", gv) {
 				return nil, err


### PR DESCRIPTION
The Metrics API tends to be misconfigured, causing discovery errors which ultimately makes syncs fail.

This change makes Flux ignore those errors.

Fixes #1991 