### PR TITLE
Support image formats with separate registry entry

### DIFF
--- a/bin/kubeyaml
+++ b/bin/kubeyaml
@@ -1,2 +1,2 @@
 #!/bin/sh
-docker run --rm -i quay.io/squaremo/kubeyaml:0.5.2 "$@"
+docker run --rm -i quay.io/squaremo/kubeyaml:0.6.1 "$@"

--- a/cluster/kubernetes/resource/fluxhelmrelease_test.go
+++ b/cluster/kubernetes/resource/fluxhelmrelease_test.go
@@ -95,6 +95,100 @@ spec:
 	}
 }
 
+func TestParseRegistryImageTagFormat(t *testing.T) {
+	expectedRegistry := "registry.com"
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedRegistry + "/" + expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    first: post
+    registry: ` + expectedRegistry + `
+    image: ` + expectedImageName + `
+    tag: ` + expectedImageTag + `
+    persistence:
+      enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+}
+
+func TestParseRegistryImageFormat(t *testing.T) {
+	expectedRegistry := "registry.com"
+	expectedImageName := "bitnami/mariadb:10.1.30-r1"
+	expectedImage := expectedRegistry + "/" + expectedImageName
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    first: post
+    registry: ` + expectedRegistry + `
+    image: ` + expectedImageName + `
+    persistence:
+      enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Errorf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+}
+
 func TestParseNamedImageFormat(t *testing.T) {
 	expectedContainer := "db"
 	expectedImage := "bitnami/mariadb:10.1.30-r1"
@@ -212,6 +306,150 @@ spec:
 	}
 
 	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
+		t.Error(err)
+	}
+
+	containers = fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image = containers[0].Image.String()
+	if image != newImage.String() {
+		t.Errorf("expected container image %q, got %q", newImage.String(), image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}
+
+func TestParseNamedRegistryImageTagFormat(t *testing.T) {
+	expectedContainer := "db"
+	expectedRegistry := "registry.com"
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedRegistry + "/" + expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    other:
+      not: "containing image"
+    ` + expectedContainer + `:
+      first: post
+      registry: ` + expectedRegistry + `
+      image: ` + expectedImageName + `
+      tag: ` + expectedImageTag + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+
+	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	newImage.Domain = "someotherregistry.com"
+	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
+		t.Error(err)
+	}
+
+	containers = fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image = containers[0].Image.String()
+	if image != newImage.String() {
+		t.Errorf("expected container image %q, got %q", newImage.String(), image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}
+
+func TestParseNamedRegistryImageFormat(t *testing.T) {
+	expectedContainer := "db"
+	expectedRegistry := "registry.com"
+	expectedImageName := "bitnami/mariadb:10.1.30-r1"
+	expectedImage := expectedRegistry + "/" + expectedImageName
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    other:
+      not: "containing image"
+    ` + expectedContainer + `:
+      first: post
+      registry: ` + expectedRegistry + `
+      image: ` + expectedImageName + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+
+	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	newImage.Domain = "someotherregistry.com"
 	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
 		t.Error(err)
 	}
@@ -347,10 +585,84 @@ spec:
 	}
 }
 
