### PR TITLE
Implement whitelist for usage of TS from labels

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -234,6 +234,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `registry.insecureHosts`                          | `None`                                               | Use HTTP rather than HTTPS for the image registry domains
 | `registry.cacheExpiry`                            | `None`                                               | Duration to keep cached image info (deprecated)
 | `registry.excludeImage`                           | `None`                                               | Do not scan images that match these glob expressions; if empty, 'k8s.gcr.io/*' images are excluded
+| `registry.useTimestampLabels`                     | `None`                                               | Allow usage of (RFC3339) timestamp labels from (canonical) image refs that match these glob expressions; if empty, 'index.docker.io/weaveworks/*' images are allowed
 | `registry.ecr.region`                             | `None`                                               | Restrict ECR scanning to these AWS regions; if empty, only the cluster's region will be scanned
 | `registry.ecr.includeId`                          | `None`                                               | Restrict ECR scanning to these AWS account IDs; if empty, all account IDs that aren't excluded may be scanned
 | `registry.ecr.excludeId`                          | `602401143452`                                       | Do not scan ECR for images in these AWS account IDs; the default is to exclude the EKS system account

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -199,6 +199,9 @@ spec:
           {{- if .Values.registry.excludeImage }}
           - --registry-exclude-image={{ .Values.registry.excludeImage }}
           {{- end }}
+          {{- if .Values.registry.useTimestampLabels }}
+          - --registry-use-labels={{ .Values.registry.useTimestampLabels }}
+          {{- end }}
           {{- if .Values.registry.ecr.region }}
           - --registry-ecr-region={{ .Values.registry.ecr.region }}
           {{- end }}

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -184,6 +184,8 @@ registry:
   cacheExpiry:
   # Do not scan images that match these glob expressions
   excludeImage:
