### PR TITLE
Switch to Debian slim as base image

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -1,8 +1,18 @@
-FROM alpine:3.9
+FROM debian:stable-slim
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list.d/stretch-backports.list && \
+  echo "deb http://deb.debian.org/debian testing main" | tee -a /etc/apt/sources.list.d/testing.list && \
+  apt-get update && \
+  apt-get install -t stable -y --no-install-recommends \
+    openssh-client \
+    ca-certificates \
+    dirmngr \
+    gnupg && \
+  apt-get install -t stretch-backports -y --no-install-recommends git && \
+  apt-get install -t testing -y --no-install-recommends tini && \
+  rm -rf /var/lib/apt/lists/*
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
@@ -29,21 +39,12 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
       org.label-schema.vcs-url="git@github.com:weaveworks/flux" \
       org.label-schema.vendor="Weaveworks"
 
-ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
+ENTRYPOINT [ "tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
 COPY --from=quay.io/squaremo/kubeyaml:0.5.2 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
-# Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.
-# This resolves the conflict between:
-# * fluxd using netgo for static compilation. netgo reads nsswitch.conf to mimic glibc,
-#   defaulting to prioritize DNS queries over /etc/hosts if nsswitch.conf is missing:
-#   https://github.com/golang/go/issues/22846
-# * Alpine not including a nsswitch.conf file. Since Alpine doesn't use glibc
-#   (it uses musl), maintainers argue that the need of nsswitch.conf is a Go bug:
-#   https://github.com/gliderlabs/docker-alpine/issues/367#issuecomment-354316460
-RUN [ ! -e /etc/nsswitch.conf ] && echo 'hosts: files dns' > /etc/nsswitch.conf
 COPY ./kubeconfig /root/.kube/config
 COPY ./fluxd /usr/local/bin/
 

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -1,8 +1,16 @@
-FROM alpine:3.9
+FROM debian:stable-slim
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0'
+RUN echo "deb http://deb.debian.org/debian stretch-backports main" | tee -a /etc/apt/sources.list.d/stretch-backports.list && \
+  echo "deb http://deb.debian.org/debian testing main" | tee -a /etc/apt/sources.list.d/testing.list && \
+  apt-get update && \
+  apt-get install -t stable -y --no-install-recommends \
+    openssh-client \
+    ca-certificates && \
+  apt-get install -t stretch-backports -y --no-install-recommends git && \
+  apt-get install -t testing -y --no-install-recommends tini && \
+  rm -rf /var/lib/apt/lists/*
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh
@@ -31,7 +39,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
       org.label-schema.vcs-url="git@github.com:weaveworks/flux" \
       org.label-schema.vendor="Weaveworks"
 
-ENTRYPOINT [ "/sbin/tini", "--", "helm-operator" ]
+ENTRYPOINT [ "tini", "--", "helm-operator" ]
 
 ENV HELM_HOME=/var/fluxd/helm
 COPY ./helm-repositories.yaml /var/fluxd/helm/repository/repositories.yaml

--- a/docker/known_hosts.sh
+++ b/docker/known_hosts.sh
@@ -60,7 +60,7 @@ wait=2
 until ${ok}; do
     generate && validate && ok=true || ok=false
     count=$(($count + 1))
-    if [[ ${count} -eq ${retries} ]]; then
+    if [ ${count} -eq ${retries} ]; then
         echo "ssh-keyscan failed, no more retries left"
         exit 1
     fi


### PR DESCRIPTION
Alternative to #2055

In versions of Alpine 3.4 and later, a name resolution issue was
introduced and causes problems with certain Kubernetes setups. The
issue appears to be incosistent and difficult to reproduce (but has been
detected on CentOS and NixOS setups). Moving away from Alpine seems the
best option for now.

Fixes #2051, addresses #1980, #1148
