### PR TITLE
Construct release name when not provided

### DIFF
--- a/integrations/helm/release/release.go
+++ b/integrations/helm/release/release.go
@@ -164,7 +164,7 @@ func (r *Release) Install(chartPath, releaseName string, fhr flux_v1beta1.HelmRe
 		return nil, fmt.Errorf("error statting path given for chart %s: %s", chartPath, err.Error())
 	}
 
-	r.logger.Log("info", fmt.Sprintf("processing release %s (as %s)", fhr.Spec.ReleaseName, releaseName),
+	r.logger.Log("info", fmt.Sprintf("processing release %s (as %s)", GetReleaseName(fhr), releaseName),
 		"action", fmt.Sprintf("%v", action),
 		"options", fmt.Sprintf("%+v", opts),
 		"timeout", fmt.Sprintf("%vs", fhr.GetTimeout()))


### PR DESCRIPTION
This message is not useful because the release name is missing:

```
default/flux-helm-operator-584b855858-tkh96[flux-helm-operator]: ts=2019-05-13T23:43:32.512987397Z caller=release.go:149 component=release info="processing release  (as 9df18980-7298-11e9-80f9-02ec2cc6f79e)" action=CREATE options="{DryRun:true ReuseName:false}" timeout=300s
```

This fix addresses that.