### PR TITLE
Pod DNS settings

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -194,6 +194,10 @@ The following tables lists the configurable parameters of the Weave Flux chart a
 | `nodeSelector`                                    | `{}`                                                 | Node Selector properties for the Flux deployment
 | `tolerations`                                     | `[]`                                                 | Tolerations properties for the Flux deployment
 | `affinity`                                        | `{}`                                                 | Affinity properties for the Flux deployment
+| `extraVolumeMounts`                               | `[]`                                                 | Extra volumes mounts
+| `extraVolumes`                                    | `[]`                                                 | Extra volumes
+| `dnsPolicy`                                       | ``                                                   | Pod DNS policy
+| `dnsConfig`                                       | ``                                                   | Pod DNS config
 | `token`                                           | `None`                                               | Weave Cloud service token
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -218,6 +218,13 @@ spec:
 {{ toYaml .Values.additionalArgs | indent 10 }}
           {{- end }}
           resources:
+{{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+{{- end }}
+{{- if .Values.dnsConfig }}
+      dnsConfig:
+{{ toYaml .Values.dnsConfig | indent 8 }}
+{{- end }}
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -104,6 +104,14 @@ extraVolumeMounts: []
 
 extraVolumes: []
 
+# Optional DNS settings, configuring the ndots option may resolve
+# nslookup issues on some Kubernetes setups.
+# dnsPolicy: "None"
+# dnsConfig:
+#   options:
+#     - name: ndots
+#       value: "1"
+
 gpgKeys:
   # These keys will be imported into GPG in the Flux container.
   secretName: ""

--- a/deploy/flux-deployment.yaml
+++ b/deploy/flux-deployment.yaml
@@ -139,3 +139,11 @@ spec:
         # Serve /metrics endpoint at different port;
         # make sure to set prometheus' annotation to scrape the port value.
         - --listen-metrics=:3031
+
+      # Optional DNS settings, configuring the ndots option may resolve
+      # nslookup issues on some Kubernetes setups.
+      # dnsPolicy: "None"
+      # dnsConfig:
+      #   options:
+      #     - name: ndots
+      #       value: "1"


### PR DESCRIPTION
Per https://github.com/weaveworks/flux/issues/2051#issuecomment-494040058, this gives people control over the pod DNS settings, to make it easier to tweak the `ndots` option on clusters with `nslookup` issues.