### PR TITLE
Do not fail on non RFC3339 labels but log warning

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -153,6 +153,23 @@ func TestImageLabelsSerialisation(t *testing.T) {
 	assert.Equal(t, labels, labels1)
 }
 
+func TestNonRFC3339ImageLabelsUnmarshal(t *testing.T) {
+	str := `{
+	"org.label-schema.build-date": "20190523",
+	"org.opencontainers.image.created": "20190523"
+}`
+
+	var labels Labels
+	err := json.Unmarshal([]byte(str), &labels)
+	lpe, ok := err.(*LabelTimestampFormatError)
+	if !ok {
+		t.Fatalf("Got %v, but expected LabelTimestampFormatError", err)
+	}
+	if lc := len(lpe.Labels); lc != 2 {
+		t.Errorf("Got error for %v labels, expected 2", lc)
+	}
+}
+
 func TestImageLabelsZeroTime(t *testing.T) {
 	labels := Labels{}
 	bytes, err := json.Marshal(labels)

--- a/registry/cache/repocachemanager.go
+++ b/registry/cache/repocachemanager.go
@@ -254,7 +254,10 @@ func (c *repoCacheManager) updateImage(ctx context.Context, update imageToUpdate
 		if ctx.Err() == context.DeadlineExceeded {
 			return registry.ImageEntry{}, c.clientTimeoutError()
 		}
-		return registry.ImageEntry{}, err
+		if _, ok := err.(*image.LabelTimestampFormatError); !ok {
+			return registry.ImageEntry{}, err
+		}
+		c.logger.Log("err", err, "ref", imageID)
 	}
 
 	refresh := update.previousRefresh


### PR DESCRIPTION
Some image vendors have not read the spec properly and pass along
a timestamp in a different format than RFC3339. Before this change
the unmarshal of the JSON would fail for those labels and the affected
images would be excluded from our cache.

We now include those images in our cache and collect all labels that
failed parsing in a custom error, which we detect and log (instead
of bailing out).

Addresses #2075, but in a stricter way.