### PR TITLE
Log warning re not applying resource by namespace

### DIFF
--- a/cluster/kubernetes/sync.go
+++ b/cluster/kubernetes/sync.go
@@ -64,10 +64,11 @@ func (c *Cluster) Sync(syncSet cluster.SyncSet) error {
 	var errs cluster.SyncError
 	for _, res := range syncSet.Resources {
 		resID := res.ResourceID()
+		id := resID.String()
 		if !c.IsAllowedResource(resID) {
+			logger.Log("warning", "not applying resource; excluded by namespace constraints", "resource", id, "source", res.Source())
 			continue
 		}
-		id := resID.String()
 		// make a record of the checksum, whether we stage it to
 		// be applied or not, so that we don't delete it later.
 		csum := sha1.Sum(res.Bytes())


### PR DESCRIPTION
We log when a resource in a manifest is dropped from sync because it's
marked as ignored; would also help troubleshooting if we log when a
resource is dropped because it's not in the allowed namespaces.

Fixes #2012.