### PR TITLE
Show tag image for workload in list-images

### DIFF
--- a/cmd/fluxctl/list_images_cmd.go
+++ b/cmd/fluxctl/list_images_cmd.go
@@ -136,6 +136,14 @@ func (opts *imageListOpts) RunE(cmd *cobra.Command, args []string) error {
 					fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, tag, createdAt)
 				}
 			}
+			if !foundRunning {
+				running := "'->"
+				if currentTag == "" {
+					currentTag = "(untagged)"
+				}
+				fmt.Fprintf(out, "\t\t%s %s\t%s\n", running, currentTag, "?")
+
+			}
 			workloadName = ""
 		}
 	}


### PR DESCRIPTION
Fixes #847

Before this change the comparison to list an image as being used by the workload was purely based upon the tag name. We now also check if the digest of the image matches the one in our image cache.

In addition, if we are unable to match the image of the workload to a tag and digest in our image cache, we still list the name of the tag (as we have no other data available), but with a question mark added as a prefix (`?->`).