### PR TITLE
drop [] in list of labels (issue templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve Weave Flux
 title: ''
-labels: [blocked-needs-validation, bug]
+labels: blocked-needs-validation, bug
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Suggest a new feature for Weave Flux
 title: ''
-labels: [blocked-needs-validation, enhancement]
+labels: blocked-needs-validation, enhancement
 assignees: ''
 
 ---


### PR DESCRIPTION
Trying to use the issue template editor from Github, I got a 500 error, so I took a look at k/community and it appears that square brackets are not needed when listing more than one label

https://raw.githubusercontent.com/kubernetes/community/master/.github/ISSUE_TEMPLATE/slack-request.md