### PR TITLE
Enable connection to a Remote Cluster for easy development

### DIFF
--- a/site/get-started-developing.md
+++ b/site/get-started-developing.md
@@ -17,6 +17,17 @@ This guide shows a workflow for making a small (actually, tiny) change to Flux, 
 >    1. make a change to the code
 >    1. see your code changes have been deployed
 >    1. repeat
+> 1. Remote cluster development approach:
+>    1. ensure local kubectl access to a remote kubernetes cluster.
+>    1. have an available local memcached instance.
+>    1. make a change to the code
+>    1. ```bash
+>          go run cmd/fluxd/main.go --memcached-hostname localhost  \
+>          --memcached-port 11211 \
+>          --git-url git@github.com:bzon/flux-get-started \
+>          --memcached-service ""
+>       ```
+>    1. repeat
 > 1. Use `helm` and `skaffold` together to deploy changes to the Flux helm chart.
 >    1. `make`
 >    1. make a change to the code
@@ -82,7 +93,7 @@ Now that we know everything is working with `flux-getting-started`, we're going 
 
 1. Clone `git@github.com:<YOUR-GITHUB-USERNAME>/flux.git` replacing `<YOUR-GITHUB-USERNAME>` with your GitHub username.
 
-    In the same terminal you ran `eval $(minikube docker-env)`, run `dep ensure` followed by `make` from the root directory of the Flux repo.  You'll see docker's usual output as it builds the image layers.  Once it's done, you should see something like this in the middle of the output:
+    In the same terminal you ran `eval $(minikube docker-env)`, run `GO111MODULE=on go mod download` followed by `make` from the root directory of the Flux repo.  You'll see docker's usual output as it builds the image layers.  Once it's done, you should see something like this in the middle of the output:
     ```
     Successfully built 606610e0f4ef
     Successfully tagged docker.io/weaveworks/flux:latest

--- a/site/get-started-developing.md
+++ b/site/get-started-developing.md
@@ -22,10 +22,12 @@ This guide shows a workflow for making a small (actually, tiny) change to Flux, 
 >    1. have an available local memcached instance.
 >    1. make a change to the code
 >    1. ```bash
->          go run cmd/fluxd/main.go --memcached-hostname localhost  \
->          --memcached-port 11211 \
->          --git-url git@github.com:bzon/flux-get-started \
->          --memcached-service ""
+>          go run cmd/fluxd/main.go \
+>           --memcached-hostname localhost  \
+>           --memcached-port 11211 \
+>           --memcached-service "" \
+>           --git-url git@github.com:weaveworks/flux-get-started \
+>           --k8s-in-cluster=false
 >       ```
 >    1. repeat
 > 1. Use `helm` and `skaffold` together to deploy changes to the Flux helm chart.

--- a/ssh/keyring.go
+++ b/ssh/keyring.go
@@ -7,3 +7,19 @@ type KeyRing interface {
 	KeyPair() (publicKey PublicKey, privateKeyPath string)
 	Regenerate() error
 }
+
+type sshKeyRing struct{}
+
+// NewNopSSHKeyRing returns a KeyRing that doesn't do anything.
+// It is meant for local development purposes when running fluxd outside a Kubernetes container.
+func NewNopSSHKeyRing() KeyRing {
+	return &sshKeyRing{}
+}
+
+func (skr *sshKeyRing) KeyPair() (PublicKey, string) {
+	return PublicKey{}, ""
+}
+
+func (skr *sshKeyRing) Regenerate() error {
+	return nil
+}


### PR DESCRIPTION
## Propose Change

Enable running **fluxd** binary locally.

```bash
go run cmd/fluxd/main.go \
    --memcached-hostname localhost  \
    --memcached-port 11211 \
    --memcached-service "" \
    --git-url git@github.com:bzon/flux-get-started \
    --k8s-in-cluster=false
```

This is a continuation of the unmaintained PR #1156 started by @andersjanmyr.

I had to add an implementation of **ssh.KeyRing** interface because without it, `fluxctl -u http://localhost:3030/api/flux [command]` makes **fluxd** panics with the below error:

```txt
2019/06/09 17:27:51 http: panic serving [::1]:58686: runtime error: invalid memory address or nil pointer dereference
goroutine 767 [running]:
net/http.(*conn).serve.func1(0xc0006365a0)
	/usr/local/Cellar/go/1.11.5/libexec/src/net/http/server.go:1746 +0xd0
panic(0x2159f60, 0x31a9640)
	/usr/local/Cellar/go/1.11.5/libexec/src/runtime/panic.go:513 +0x1b9
github.com/weaveworks/flux/cluster/kubernetes.(*Cluster).PublicSSHKey(0xc0005180f0, 0x12f6500, 0xc0003f0868, 0x2076740, 0xc000611b84, 0x16, 0x0)
	/Users/jb/Golang/src/github.com/weaveworks/flux/cluster/kubernetes/kubernetes.go:276 +0x3a
github.com/weaveworks/flux/daemon.(*Daemon).GitRepoConfig(0xc00033a120, 0x255a2c0, 0xc0004db770, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/jb/Golang/src/github.com/weaveworks/flux/daemon/daemon.go:610 +0x83
github.com/weaveworks/flux/http/daemon.HTTPServer.GitRepoConfig(0x256c940, 0xc00033a120, 0x254bec0, 0xc0007bfdc0, 0xc000ec8600)
	/Users/jb/Golang/src/github.com/weaveworks/flux/http/daemon/server.go:187 +0x181
github.com/weaveworks/flux/http/daemon.HTTPServer.GitRepoConfig-fm(0x254bec0, 0xc0007bfdc0, 0xc000ec8600)
	/Users/jb/Golang/src/github.com/weaveworks/flux/http/daemon/server.go:59 +0x57
```