### PR TITLE
Fix memcached security context

### DIFF
--- a/chart/flux/CHANGELOG.md
+++ b/chart/flux/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.10.1 (2019-06-16)
+
+### Bug fixes
+
+ - Fix memcached security context
+   [weaveworks/flux#2163](https://github.com/weaveworks/flux/pull/2163)
+
 ## 0.10.0 (2019-06-14)
 
 ### Improvements

--- a/chart/flux/Chart.yaml
+++ b/chart/flux/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 appVersion: "1.13.0"
-version: 0.10.0
+version: 0.10.1
 kubeVersion: ">=1.9.0-0"
 name: flux
 description: Flux is a tool that automatically ensures that the state of a cluster matches what is specified in version control

--- a/chart/flux/templates/memcached.yaml
+++ b/chart/flux/templates/memcached.yaml
@@ -55,10 +55,6 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-    {{- with .Values.memcached.securityContext }}
-      securityContext:
-{{ toYaml . | indent 8 }}
-    {{- end }}
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
The security context was added twice to the memcached deployment resulting in errors like:

```
Error: validation failed: error validating "": error validating data: ValidationError(Deployment.spec.template.spec.securityContext): unknown field "allowPrivilegeEscalation" in io.k8s.api.core.v1.PodSecurityContext
```

Tested on GKE 1.13, the  memcached security context  is correctly added to the container only:

```yaml
spec:
  containers:
  - args:
    - -m 512
    - -p 11211
    - -I 5m
    image: memcached:1.5.15
    imagePullPolicy: IfNotPresent
    name: memcached
    ports:
    - containerPort: 11211
      name: memcached
      protocol: TCP
    resources: {}
    securityContext:
      allowPrivilegeEscalation: false
      procMount: Default
      runAsUser: 11211
```