### PR TITLE
Use openssh-client instead of openssh apk

### DIFF
--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -2,7 +2,7 @@ FROM alpine:3.9
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg
+RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0' 'gnutls>=3.6.7' gnupg
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh

--- a/docker/Dockerfile.helm-operator
+++ b/docker/Dockerfile.helm-operator
@@ -2,7 +2,7 @@ FROM alpine:3.9
 
 WORKDIR /home/flux
 
-RUN apk add --no-cache openssh ca-certificates tini 'git>=2.12.0'
+RUN apk add --no-cache openssh-client ca-certificates tini 'git>=2.12.0'
 
 # Add git hosts to known hosts file so we can use
 # StrickHostKeyChecking with git+ssh


### PR DESCRIPTION
In the primary Flux container, `ssh` is only required as a client to connect to external SSH servers. Replacing the use of the `openssh` apk with `openssh-client` reduces the surface area of the container and removes a class of vulnerability/configuration warnings that get picked up by static analysis tools in relation to `sshd`.
