### PR TITLE
Ensure gnutls >=3.6.7

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -2,7 +2,7 @@ FROM alpine:3.9
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0' gnupg
+RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh


### PR DESCRIPTION
Should resolve the trigger of several CVE warnings (which did not pose
a threat): CVE-2019-3829, CVE-2019-3836, CVE-2018-1000654

Addresses #1964 