### PR TITLE
Only require image TS when it is used for sorting

### DIFF
--- a/daemon/images.go
+++ b/daemon/images.go
@@ -102,7 +102,7 @@ func calculateChanges(logger log.Logger, candidateWorkloads resources, workloads
 					continue containers
 				}
 				current := repoMetadata.FindImageWithRef(currentImageID)
-				if current.CreatedTS().IsZero() || latest.CreatedTS().IsZero() {
+				if pattern.RequiresTimestamp() && (current.CreatedTS().IsZero() || latest.CreatedTS().IsZero()) {
 					logger.Log("warning", "image with zero created timestamp", "current", fmt.Sprintf("%s (%s)", current.ID, current.CreatedTS()), "latest", fmt.Sprintf("%s (%s)", latest.ID, latest.CreatedTS()), "action", "skip container")
 					continue containers
 				}

--- a/daemon/images_test.go
+++ b/daemon/images_test.go
@@ -18,6 +18,7 @@ import (
 const (
 	container1 = "container1"
 	container2 = "container2"
+	container3 = "container3"
 
 	currentContainer1Image = "container1/application:current"
 	newContainer1Image     = "container1/application:new"
@@ -25,6 +26,9 @@ const (
 	currentContainer2Image = "container2/application:current"
 	newContainer2Image     = "container2/application:new"
 	noTagContainer2Image   = "container2/application"
+
+	currentContainer3Image = "container3/application:1.0.0"
+	newContainer3Image     = "container3/application:1.1.0"
 )
 
 type candidate struct {
@@ -152,6 +156,7 @@ func TestCalculateChanges_UntaggedImage(t *testing.T) {
 		t.Errorf("Expected changed image to be %s, got %s", newContainer1Image, newImage)
 	}
 }
+
 func TestCalculateChanges_ZeroTimestamp(t *testing.T) {
 	logger := log.NewNopLogger()
 	resourceID := resource.MakeID(ns, "deployment", "application")
@@ -159,7 +164,8 @@ func TestCalculateChanges_ZeroTimestamp(t *testing.T) {
 		resourceID: candidate{
 			resourceID: resourceID,
 			policies: policy.Set{
-				policy.Automated: "true",
+				policy.Automated:             "true",
+				policy.TagPrefix(container3): "semver:^1.0",
 			},
 		},
 	}
@@ -176,6 +182,10 @@ func TestCalculateChanges_ZeroTimestamp(t *testing.T) {
 						Name:  container2,
 						Image: mustParseImageRef(currentContainer2Image),
 					},
+					{
+						Name:  container3,
+						Image: mustParseImageRef(currentContainer3Image),
+					},
 				},
 			},
 		},
@@ -184,14 +194,21 @@ func TestCalculateChanges_ZeroTimestamp(t *testing.T) {
 	{
 		current1 := makeImageInfo(currentContainer1Image, time.Now())
 		new1 := makeImageInfo(newContainer1Image, time.Now().Add(1*time.Second))
+
 		zeroTimestampCurrent2 := image.Info{ID: mustParseImageRef(currentContainer2Image)}
 		new2 := makeImageInfo(newContainer2Image, time.Now().Add(1*time.Second))
+
+		current3 := makeImageInfo(currentContainer3Image, time.Now())
+		zeroTimestampNew3 := image.Info{ID: mustParseImageRef(newContainer3Image)}
+
 		imageRegistry = &registryMock.Registry{
 			Images: []image.Info{
 				current1,
 				new1,
 				zeroTimestampCurrent2,
 				new2,
+				current3,
+				zeroTimestampNew3,
 			},
 		}
 	}
@@ -202,9 +219,13 @@ func TestCalculateChanges_ZeroTimestamp(t *testing.T) {
 
 	changes := calculateChanges(logger, candidateWorkloads, workloads, imageRepos)
 
-	if len := len(changes.Changes); len != 1 {
-		t.Errorf("Expected exactly 1 change, got %d changes", len)
-	} else if newImage := changes.Changes[0].ImageID.String(); newImage != newContainer1Image {
+	if len := len(changes.Changes); len != 2 {
+		t.Fatalf("Expected exactly 2 changes, got %d changes: %v", len, changes.Changes)
+	}
+	if newImage := changes.Changes[0].ImageID.String(); newImage != newContainer1Image {
 		t.Errorf("Expected changed image to be %s, got %s", newContainer1Image, newImage)
+	}
+	if newImage := changes.Changes[1].ImageID.String(); newImage != newContainer3Image {
+		t.Errorf("Expected changed image to be %s, got %s", newContainer3Image, newImage)
 	}
 }

--- a/policy/pattern.go
+++ b/policy/pattern.go
@@ -32,6 +32,8 @@ type Pattern interface {
 	Newer(a, b *image.Info) bool
 	// Valid returns true if the pattern is considered valid.
 	Valid() bool
+	// RequiresTimestamp returns true if the pattern orders based on timestamp data.
+	RequiresTimestamp() bool
 }
 
 type GlobPattern string
@@ -87,6 +89,10 @@ func (g GlobPattern) Valid() bool {
 	return true
 }
 
+func (g GlobPattern) RequiresTimestamp() bool {
+	return true
+}
+
 func (s SemverPattern) Matches(tag string) bool {
 	v, err := semver.NewVersion(tag)
 	if err != nil {
@@ -111,6 +117,10 @@ func (s SemverPattern) Valid() bool {
 	return s.constraints != nil
 }
 
+func (s SemverPattern) RequiresTimestamp() bool {
+	return false
+}
+
 func (r RegexpPattern) Matches(tag string) bool {
 	if r.regexp == nil {
 		// Invalid regexp match anything
@@ -129,4 +139,8 @@ func (r RegexpPattern) Newer(a, b *image.Info) bool {
 
 func (r RegexpPattern) Valid() bool {
 	return r.regexp != nil
+}
+
+func (r RegexpPattern) RequiresTimestamp() bool {
+	return true
 }


### PR DESCRIPTION
As the semver filter does not make use of the image creation timestamp
for filtering and sorting images, but instead has its own logic based
on the semver spec, the block for automated image updates when a
timestamp was missing for an image with a semver filter policy did more
harm than good.

This commit introduces a `RequiresTimestamp` method on the `Pattern`
interface to indicate if the filter needs the timestamps on images to
be present to give a reliable filtered and sorted output. Which is
implemented in `calculateChanges`, so we only bail on missing
timestamps when they are actually required.

Addresses #2172, but is by no means a fix.