### PR TITLE
Enqueue release on clone change only

### DIFF
--- a/integrations/helm/chartsync/chartsync.go
+++ b/integrations/helm/chartsync/chartsync.go
@@ -243,15 +243,15 @@ func (chs *ChartChangeSync) Run(stopCh <-chan struct{}, errc chan error, wg *syn
 							if cloneForChart.export != nil {
 								cloneForChart.export.Clean()
 							}
-						}
 
-						// Enqueue release
-						cacheKey, err := cache.MetaNamespaceKeyFunc(fhr.GetObjectMeta())
-						if err != nil {
-							continue
+							// we have a (new) clone, enqueue a release
+							cacheKey, err := cache.MetaNamespaceKeyFunc(fhr.GetObjectMeta())
+							if err != nil {
+								continue
+							}
+							chs.logger.Log("info", "enqueing release upgrade due to change in git chart source", "resource", fhr.ResourceID().String())
+							chs.releaseQueue.AddRateLimited(cacheKey)
 						}
-						chs.logger.Log("info", "enqueing release upgrade due to change in git chart source", "resource", fhr.ResourceID().String())
-						chs.releaseQueue.AddRateLimited(cacheKey)
 					}
 				}
 			case <-stopCh:


### PR DESCRIPTION
During the refactor of synchronization mechanics in #1906, this got
accidentally moved outside the condition that checks if we have a clone
or it needs updating, with the result that a release is always enqueued
on a signal from the mirror it is bound to.

Move it back inside the condition so we only enqueue releases we
actually have updates from git for.