### PR TITLE
Fix flakey test due to mismatching error

### DIFF
--- a/registry/cache/repocachemanager_test.go
+++ b/registry/cache/repocachemanager_test.go
@@ -30,8 +30,8 @@ func Test_ClientTimeouts(t *testing.T) {
 	cf := &registry.RemoteClientFactory{
 		Logger: log.NewLogfmtLogger(os.Stdout),
 		Limiters: &middleware.RateLimiters{
-			RPS:    100,
-			Burst:  100,
+			RPS:    1000,
+			Burst:  1,
 			Logger: logger,
 		},
 		Trace:         false,


### PR DESCRIPTION
The expected error is `client timeout (2ms) exceeded`, but sometimes, due to rate limiting, it's `Wait(n=1) would exceed context deadline`

