### PR TITLE
Mount sub path of repositories secret

### DIFF
--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -111,7 +111,9 @@ spec:
         {{- end }}
         {{- if .Values.helmOperator.configureRepositories.enable }}
         - name: {{ .Values.helmOperator.configureRepositories.volumeName | quote }}
-          mountPath: /var/fluxd/helm/repository
+          mountPath: /var/fluxd/helm/repository/repositories.yaml
+          subPath: repositories.yaml
+          readOnly: true
         - name: {{ .Values.helmOperator.configureRepositories.cacheVolumeName | quote }}
           mountPath: /var/fluxd/helm/repository/cache
         {{- end }}


### PR DESCRIPTION
To prevent the emptyDir for the repositories cache from overwriting the
repositories.yaml since it's mounted on the same path.
Courtesy of https://blog.sebastian-daschner.com/entries/multiple-kubernetes-volumes-directory

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
