### PR TITLE
Explicitly configure memcached user

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -242,6 +242,7 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `memcached.pullSecret`                            | `None`                                               | Image pull secret
 | `memcached.repository`                            | `memcached`                                          | Image repository
 | `memcached.resources`                             | `None`                                               | CPU/memory resource requests/limits for memcached
+| `memcached.securityContext`                       | [See values.yaml](/chart/flux/values.yaml#L192-L195) | Container security context for memcached
 | `helmOperator.create`                             | `false`                                              | If `true`, install the Helm operator
 | `helmOperator.createCRD`                          | `true`                                               | Create the `v1beta1` and `v1alpha2` Flux CRDs. Dependent on `helmOperator.create=true`
 | `helmOperator.repository`                         | `docker.io/weaveworks/helm-operator`                 | Helm operator image repository

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -41,6 +41,8 @@ spec:
           containerPort: 11211
         resources:
 {{ toYaml .Values.memcached.resources | indent 10 }}
+        securityContext:
+{{ toYaml .Values.memcached.securityContext | indent 10 }}
     {{- with .Values.memcached.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -183,12 +183,16 @@ registry:
 
 memcached:
   repository: memcached
-  tag: 1.4.25
+  tag: 1.5.15
   pullSecret:
   createClusterIP: true
   verbose: false
   maxItemSize: 5m
   maxMemory: 512
+  securityContext:
+    runAsUser: 11211
+    runAsGroup: 11211
+    allowPrivilegeEscalation: false
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
This is a "fix" for https://github.com/weaveworks/flux/issues/2106 by getting more explicit with the memcached container securityContext and also while there adding some sensible defaults and dissalowing privilege escalation.

As I found some discrepancies with the uid/gid between versions of memcached, it appears as though there was some work in the later versions to settle on the well known value of `11211` (https://github.com/docker-library/memcached/pull/41) so I upgraded to the latest version which so far appears to be working fine.

While this fix is probably not required it ties in with my work of running as non-root and getting explicit about the users running containers and removing capabilities that are not required.