### PR TITLE
Garbage collection dry run

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -277,6 +277,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `kube.config`                                     | [See values.yaml](/chart/flux/values.yaml#L151-L165) | Override for kubectl default config in the Flux pod(s).
 | `prometheus.enabled`                              | `false`                                              | If enabled, adds prometheus annotations to Flux and helmOperator pod(s)
 | `syncGarbageCollection.enabled`                   | `false`                                              | If enabled, fluxd will delete resources that it created, but are no longer present in git (experimental, see [garbage collection](/site/garbagecollection.md))
+| `syncGarbageCollection.dry`                       | `false`                                              | If enabled, fluxd won't delete any resources, but log the garbage collection output (experimental, see [garbage collection](/site/garbagecollection.md))
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example:
 

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -191,8 +191,10 @@ spec:
           - --connect=wss://cloud.weave.works/api/flux
           - --token={{ .Values.token }}
           {{- end }}
-          {{- if .Values.syncGarbageCollection.enabled }}
+          {{- if and .Values.syncGarbageCollection.enabled (not .Values.syncGarbageCollection.dry) }}
           - --sync-garbage-collection={{ .Values.syncGarbageCollection.enabled }}
+          {{- else if .Values.syncGarbageCollection.dry }}
+          - --sync-garbage-collection-dry={{ .Values.syncGarbageCollection.dry }}
           {{- end }}
           {{- if .Values.additionalArgs }}
 {{ toYaml .Values.additionalArgs | indent 10 }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -231,6 +231,7 @@ prometheus:
 
 syncGarbageCollection:
   enabled: false
+  dry: false
 
 # Add your own init container or uncomment and modify the given example.
 initContainers: {}

--- a/cluster/kubernetes/kubernetes.go
+++ b/cluster/kubernetes/kubernetes.go
@@ -85,6 +85,8 @@ func isAddon(obj k8sObject) bool {
 type Cluster struct {
 	// Do garbage collection when syncing resources
 	GC bool
+	// dry run garbage collection without syncing
+	DryGC bool
 
 	client  ExtendedClient
 	applier Applier

--- a/cluster/kubernetes/sync_test.go
+++ b/cluster/kubernetes/sync_test.go
@@ -436,6 +436,23 @@ metadata:
 		test(t, kube, "", "", false)
 	})
 
+	t.Run("sync adds and GCs dry run", func(t *testing.T) {
+		kube, _, cancel := setup(t)
+		defer cancel()
+
+		// without GC on, resources persist if they are not mentioned in subsequent syncs.
+		test(t, kube, "", "", false)
+		test(t, kube, ns1+defs1, ns1+defs1, false)
+		test(t, kube, ns1+defs1+defs2, ns1+defs1+defs2, false)
+		test(t, kube, ns3+defs3, ns1+defs1+defs2+ns3+defs3, false)
+
+		// with GC dry run the collect garbage routine is running but only logging results with out collecting any resources
+		kube.DryGC = true
+		test(t, kube, ns1+defs2+ns3+defs3, ns1+defs1+defs2+ns3+defs3, false)
+		test(t, kube, ns1+defs1+defs2, ns1+defs1+defs2+ns3+defs3, false)
+		test(t, kube, "", ns1+defs1+defs2+ns3+defs3, false)
+	})
+
 	t.Run("sync won't incorrectly delete non-namespaced resources", func(t *testing.T) {
 		kube, _, cancel := setup(t)
 		defer cancel()

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -127,6 +127,7 @@ func main() {
 		// syncing
 		syncInterval = fs.Duration("sync-interval", 5*time.Minute, "apply config in git to cluster at least this often, even if there are no new commits")
 		syncGC       = fs.Bool("sync-garbage-collection", false, "experimental; delete resources that were created by fluxd, but are no longer in the git repo")
+		dryGC        = fs.Bool("sync-garbage-collection-dry", false, "experimental; only log what would be garbage collected, rather than deleting. Implies --sync-garbage-collection")
 
 		// registry
 		memcachedHostname = fs.String("memcached-hostname", "memcached", "hostname for memcached service.")
@@ -370,6 +371,7 @@ func main() {
 		allowedNamespaces := append(*k8sNamespaceWhitelist, *k8sAllowNamespace...)
 		k8sInst := kubernetes.NewCluster(client, kubectlApplier, sshKeyRing, logger, allowedNamespaces, *registryExcludeImage)
 		k8sInst.GC = *syncGC
+		k8sInst.DryGC = *dryGC
 
 		if err := k8sInst.Ping(); err != nil {
 			logger.Log("ping", err)
@@ -485,15 +487,15 @@ func main() {
 
 	gitRemote := git.Remote{URL: *gitURL}
 	gitConfig := git.Config{
-		Paths:            *gitPath,
-		Branch:           *gitBranch,
-		SyncTag:          *gitSyncTag,
-		NotesRef:         *gitNotesRef,
-		UserName:         *gitUser,
-		UserEmail:        *gitEmail,
-		SigningKey:       *gitSigningKey,
-		SetAuthor:        *gitSetAuthor,
-		SkipMessage:      *gitSkipMessage,
+		Paths:       *gitPath,
+		Branch:      *gitBranch,
+		SyncTag:     *gitSyncTag,
+		NotesRef:    *gitNotesRef,
+		UserName:    *gitUser,
+		UserEmail:   *gitEmail,
+		SigningKey:  *gitSigningKey,
+		SetAuthor:   *gitSetAuthor,
+		SkipMessage: *gitSkipMessage,
 	}
 
 	repo := git.NewRepo(gitRemote, git.PollInterval(*gitPollInterval), git.Timeout(*gitTimeout), git.Branch(*gitBranch))


### PR DESCRIPTION
I added a new `syncGarbageCollection.dry` option for helm chart and deployment. With this option activated it is irrelevant how `syncGarbageCollection.enabled` is set, the garbage collection will run in a trace mode. Only logs appear in the console but no resources are touched. 
I created a Test for this behaviour in the style of the existing tests.

Fixes #1990 