+  # Allow usage of (RFC3339) timestamp labels from (canonical) image refs that match these glob expressions
+  useTimestampLabels:
   # AWS ECR settings
   ecr:
     region:

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -146,7 +146,7 @@ func main() {
 		registryTrace        = fs.Bool("registry-trace", false, "output trace of image registry requests to log")
 		registryInsecure     = fs.StringSlice("registry-insecure-host", []string{}, "let these registry hosts skip TLS host verification and fall back to using HTTP instead of HTTPS; this allows man-in-the-middle attacks, so use with extreme caution")
 		registryExcludeImage = fs.StringSlice("registry-exclude-image", []string{"k8s.gcr.io/*"}, "do not scan images that match these glob expressions; the default is to exclude the 'k8s.gcr.io/*' images")
-		registryUseLabels    = fs.StringSlice("registry-use-labels", []string{"index.docker.io/weaveworks/*"}, "use the timestamp (RFC3339) from labels for (canonical) image refs that match these glob expression")
+		registryUseLabels    = fs.StringSlice("registry-use-labels", []string{"index.docker.io/weaveworks/*", "index.docker.io/fluxcd/*"}, "use the timestamp (RFC3339) from labels for (canonical) image refs that match these glob expression")
 
 		// AWS authentication
 		registryAWSRegions         = fs.StringSlice("registry-ecr-region", nil, "include just these AWS regions when scanning images in ECR; when not supplied, the cluster's region will included if it can be detected through the AWS API")

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -146,6 +146,7 @@ func main() {
 		registryTrace        = fs.Bool("registry-trace", false, "output trace of image registry requests to log")
 		registryInsecure     = fs.StringSlice("registry-insecure-host", []string{}, "let these registry hosts skip TLS host verification and fall back to using HTTP instead of HTTPS; this allows man-in-the-middle attacks, so use with extreme caution")
 		registryExcludeImage = fs.StringSlice("registry-exclude-image", []string{"k8s.gcr.io/*"}, "do not scan images that match these glob expressions; the default is to exclude the 'k8s.gcr.io/*' images")
+		registryUseLabels    = fs.StringSlice("registry-use-labels", []string{"index.docker.io/weaveworks/*"}, "use the timestamp (RFC3339) from labels for (canonical) image refs that match these glob expression")
 
 		// AWS authentication
 		registryAWSRegions         = fs.StringSlice("registry-ecr-region", nil, "include just these AWS regions when scanning images in ECR; when not supplied, the cluster's region will included if it can be detected through the AWS API")
@@ -498,6 +499,9 @@ func main() {
 
 		cacheRegistry = &cache.Cache{
 			Reader: cacheClient,
+			Decorators: []cache.Decorator{
+				cache.TimestampLabelWhitelist(*registryUseLabels),
+			},
 		}
 		cacheRegistry = registry.NewInstrumentedRegistry(cacheRegistry)
 

--- a/registry/cache/memcached/integration_test.go
+++ b/registry/cache/memcached/integration_test.go
@@ -48,7 +48,7 @@ func TestWarming_WarmerWriteCacheRead(t *testing.T) {
 		Trace:    true,
 	}
 
-	r := &cache.Cache{mc}
+	r := &cache.Cache{Reader: mc}
 
 	w, _ := cache.NewWarmer(remote, mc, 125)
 	shutdown := make(chan struct{})

--- a/registry/cache/registry.go
+++ b/registry/cache/registry.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/ryanuber/go-glob"
 
 	fluxerr "github.com/weaveworks/flux/errors"
 	"github.com/weaveworks/flux/image"
@@ -28,7 +29,48 @@ repository.
 
 // Cache is a local cache of image metadata.
 type Cache struct {
-	Reader Reader
+	Reader     Reader
+	Decorators []Decorator
+}
+
+// Decorator is for decorating an ImageRepository before it is returned.
+type Decorator interface {
+	apply(*ImageRepository)
+}
+
+// TimestampLabelWhitelist contains a string slice of glob patterns. Any
+// canonical image reference that matches one of the glob patterns will
+// prefer creation timestamps from labels over the one it received from
+// the registry.
+type TimestampLabelWhitelist []string
+
+// apply checks if any of the canonical image references from the
+// repository matches a glob pattern from the list. If it does, and the
+// image record has a valid timestamp label, it will replace the Created
+// field with the value from the label for all images in the repository.
+func (l TimestampLabelWhitelist) apply(r *ImageRepository) {
+	var match bool
+	for k, i := range r.Images {
+		if !match {
+			for _, exp := range l {
+				if glob.Glob(exp, i.ID.CanonicalName().String()) {
+					match = true
+					break
+				}
+			}
+			if !match {
+				return
+			}
+		}
+
+		switch {
+		case !i.Labels.Created.IsZero():
+			i.CreatedAt = i.Labels.Created
+		case !i.Labels.BuildDate.IsZero():
+			i.CreatedAt = i.Labels.BuildDate
+		}
+		r.Images[k] = i
+	}
 }
 
 // GetImageRepositoryMetadata returns the metadata from an image
@@ -51,6 +93,11 @@ func (c *Cache) GetImageRepositoryMetadata(id image.Name) (image.RepositoryMetad
 			return image.RepositoryMetadata{}, errors.New(repo.LastError)
 		}
 		return image.RepositoryMetadata{}, ErrNotCached
+	}
+
+	// (Maybe) decorate the image repository.
+	for _, d := range c.Decorators {
+		d.apply(&repo)
 	}
 
 	return repo.RepositoryMetadata, nil

--- a/registry/cache/registry_test.go
+++ b/registry/cache/registry_test.go
@@ -1,0 +1,74 @@
+package cache
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/flux/image"
+)
+
+// mockStorage holds a fixed ImageRepository item.
+type mockStorage struct {
+	Item ImageRepository
+}
+
+// GetKey will always return the same item from the storage,
+// and does not care about the key it receives.
+func (m *mockStorage) GetKey(k Keyer) ([]byte, time.Time, error) {
+	b, err := json.Marshal(m.Item)
+	if err != nil {
+		return []byte{}, time.Time{}, err
+	}
+	return b, time.Time{}, nil
+}
+
+// appendImage adds an image to the mocked storage item.
+func (m *mockStorage) appendImage(i image.Info) {
+	tag := i.ID.Tag
+
+	m.Item.Images[tag] = i
+	m.Item.Tags = append(m.Item.Tags, tag)
+}
+
+func mockReader() *mockStorage {
+	return &mockStorage{
+		Item: ImageRepository{
+			RepositoryMetadata: image.RepositoryMetadata{
+				Tags: []string{},
+				Images: map[string]image.Info{},
+			},
+			LastUpdate: time.Now(),
+		},
+	}
+}
+
+func Test_WhitelabelDecorator(t *testing.T) {
+	r := mockReader()
+
+	// Image with no timestamp label
+	r.appendImage(mustMakeInfo("docker.io/fluxcd/flux:equal", time.Time{}, time.Now().UTC()))
+	// Image with a timestamp label
+	r.appendImage(mustMakeInfo("docker.io/fluxcd/flux:label", time.Now().Add(-10*time.Second).UTC(), time.Now().UTC()))
+
+	c := Cache{r, []Decorator{TimestampLabelWhitelist{"index.docker.io/fluxcd/*"}}}
+
+	rm, err := c.GetImageRepositoryMetadata(image.Name{})
+	assert.NoError(t, err)
+
+	assert.Equal(t, r.Item.Images["equal"].CreatedAt, rm.Images["equal"].CreatedAt)
+	assert.Equal(t, r.Item.Images["label"].Labels.Created, rm.Images["label"].CreatedAt)
+}
+
+func mustMakeInfo(ref string, label time.Time, created time.Time) image.Info {
+	r, err := image.ParseRef(ref)
+	if err != nil {
+		panic(err)
+	}
+	var labels image.Labels
+	if !label.IsZero() {
+		labels.Created = label
+	}
+	return image.Info{ID: r, Labels: labels, CreatedAt: created}
+}

--- a/site/daemon.md
+++ b/site/daemon.md
@@ -42,58 +42,59 @@ document.
 
 fluxd requires setup and offers customization though a multitude of flags.
 
-| Flag                                             | Default                  | Purpose
-| ------------------------------------------------ | ------------------------ | ---
-| --listen -l                                      | `:3030`                  | listen address where /metrics and API will be served
-| --listen-metrics                                 |                          | listen address for /metrics endpoint
-| --kubernetes-kubectl                             |                          | optional, explicit path to kubectl tool
-| --version                                        | false                    | output the version number and exit
+| Flag                                             | Default                            | Purpose
+| ------------------------------------------------ | ---------------------------------- | ---
+| --listen -l                                      | `:3030`                            | listen address where /metrics and API will be served
+| --listen-metrics                                 |                                    | listen address for /metrics endpoint
+| --kubernetes-kubectl                             |                                    | optional, explicit path to kubectl tool
+| --version                                        | false                              | output the version number and exit
 | **Git repo & key etc.**
-| --git-url                                        |                          | URL of git repo with Kubernetes manifests; e.g., `git@github.com:weaveworks/flux-get-started`
-| --git-branch                                     | `master`                 | branch of git repo to use for Kubernetes manifests
-| --git-ci-skip                                    | false                    | when set, fluxd will append `\n\n[ci skip]` to its commit messages
-| --git-ci-skip-message                            | `""`                     | if provided, fluxd will append this to commit messages (overrides --git-ci-skip`)
-| --git-path                                       |                          | path within git repo to locate Kubernetes manifests (relative path)
-| --git-user                                       | `Weave Flux`             | username to use as git committer
-| --git-email                                      | `support@weave.works`    | email to use as git committer
-| --git-set-author                                 | false                    | if set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer
-| --git-gpg-key-import                             |                          | if set, fluxd will attempt to import the gpg key(s) found on the given path
-| --git-signing-key                                |                          | if set, commits made by fluxd to the user git repo will be signed with the provided GPG key. See [Git commit signing](git-commit-signing.md) to learn how to use this feature
-| --git-label                                      |                          | label to keep track of sync progress; overrides both --git-sync-tag and --git-notes-ref
-| --git-sync-tag                                   | `flux-sync`              | tag to use to mark sync progress for this cluster (old config, still used if --git-label is not supplied)
-| --git-notes-ref                                  | `flux`                   | ref to use for keeping commit annotations in git notes
-| --git-poll-interval                              | `5m`                     | period at which to fetch any new commits from the git repo
-| --git-timeout                                    | `20s`                    | duration after which git operations time out
-| --git-secret                                     | false                    | if set, git-secret will be run on every git checkout. A gpg key must be imported using  --git-gpg-key-import or by mounting a keyring containing it directly
+| --git-url                                        |                                    | URL of git repo with Kubernetes manifests; e.g., `git@github.com:weaveworks/flux-get-started`
+| --git-branch                                     | `master`                           | branch of git repo to use for Kubernetes manifests
+| --git-ci-skip                                    | false                              | when set, fluxd will append `\n\n[ci skip]` to its commit messages
+| --git-ci-skip-message                            | `""`                               | if provided, fluxd will append this to commit messages (overrides --git-ci-skip`)
+| --git-path                                       |                                    | path within git repo to locate Kubernetes manifests (relative path)
+| --git-user                                       | `Weave Flux`                       | username to use as git committer
+| --git-email                                      | `support@weave.works`              | email to use as git committer
+| --git-set-author                                 | false                              | if set, the author of git commits will reflect the user who initiated the commit and will differ from the git committer
+| --git-gpg-key-import                             |                                    | if set, fluxd will attempt to import the gpg key(s) found on the given path
+| --git-signing-key                                |                                    | if set, commits made by fluxd to the user git repo will be signed with the provided GPG key. See [Git commit signing](git-commit-signing.md) to learn how to use this feature
+| --git-label                                      |                                    | label to keep track of sync progress; overrides both --git-sync-tag and --git-notes-ref
+| --git-sync-tag                                   | `flux-sync`                        | tag to use to mark sync progress for this cluster (old config, still used if --git-label is not supplied)
+| --git-notes-ref                                  | `flux`                             | ref to use for keeping commit annotations in git notes
+| --git-poll-interval                              | `5m`                               | period at which to fetch any new commits from the git repo
+| --git-timeout                                    | `20s`                              | duration after which git operations time out
+| --git-secret                                     | false                              | if set, git-secret will be run on every git checkout. A gpg key must be imported using  --git-gpg-key-import or by mounting a keyring containing it directly
 | **syncing:** control over how config is applied to the cluster
-| --sync-interval                                  | `5m`                     | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs
-| --sync-garbage-collection                        | `false`                  | experimental: when set, fluxd will delete resources that it created, but are no longer present in git (see [garbage collection](./garbagecollection.md))
+| --sync-interval                                  | `5m`                               | apply the git config to the cluster at least this often. New commits may provoke more frequent syncs
+| --sync-garbage-collection                        | `false`                            | experimental: when set, fluxd will delete resources that it created, but are no longer present in git (see [garbage collection](./garbagecollection.md))
 | **registry cache:** (none of these need overriding, usually)
-| --memcached-hostname                             | `memcached`              | hostname for memcached service to use for caching image metadata
-| --memcached-timeout                              | `1s`                     | maximum time to wait before giving up on memcached requests
-| --memcached-service                              | `memcached`              | SRV service used to discover memcache servers
-| --registry-cache-expiry                          | `1h`                     | Duration to keep cached registry tag info. Must be < 1 month.
-| --registry-poll-interval                         | `5m`                     | period at which to poll registry for new images
-| --registry-rps                                   | `200`                    | maximum registry requests per second per host
-| --registry-burst                                 | `125`                    | maximum number of warmer connections to remote and memcache
-| --registry-insecure-host                         | []                       | registry hosts to use HTTP for (instead of HTTPS)
-| --registry-exclude-image                         | `["k8s.gcr.io/*"]`       | do not scan images that match these glob expressions
-| --docker-config                                  | `""`                     | path to a Docker config file with default image registry credentials
-| --registry-ecr-region                            | `[]`                     | Allow these AWS regions when scanning images from ECR (multiple values allowed); defaults to the detected cluster region
-| --registry-ecr-include-id                        | `[]`                     | Include these AWS account ID(s) when scanning images in ECR (multiple values allowed); empty means allow all, unless excluded
-| --registry-ecr-exclude-id                        | `[<EKS SYSTEM ACCOUNT>]` | Exclude these AWS account ID(s) when scanning ECR (multiple values allowed); defaults to the EKS system account, so system images will not be scanned
-| --registry-require                               | `[]`                  | exit with an error if the given services are not available. Useful for escalating misconfiguration or outages that might otherwise go undetected. Presently supported values: {`ecr`} |
+| --memcached-hostname                             | `memcached`                        | hostname for memcached service to use for caching image metadata
+| --memcached-timeout                              | `1s`                               | maximum time to wait before giving up on memcached requests
+| --memcached-service                              | `memcached`                        | SRV service used to discover memcache servers
+| --registry-cache-expiry                          | `1h`                               | Duration to keep cached registry tag info. Must be < 1 month.
+| --registry-poll-interval                         | `5m`                               | period at which to poll registry for new images
+| --registry-rps                                   | `200`                              | maximum registry requests per second per host
+| --registry-burst                                 | `125`                              | maximum number of warmer connections to remote and memcache
+| --registry-insecure-host                         | []                                 | registry hosts to use HTTP for (instead of HTTPS)
+| --registry-exclude-image                         | `["k8s.gcr.io/*"]`                 | do not scan images that match these glob expressions
+| --registry-use-labels                            | `["index.docker.io/weaveworks/*"]` | use the timestamp (RFC3339) from labels for (canonical) image refs that match these glob expressions
+| --docker-config                                  | `""`                               | path to a Docker config file with default image registry credentials
+| --registry-ecr-region                            | `[]`                               | allow these AWS regions when scanning images from ECR (multiple values allowed); defaults to the detected cluster region
+| --registry-ecr-include-id                        | `[]`                               | include these AWS account ID(s) when scanning images in ECR (multiple values allowed); empty means allow all, unless excluded
+| --registry-ecr-exclude-id                        | `[<EKS SYSTEM ACCOUNT>]`           | exclude these AWS account ID(s) when scanning ECR (multiple values allowed); defaults to the EKS system account, so system images will not be scanned
+| --registry-require                               | `[]`                               | exit with an error if the given services are not available. Useful for escalating misconfiguration or outages that might otherwise go undetected. Presently supported values: {`ecr`} |
 | **k8s-secret backed ssh keyring configuration**
-| --k8s-secret-name                                | `flux-git-deploy`        | name of the k8s secret used to store the private SSH key
-| --k8s-secret-volume-mount-path                   | `/etc/fluxd/ssh`         | mount location of the k8s secret storing the private SSH key
-| --k8s-secret-data-key                            | `identity`               | data key holding the private SSH key within the k8s secret
+| --k8s-secret-name                                | `flux-git-deploy`                  | name of the k8s secret used to store the private SSH key
+| --k8s-secret-volume-mount-path                   | `/etc/fluxd/ssh`                   | mount location of the k8s secret storing the private SSH key
+| --k8s-secret-data-key                            | `identity`                         | data key holding the private SSH key within the k8s secret
 | **k8s configuration**
-| --k8s-allow-namespace                            |                          | experimental: restrict all operations to the provided namespaces
+| --k8s-allow-namespace                            |                                    | experimental: restrict all operations to the provided namespaces
 | **upstream service**
-| --connect                                        |                          | connect to an upstream service e.g., Weave Cloud, at this base address
-| --token                                          |                          | authentication token for upstream service
+| --connect                                        |                                    | connect to an upstream service e.g., Weave Cloud, at this base address
+| --token                                          |                                    | authentication token for upstream service
 | **SSH key generation**
-| --ssh-keygen-bits                                |                          | -b argument to ssh-keygen (default unspecified)
-| --ssh-keygen-type                                |                          | -t argument to ssh-keygen (default unspecified)
+| --ssh-keygen-bits                                |                                    | -b argument to ssh-keygen (default unspecified)
+| --ssh-keygen-type                                |                                    | -t argument to ssh-keygen (default unspecified)
 | **manifest generation**
-| --manifest-generation                            | false                    | experimental; search for .flux.yaml files to generate manifests
+| --manifest-generation                            | false                              | experimental; search for .flux.yaml files to generate manifests


### PR DESCRIPTION
We did not take the inheritance of labels from base images into account
while developing the timestamps from image labels feature. As a result,
users started experiencing issues with automated image updates, due to
the (moderately old) timestamp from the base image being picked up and
prioritized over the timestamp from the registry.

This commits adds the ability to decorate `ImageRepository` structures
before they are returned from cache by `GetImageRepositoryMetadata`.

The sole decorator for now is `TimestampLabelWhitelist`, which replaces
the `CreatedAt` field on the image info with the timestamp specified in
one of the labels if the canonical name of the image matches one of
the glob patterns on the whitelist.

As a result, the labels from images will only be used if explicitly
instructed by the user, dealing with the problem described at the top
of this comment.