### PR TITLE
Force fetch tags on checkout local working clone

### DIFF
--- a/git/working.go
+++ b/git/working.go
@@ -82,6 +82,18 @@ func (r *Repo) Clone(ctx context.Context, conf Config) (*Checkout, error) {
 	}
 
 	r.mu.RLock()
+	// Here is where we mimic `git fetch --tags --force`, but
+	// _without_ overwriting head refs. This is only required for a
+	// `Checkout` and _not_ for `Repo` as (bare) mirrors will happily
+	// accept any ref changes to tags.
+	//
+	// NB: do this before any other fetch actions, as otherwise we may
+	// get an 'existing tag clobber' error back.
+	if err := fetch(ctx, repoDir, r.dir, `'+refs/tags/*:refs/tags/*'`); err != nil {
+		os.RemoveAll(repoDir)
+		r.mu.RUnlock()
+		return nil, err
+	}
 	if err := fetch(ctx, repoDir, r.dir, realNotesRef+":"+realNotesRef); err != nil {
 		os.RemoveAll(repoDir)
 		r.mu.RUnlock()


### PR DESCRIPTION
In Git 2.20 "git fetch" was taught to forbid updates to existing tags
without the "--force" option[1]. As Flux force-pushes a tag all the
time to keep track of the sync state, this would sometimes lead to
'would clobber existing tag' errors while making sure a fresh checkout
was up-to-date with its mirror, as described issue 2169[2].

To prevent this from happening: force fetch all tags from the mirror
while creating the local working clone, and _before_ fetching anything
else.

NB: We only have to do this while creating a working clone from a
mirror, as a mirror (bare clone) will accept non-fast-forward tag
changes from remote.

[1]: https://github.com/git/git/blob/master/Documentation/RelNotes/2.20.0.txt#L67-L71
[2]: #2169

Fixes #2169 