### PR TITLE
update Helm docs with latest behaviour

### DIFF
--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -160,9 +160,7 @@ change the `tag:` line to the following:
 
 ```yaml
   values:
-    image:
-      repository: bitnami/mongodb
-      tag: 4.0.6
+    image: bitnami/mongodb:4.0.6
 ```
 
 Commit the change to your `master` branch. It will now get


### PR DESCRIPTION
Update readme to address regression bug that doesn't automatically
trigger HelmRelease deployment if
-> the full Docker Registry URL + image name + image label are not provided
  in a Helm Chart as a single variable (not splitted)
-> which in turn is read by the HelmRelease

Resolves:
Related: #2067
Signed-off-by: Daniel Andrei Minca

<!--
# General contribution criteria

Please have a look at our contribution guidelines: https://github.com/weaveworks/flux/blob/master/CONTRIBUTING.md
Particularly the sections about the:

 - DCO;
 - contribution workflow; and
 - how to get your fix accepted

To help the maintainers out when they're writing release notes, please
try to include a sentence or two here describing your change for end
users. See the CHANGELOG.md and CHANGELOG-helmop.md files in the
top-level directory for examples.

Particularly for ground-breaking changes and new features, it's important to
make users and developers aware of what's changing and where those changes
were documented or discussed.

Even for smaller changes it's useful to see things documented as well, as it
gives everybody a chance to see at a glance what's coming up in the next
release. It makes the life of the project maintainer a lot easier as well.
-->
