### PR TITLE
Ignore xdelta3 files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ _testmain.go
 
 ### Package builds (e.g. snap of fluxctl)
 fluxctl_*_*.snap
+fluxctl_*_*.snap.xdelta3
 parts
 prime
 stage

--- a/site/annotations-tutorial.md
+++ b/site/annotations-tutorial.md
@@ -102,7 +102,7 @@ The first step is done. Flux is now and up running (you can confirm by
 running `kubectl get pods --all-namespaces`).
 
 In the second step we will use fluxctl to talk to Flux in the cluster and
-interact with the deployments. First, please [install fluxctl](https://github.com/weaveworks/flux/blob/master/site/fluxctl.md#installing-fluxctl).
+interact with the deployments. First, please [install fluxctl](fluxctl.md#installing-fluxctl).
 (It enables you to drive all of Weave Flux, so have a look at the output of
 `fluxctl -h` to get a better idea.)
 

--- a/site/faq.md
+++ b/site/faq.md
@@ -183,8 +183,7 @@ There are exceptions:
 
 To work around exceptional cases, you can mount a docker config into
 the Flux container. See the argument `--docker-config` in [the daemon
-arguments
-reference](https://github.com/weaveworks/flux/blob/master/site/daemon.md#flags).
+arguments reference](daemon.md#flags).
 
 See also
 [Why are my images not showing up in the list of images?](#why-are-my-images-not-showing-up-in-the-list-of-images)


### PR DESCRIPTION
Ignore .snap.xdelta3 files, simplify links in markdown.