### PR TITLE
Configure security context memcached pod

### DIFF
--- a/deploy/memcache-dep.yaml
+++ b/deploy/memcache-dep.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: memcached
-        image: memcached:1.4.25
+        image: memcached:1.5.15
         imagePullPolicy: IfNotPresent
         args:
         - -m 512   # Maximum memory to use, in megabytes
@@ -27,3 +27,7 @@ spec:
         ports:
         - name: clients
           containerPort: 11211
+        securityContext:
+          runAsUser: 11211
+          runAsGroup: 11211
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
To keep our example manifests in line with the recent changes in the
chart (#2107), and to ensure (minikube) users do not experience issues
with memcached failing to start, due to CVE-2019-11245.

Ref: https://github.com/kubernetes/kubernetes/issues/78308