### PR TITLE
Fix (Flux)HelmRelease cluster lookups

### DIFF
--- a/cluster/kubernetes/resourcekinds.go
+++ b/cluster/kubernetes/resourcekinds.go
@@ -397,8 +397,8 @@ func (fhr *fluxHelmReleaseKind) getWorkloads(c *Cluster, namespace string) ([]wo
 	}
 
 	var workloads []workload
-	for _, f := range fluxHelmReleases.Items {
-		workloads = append(workloads, makeFluxHelmReleaseWorkload(&f))
+	for i, _ := range fluxHelmReleases.Items {
+		workloads = append(workloads, makeFluxHelmReleaseWorkload(&fluxHelmReleases.Items[i]))
 	}
 
 	return workloads, nil
@@ -459,8 +459,8 @@ func (hr *helmReleaseKind) getWorkloads(c *Cluster, namespace string) ([]workloa
 	}
 
 	var workloads []workload
-	for _, f := range helmReleases.Items {
-		workloads = append(workloads, makeHelmReleaseWorkload(&f))
+	for i, _ := range helmReleases.Items {
+		workloads = append(workloads, makeHelmReleaseWorkload(&helmReleases.Items[i]))
 	}
 
 	return workloads, nil


### PR DESCRIPTION
Fixes #2011 (Introduced in https://github.com/weaveworks/flux/pull/1111)

The value obtained by `_, value := range slice` is overwritten on every iteration. Thus, saving a pointer to `value` is dangerous since its content will be overwritten in the next iteration.

From https://golang.org/ref/spec#For_range :

> For each entry it assigns iteration values to corresponding
> iteration variables if present and then executes the block.

But the iteration variables are the same on each iteration.

More explicitly, from [the gccgo source code](https://github.com/golang/gofrontend/blob/e387439bfd24d5e142874b8e68e7039f74c744d7/go/statements.cc#L5593-L5604):

```
  // The loop we generate:
  //   len_temp := len(range)
  //   range_temp := range
  //   for index_temp = 0; index_temp < len_temp; index_temp++ {
  //           value_temp = range_temp[index_temp]
  //           index = index_temp
  //           value = value_temp
  //           original body
  //   }
```
