### PR TITLE
Do not trim space on list split

### DIFF
--- a/git/operations.go
+++ b/git/operations.go
@@ -245,10 +245,10 @@ func splitLog(s string) ([]Commit, error) {
 }
 
 func splitList(s string) []string {
-	outStr := strings.TrimSpace(s)
-	if outStr == "" {
+	if strings.TrimSpace(s) == "" {
 		return []string{}
 	}
+	outStr := strings.TrimSuffix(s, "\n")
 	return strings.Split(outStr, "\n")
 }
 

--- a/git/operations_test.go
+++ b/git/operations_test.go
@@ -146,6 +146,35 @@ func TestChangedFiles_NoPath(t *testing.T) {
 	}
 }
 
+func TestChangedFiles_LeadingSpace(t *testing.T) {
+	newDir, cleanup := testfiles.TempDir(t)
+	defer cleanup()
+
+	err := createRepo(newDir, []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	filename := " space.yaml"
+
+	if err = updateDirAndCommit(newDir, "", map[string]string{filename: "foo"}); err != nil {
+		t.Fatal(err)
+	}
+
+	files, err := changed(context.Background(), newDir, "HEAD~1", []string{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(files) != 1 {
+		t.Fatal("expected 1 changed file")
+	}
+
+	if actualFilename := files[0]; actualFilename != filename {
+		t.Fatalf("expected changed filename to equal: '%s', got '%s'", filename, actualFilename)
+	}
+}
+
 func TestOnelinelog_NoGitpath(t *testing.T) {
 	newDir, cleanup := testfiles.TempDir(t)
 	defer cleanup()


### PR DESCRIPTION
As this leads to `lstat` errors when it is used to parse the git diff
output with filenames that have leading or trailing spaces.

Fixes #1481 