### PR TITLE
Switch to minideb as base image

### DIFF
--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -1,8 +1,13 @@
-FROM alpine:3.9
+FROM bitnami/minideb:stretch
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0'
+RUN install_packages \
+  openssh-client \
+  ca-certificates \
+  git
+
+COPY --from=bitnami/minideb-extras:stretch /usr/local/bin/tini /usr/local/bin/
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
@@ -31,7 +36,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
       org.label-schema.vcs-url="git@github.com:weaveworks/flux" \
       org.label-schema.vendor="Weaveworks"
 
-ENTRYPOINT [ "/sbin/tini", "--", "helm-operator" ]
+ENTRYPOINT [ "/usr/local/bin/tini", "--", "helm-operator" ]
 
 ENV HELM_HOME=/var/fluxd/helm
 COPY ./helm-repositories.yaml /var/fluxd/helm/repository/repositories.yaml

--- a/docker/known_hosts.sh
+++ b/docker/known_hosts.sh
@@ -56,7 +56,7 @@ wait=2
 until ${ok}; do
     generate && validate && ok=true || ok=false
     count=$(($count + 1))
-    if [[ ${count} -eq ${retries} ]]; then
+    if [ ${count} -eq ${retries} ]; then
         echo "ssh-keyscan failed, no more retries left"
         exit 1
     fi


### PR DESCRIPTION
In versions of Alpine 3.4 and later, a name resolution issue was
introduced and causes problems with certain Kubernetes setups. The
issue appears to be incosistent and difficult to reproduce (but has been
detected on CentOS and NixOS setups). Moving away from Alpine seems the
best option for now.

Fixes #2051, addresses #1980, #1148