### PR TITLE
Always list the status of a workload in `fluxctl`

### DIFF
--- a/cmd/fluxctl/list_workloads_cmd.go
+++ b/cmd/fluxctl/list_workloads_cmd.go
@@ -63,7 +63,7 @@ func (opts *workloadListOpts) RunE(cmd *cobra.Command, args []string) error {
 				fmt.Fprintf(w, "\t%s\t%s\t\t\n", c.Name, c.Current.ID)
 			}
 		} else {
-			fmt.Fprintf(w, "%s\t\t\t\t\n", workload.ID)
+			fmt.Fprintf(w, "%s\t\t\t%s\t%s\n", workload.ID, workload.Status, policies(workload))
 		}
 	}
 	w.Flush()


### PR DESCRIPTION
Before this change the `fluxctl list-workloads` command would only list the status of a workload if it had containers. But because of how we integrated HelmReleases into the Flux daemon, a HelmRelease only has 'containers' if we are able to detect images in the .spec.values of the resource.

After this change it will always list the status of the workload (and any policies), regardless of the amount of containers it (does not) have.