+func TestParseNamedImageObjectFormatWithRegistry(t *testing.T) {
+	expectedContainer := "db"
+	expectedRegistry := "registry.com"
+	expectedImageName := "bitnami/mariadb"
+	expectedImageTag := "10.1.30-r1"
+	expectedImage := expectedRegistry + "/" + expectedImageName + ":" + expectedImageTag
+
+	doc := `---
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
+kind: FluxHelmRelease
+metadata:
+  name: mariadb
+  namespace: maria
+  labels:
+    chart: mariadb
+spec:
+  chartGitPath: mariadb
+  values:
+    other:
+      not: "containing image"
+    ` + expectedContainer + `:
+      first: post
+      image:
+        registry: ` + expectedRegistry + `
+        repository: ` + expectedImageName + `
+        tag: ` + expectedImageTag + `
+      persistence:
+        enabled: false
+`
+
+	resources, err := ParseMultidoc([]byte(doc), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, ok := resources["maria:fluxhelmrelease/mariadb"]
+	if !ok {
+		t.Fatalf("expected resource not found; instead got %#v", resources)
+	}
+	fhr, ok := res.(resource.Workload)
+	if !ok {
+		t.Fatalf("expected resource to be a Workload, instead got %#v", res)
+	}
+
+	containers := fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image := containers[0].Image.String()
+	if image != expectedImage {
+		t.Errorf("expected container image %q, got %q", expectedImage, image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+
+	newImage := containers[0].Image.WithNewTag("some-other-tag")
+	newImage.Domain = "someotherregistry.com"
+	if err := fhr.SetContainerImage(expectedContainer, newImage); err != nil {
+		t.Error(err)
+	}
+
+	containers = fhr.Containers()
+	if len(containers) != 1 {
+		t.Fatalf("expected 1 container; got %#v", containers)
+	}
+	image = containers[0].Image.String()
+	if image != newImage.String() {
+		t.Errorf("expected container image %q, got %q", newImage.String(), image)
+	}
+	if containers[0].Name != expectedContainer {
+		t.Errorf("expected container name %q, got %q", expectedContainer, containers[0].Name)
+	}
+}
+
 func TestParseAllFormatsInOne(t *testing.T) {
 
 	type container struct {
-		name, image, tag string
+		name, registry, image, tag string
 	}
 
 	// *NB* the containers will be calculated based on the order
@@ -360,9 +672,11 @@ func TestParseAllFormatsInOne(t *testing.T) {
 	// To avoid having to mess around later, I have cooked the order
 	// of these so they can be compared directly to the return value.
 	expected := []container{
-		{ReleaseContainerName, "repo/imageOne", "tagOne"},
-		{"AAA", "repo/imageTwo", "tagTwo"},
-		{"ZZZ", "repo/imageThree", "tagThree"},
+		{ReleaseContainerName, "", "repo/imageOne", "tagOne"},
+		{"AAA", "", "repo/imageTwo", "tagTwo"},
+		{"DDD", "", "repo/imageThree", "tagThree"},
+		{"HHH", "registry.com", "repo/imageFour", "tagFour"},
+		{"ZZZ", "registry.com", "repo/imageFive", "tagFive"},
 	}
 
 	doc := `---
@@ -389,6 +703,19 @@ spec:
         tag: ` + expected[2].tag + `
       persistence:
         enabled: false
+
+    # under .container, with a separate registry entry
+    ` + expected[3].name + `:
+      registry: ` + expected[3].registry + `
+      image: ` + expected[3].image + `
+      tag: ` + expected[3].tag + `
+
+    # under .container.image, with a separate registry entry
+    ` + expected[4].name + `:
+      image:
+        registry: ` + expected[4].registry + `
+        repository: ` + expected[4].image + `
+        tag: ` + expected[4].tag + `
 `
 
 	resources, err := ParseMultidoc([]byte(doc), "test")
@@ -413,7 +740,11 @@ spec:
 		if c1.Name != c0.name {
 			t.Errorf("names do not match %q != %q", c0, c1)
 		}
-		c0image := fmt.Sprintf("%s:%s", c0.image, c0.tag)
+		var c0image string
+		if c0.registry != "" {
+			c0image = c0.registry + "/"
+		}
+		c0image += fmt.Sprintf("%s:%s", c0.image, c0.tag)
 		if c1.Image.String() != c0image {
 			t.Errorf("images do not match %q != %q", c0image, c1.Image.String())
 		}

--- a/docker/Dockerfile.flux
+++ b/docker/Dockerfile.flux
@@ -34,7 +34,7 @@ LABEL maintainer="Weaveworks <help@weave.works>" \
 ENTRYPOINT [ "/sbin/tini", "--", "fluxd" ]
 
 # Get the kubeyaml binary (files) and put them on the path
-COPY --from=quay.io/squaremo/kubeyaml:0.5.2 /usr/lib/kubeyaml /usr/lib/kubeyaml/
+COPY --from=quay.io/squaremo/kubeyaml:0.6.1 /usr/lib/kubeyaml /usr/lib/kubeyaml/
 ENV PATH=/bin:/usr/bin:/usr/local/bin:/usr/lib/kubeyaml
 
 # Create minimal nsswitch.conf file to prioritize the usage of /etc/hosts over DNS queries.

--- a/site/helm-integration.md
+++ b/site/helm-integration.md
@@ -270,7 +270,22 @@ values:
 
 ```yaml
 values:
+  registry: docker.io
+  image: repo/image
+  tag: version
+```
+
+```yaml
+values:
   image:
+    repository: repo/image
+    tag: version
+```
+
+```yaml
+values:
+  image:
+    registry: docker.io
     repository: repo/image
     tag: version
 ```


### PR DESCRIPTION
To support the detection of image formats with a separate entry
for the registry domain, like the `stable/redis` chart has:

```yaml
# Top level
registry: docker.io
image: foo/bar
tag: v1

# As a 'container' mapping
container:
  registry: docker.io
  image: foo/bar
  tag: v1

# Also valid
container:
  registry: docker.io
  image: foo/bar:v1

# In an image object
image:
  registry: docker.io
  repository: foo/bar
  tag: v1
```

Fixes #2144