### PR TITLE
`sed` command is missing input file argument in `helm-integration.md`

### DIFF
--- a/site/helm-integration.md
+++ b/site/helm-integration.md
@@ -381,7 +381,7 @@ the filename.
 
 ```
 cp ~/.helm/repository/repositories.yaml .
-sed -i -e 's/^\( *cache: \).*\/\(.*\.yaml\)/\1\2/g'
+sed -i -e 's/^\( *cache: \).*\/\(.*\.yaml\)/\1\2/g' repositories.yaml 
 ```
 
 Now you can create a secret in the same namespace as you're running


### PR DESCRIPTION
If applied, this commit will update `helm-integration.md` with `repositories.yaml` as argument to `sed`command.