### PR TITLE
Remove Weave Cloud mentions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report
-about: Create a report to help us improve Weave Flux
+about: Create a report to help us improve Flux
 title: ''
 labels: blocked-needs-validation, bug
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,6 @@
 ---
 name: Feature request
-about: Suggest a new feature for Weave Flux
+about: Suggest a new feature for Flux
 title: ''
 labels: blocked-needs-validation, enhancement
 assignees: ''

--- a/README.md
+++ b/README.md
@@ -81,19 +81,14 @@ Its major features are:
 
 If you too are using Flux in production; please submit a PR to add your organization to the list!
 
-### Relation to Weave Cloud
+### History
 
-Weave Cloud is a SaaS product by Weaveworks that includes Flux, as well
-as:
-
-- a UI and alerts for deployments: nicely integrated overview, all Flux
-  operations just a click away.
-- full observability and insights into your cluster: Instantly start using
-  monitoring dashboards for your cluster, hosted 13 months of history, use
-  a realtime map of your cluster to debug and analyse its state.
-
-If you want to learn more about Weave Cloud, you can see it in action on
-[its homepage](https://www.weave.works/product/cloud/).
+In the first years of its existence, the development of Flux was very
+closely couple to the one of [Weave
+Cloud](https://www.weave.works/product/cloud/). Over the years the community
+around Flux grew, the numbers of [integrations](#integrations) grew and
+the team started the process of generalising the code, so that more projects
+could easily integrate.
 
 ## Get started with Flux
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ be interested in the following:
 
 If you have any questions about Flux and continuous delivery:
 
-- Read [the Weave Flux docs](https://github.com/weaveworks/flux/tree/master/site).
+- Read [the Flux docs](https://github.com/weaveworks/flux/tree/master/site).
 - Invite yourself to the <a href="https://slack.weave.works/" target="_blank">Weave community</a>
   slack and ask a question on the [#flux](https://weave-community.slack.com/messages/flux/)
   channel.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ If you too are using Flux in production; please submit a PR to add your organiza
 ### History
 
 In the first years of its existence, the development of Flux was very
-closely couple to the one of [Weave
+closely coupled to that of [Weave
 Cloud](https://www.weave.works/product/cloud/). Over the years the community
 around Flux grew, the numbers of [integrations](#integrations) grew and
 the team started the process of generalising the code, so that more projects

--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -179,7 +179,7 @@ You should also remove the deploy key from your GitHub repository.
 
 ### Configuration
 
-The following tables lists the configurable parameters of the Weave Flux chart and their default values.
+The following tables lists the configurable parameters of the Flux chart and their default values.
 
 | Parameter                                         | Default                                              | Description
 | -----------------------------------------------   | ---------------------------------------------------- | ---
@@ -299,7 +299,7 @@ weaveworks/flux
 
 ### Upgrade
 
-Update Weave Flux version with:
+Update Flux version with:
 
 ```sh
 helm upgrade --reuse-values flux \

--- a/daemon/sync_test.go
+++ b/daemon/sync_test.go
@@ -31,7 +31,7 @@ const (
 	gitPath     = ""
 	gitSyncTag  = "flux-sync"
 	gitNotesRef = "flux"
-	gitUser     = "Weave Flux"
+	gitUser     = "Flux"
 	gitEmail    = "support@weave.works"
 )
 

--- a/gpg/gpgtest/gpg.go
+++ b/gpg/gpgtest/gpg.go
@@ -29,7 +29,7 @@ func GPGKey(t *testing.T) (string, string, func()) {
 	io.WriteString(stdin, "Key-Type: DSA\n")
 	io.WriteString(stdin, "Key-Length: 1024\n")
 	io.WriteString(stdin, "Key-Usage: sign\n")
-	io.WriteString(stdin, "Name-Real: Weave Flux\n")
+	io.WriteString(stdin, "Name-Real: Flux\n")
 	io.WriteString(stdin, "Name-Email: flux@weave.works\n")
 	io.WriteString(stdin, "%no-protection\n")
 	stdin.Close()

--- a/site/annotations-tutorial.md
+++ b/site/annotations-tutorial.md
@@ -1,6 +1,6 @@
-# Driving Weave Flux - automations, locks and annotations
+# Driving Flux - automations, locks and annotations
 
-In this tutorial we want to get a better feel for what we can do with Weave
+In this tutorial we want to get a better feel for what we can do with 
 Flux. We won't spend too much time with getting it up and running, so let's
 get that out of the way first.
 
@@ -11,7 +11,7 @@ deployment](https://github.com/weaveworks/flux-get-started) and click on the
 
 ## Setup
 
-Get the source code of Weave Flux:
+Get the source code of Flux:
 
 ```sh
 git clone https://github.com/weaveworks/flux
@@ -83,7 +83,7 @@ Apply the Helm Release CRD:
 kubectl apply -f https://raw.githubusercontent.com/weaveworks/flux/master/deploy-helm/flux-helm-release-crd.yaml
 ```
 
-Install Weave Flux and its Helm Operator by specifying your fork URL. Just
+Install Flux and its Helm Operator by specifying your fork URL. Just
 make sure you replace `YOURUSER` with your GitHub username in the command
 below:
 
@@ -108,14 +108,14 @@ running `kubectl get pods --all-namespaces`).
 
 In the second step we will use fluxctl to talk to Flux in the cluster and
 interact with the deployments. First, please [install fluxctl](fluxctl.md#installing-fluxctl).
-(It enables you to drive all of Weave Flux, so have a look at the output of
+(It enables you to drive all of Flux, so have a look at the output of
 `fluxctl -h` to get a better idea.)
 
 > **Note:** Another option (without installing `fluxctl` is to take a look
 at the resulting annotation changes and make the changes in Git. This is
 GitOps after all. :-)
 
-To enable Weave Flux to sync your config, you need to add the deployment key
+To enable Flux to sync your config, you need to add the deployment key
 to your fork.
 
 Get your Flux deployment key by running
@@ -134,11 +134,11 @@ Wait for sync to happen or run
 fluxctl sync
 ```
 
-## Driving Weave Flux
+## Driving Flux
 
-After syncing, Weave Flux will find out which workloads there are, which
+After syncing, Flux will find out which workloads there are, which
 images are available and what needs doing. To find out which workloads are
-managed by Weave Flux, run
+managed by Flux, run
 
 ```sh
 fluxctl list-workloads -a
@@ -167,7 +167,7 @@ Commit pushed:  4755a3b
 ```
 
 If you now go back to `https://github.com/YOUR-USER-ID/flux-get-started` in
-your browser, you will notice that Weave Flux has made a commit on your
+your browser, you will notice that Flux has made a commit on your
 behalf. The policy change is now in Git, which is great for transparency and
 for defining expected state.
 
@@ -265,7 +265,7 @@ and the diff for this is going to look like this:
 ```
 
 And that's it. At the end of this tutorial, you have automated, locked and
-annotated deployments with Weave Flux.
+annotated deployments with Flux.
 
 Another tip, if you should get stuck anywhere: check what Flux is doing. You
 can do that by simply running

--- a/site/building.md
+++ b/site/building.md
@@ -1,5 +1,5 @@
 ---
-title: Building Weave Flux
+title: Building Flux
 menu_order: 80
 ---
 

--- a/site/faq.md
+++ b/site/faq.md
@@ -1,5 +1,5 @@
 ---
-title: Weave Flux FAQ
+title: Flux FAQ
 menu_order: 60
 ---
 

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -37,10 +37,7 @@ menu_order: 40
   * [Errors due to author customization](#errors-due-to-author-customization)
 - [Using Annotations](#using-annotations)
 
-All of the features of Flux are accessible from within
-[Weave Cloud](https://cloud.weave.works).
-
-However, `fluxctl` provides an equivalent API that can be used from
+`fluxctl` provides an equivalent API that can be used from
 the command line.
 
 The `--help` for `fluxctl` is described below.
@@ -223,9 +220,6 @@ Connecting:
   # To a fluxd running in namespace "weave" in your current kubectl context
   fluxctl --k8s-fwd-ns=weave list-workloads
 
-  # To a Weave Cloud instance, with your instance token in $TOKEN
-  fluxctl --token $TOKEN list-workloads
-
 Workflow:
   fluxctl list-workloads                                                   # Which workloads are running?
   fluxctl list-images --workload=default:deployment/foo                    # Which images are running/available?
@@ -330,9 +324,7 @@ default:deployment/helloworld  helloworld  quay.io/weaveworks/helloworld
 
 ## Turning on Automation
 
-Automation can be easily controlled from within
-[Weave Cloud](https://cloud.weave.works) by selecting the "Automate"
-button when inspecting a workload. But we can also do this from `fluxctl`
+Automation can be easily controlled from `fluxctl`
 with the `automate` subcommand.
 
 ```sh
@@ -462,7 +454,7 @@ started with several flags that impact the commit information:
 | git-email      | committer email            | `support@weave.works`
 | git-set-author | override the commit author | false
 
-Actions triggered by a user through the Weave Cloud UI or the CLI `fluxctl`
+Actions triggered by a user through the CLI `fluxctl`
 tool, can have the commit author information customized. This is handy for providing extra context in the
 notifications and history. Whether the customization is possible, depends on the Flux daemon (fluxd)
 `git-set-author` flag. If set, the commit author will be customized in the following way:

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -37,8 +37,7 @@ menu_order: 40
   * [Errors due to author customization](#errors-due-to-author-customization)
 - [Using Annotations](#using-annotations)
 
-`fluxctl` provides an equivalent API that can be used from
-the command line.
+`fluxctl` provides an API that can be used from the command line.
 
 The `--help` for `fluxctl` is described below.
 

--- a/site/fluxctl.md
+++ b/site/fluxctl.md
@@ -1,5 +1,5 @@
 ---
-title: Using Weave Flux
+title: Using Flux
 menu_order: 40
 ---
 

--- a/site/get-started.md
+++ b/site/get-started.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Weave Flux Manually
+title: Installing Flux Manually
 menu_order: 10
 ---
 

--- a/site/helm-get-started.md
+++ b/site/helm-get-started.md
@@ -1,11 +1,11 @@
 ---
-title: Installing Weave Flux using Helm
+title: Installing Flux using Helm
 menu_order: 20
 ---
 
 - [Get started with Flux using Helm](#get-started-with-flux-using-helm)
   * [Prerequisites](#prerequisites)
-  * [Install Weave Flux](#install-weave-flux)
+  * [Install Flux](#install-flux)
   * [Giving write access](#giving-write-access)
   * [Committing a small change](#committing-a-small-change)
   * [Conclusion](#conclusion)
@@ -60,7 +60,7 @@ helm init --skip-refresh --upgrade --service-account tiller --history-max 10
 > and be aware of the `--history-max` flag before promoting to
 > production.
 
-## Install Weave Flux
+## Install Flux
 
 Add the Flux repository of Weaveworks:
 
@@ -74,12 +74,12 @@ Apply the Helm Release CRD:
 kubectl apply -f https://raw.githubusercontent.com/weaveworks/flux/master/deploy-helm/flux-helm-release-crd.yaml
 ```
 
-In this next step you install Weave Flux using `helm`. Simply
+In this next step you install Flux using `helm`. Simply
 
  1. Fork [flux-get-started](https://github.com/weaveworks/flux-get-started)
     on GitHub and replace the `weaveworks` with your GitHub username in
     [here](https://github.com/weaveworks/flux-get-started/blob/master/releases/ghost.yaml#L13)
- 1. Install Weave Flux and its Helm Operator by specifying your fork URL:
+ 1. Install Flux and its Helm Operator by specifying your fork URL:
 
       *Just make sure you replace `YOURUSER` with your GitHub username
       in the command below:*

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -30,11 +30,11 @@ helm-operator requires setup and offers customization though a multitude of flag
 | --log-release-diffs       | `false`                       | Log the diff when a chart release diverges. **Potentially insecure.**
 | --update-chart-deps       | `true`                        | Update chart dependencies before installing or upgrading a release.
 
-## Installing Weave Flux Helm Operator and Helm with TLS enabled
+## Installing Flux Helm Operator and Helm with TLS enabled
 
 ### Installing Helm / Tiller
 
-Generate certificates for Tiller and Flux. This will provide a CA, servercerts for Tiller and client certs for Helm / Weave Flux.
+Generate certificates for Tiller and Flux. This will provide a CA, servercerts for Tiller and client certs for Helm / Flux.
 
 > **Note:** When creating the certificate for Tiller the Common Name should match the hostname you are connecting to from the Helm operator.
 
@@ -171,7 +171,7 @@ helm --tls --tls-verify \
   ls
 ```
 
-### Deploy Weave Flux Helm Operator
+### Deploy Flux Helm Operator
 
 First create a new Kubernetes TLS secret for the client certs;
 

--- a/site/helm-operator.md
+++ b/site/helm-operator.md
@@ -227,23 +227,3 @@ metadata:
   selfLink: /api/v1/namespaces/helm-system/configmaps/flux-helm-tls-ca-config
   uid: c106f866-7f9e-11e8-904a-025000000001
 ```
-
-## Installing Weave Flux Helm Operator for Weave Cloud
-
-In order to use the Helm operator with Weave Cloud you have to apply the `HelmRelease` CRD definition and the operator
-deployment in the `weave` namespace:
-
-```bash
-export REPO=https://raw.githubusercontent.com/weaveworks/flux/master
-
-kubectl apply -f ${REPO}/deploy-helm/flux-helm-release-crd.yaml
-kubectl apply -f ${REPO}/deploy-helm/weave-cloud-helm-operator-deployment.yaml
-```
-
-Check the operator logs with:
-
-```bash
-kubectl -n weave logs deployment/flux-helm-operator -f
-```
-
-> **Note:** The above instructions are assuming that Tiller is deployed in the `kube-system` namespace without TLS.

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -1,5 +1,5 @@
 ---
-title: How Weave Flux Works
+title: How Flux Works
 menu_order: 20
 ---
 

--- a/site/how-it-works.md
+++ b/site/how-it-works.md
@@ -23,9 +23,9 @@ with an orchestrator (which is a common source of accidental failure) or
 with the systems that ensure that the orchestrator is in a working
 state.
 
-Flux provides a CLI ([`fluxctl`](fluxctl.md)) and a UI (as a component of Weave Cloud)
-to perform these operations manually. Flux is flexible enough to fit
-into any development process.
+Flux provides a CLI ([`fluxctl`](fluxctl.md)) to perform these
+operations manually. Flux is flexible enough to fit into any
+development process.
 
 # Implementation Overview
 
@@ -78,19 +78,6 @@ configuration of the cluster to deploy the new images.
 
 Images can be "locked" to a specific version. "locked" images won't be
 updated by automated or manual means.
-
-# Weave Cloud only
-
-## Slack integration
-
-Flux integrates with Slack. A Slack API endpoint is required.
-
-Flux will announce to slack when changes have occured.
-
-## Auditing
-
-Flux also exposes the history of its actions for auditing
-purposes. You can see every event that has happened on the cluster.
 
 ## Next
 

--- a/site/installing.md
+++ b/site/installing.md
@@ -1,5 +1,5 @@
 ---
-title: Installing Weave Flux
+title: Installing Flux
 menu_order: 30
 ---
 
@@ -10,7 +10,7 @@ contains [manifests][k8s-manifests] (as YAML files) describing what
 should run in the cluster. Flux imposes
 [some requirements](/site/requirements.md) on these files.
 
-# Installing Weave Flux
+# Installing Flux
 
 Here are the instructions to [install Flux on your own
 cluster](./get-started.md).

--- a/site/introduction.md
+++ b/site/introduction.md
@@ -8,7 +8,7 @@ that surround building, deploying and monitoring applications. The
 goal is to provide a sustainable model for maintaining and improving 
 an application.
 
-Weave Flux is a tool that automates the deployment of containers to 
+Flux is a tool that automates the deployment of containers to 
 Kubernetes. It fills the automation void that exists between building
 and monitoring.
 

--- a/site/introduction.md
+++ b/site/introduction.md
@@ -1,5 +1,5 @@
 ---
-title: Introducing Weave Flux
+title: Introducing Flux
 menu_order: 10
 ---
 

--- a/site/introduction.md
+++ b/site/introduction.md
@@ -8,12 +8,6 @@ that surround building, deploying and monitoring applications. The
 goal is to provide a sustainable model for maintaining and improving 
 an application.
 
-The promise of continuous delivery relies upon automation and in recent 
-years the automation of building and testing software has become 
-commonplace. But it is comparatively difficult to automate the 
-deployment and monitoring of an application.
-[Weave Cloud](https://cloud.weave.works) fixes this problem.
-
 Weave Flux is a tool that automates the deployment of containers to 
 Kubernetes. It fills the automation void that exists between building
 and monitoring.
@@ -56,10 +50,6 @@ One final high-level feature is that Flux increases visibility of your
 application. Clear visibility of the state of a cluster is key for
 maintaining operational systems. Developers can be confident in their
 changes by observing a predictable series of deployment events.
-
-Flux can send notifications to a service (e.g., [Weave
-Cloud](https://cloud.weave.works/)) to provide integrations with Slack
-and other such media.
 
 ## Next
 

--- a/site/monitoring.md
+++ b/site/monitoring.md
@@ -1,5 +1,5 @@
 ---
-title: Monitoring Weave Flux
+title: Monitoring Flux
 menu_order: 70
 ---
 

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -1,5 +1,5 @@
 ---
-title: Troubleshooting Weave Flux
+title: Troubleshooting Flux
 menu_order: 50
 ---
 

--- a/site/troubleshooting.md
+++ b/site/troubleshooting.md
@@ -52,19 +52,6 @@ This means Flux can't read from and write to the git repo. Check that
    need to add its host key. See
    [./standalone-setup.md](./standalone-setup.md#using-a-private-git-host).
 
-### "The request failed authentication"
-
-If you're using [Weave Cloud](https://cloud.weave.works/), this
-probably means you haven't supplied the token. You can get the token
-from the settings in Weave Cloud; set the environment variable
-`FLUX_TOKEN` to the token.
-
-If you have set Flux up standalone (as in the instructions in
-[./get-started.md](./get-started.md)), this
-probably means Flux is defaulting to using Weave Cloud because you've
-not set the environment variable `FLUX_URL` to point at the
-daemon. See [./standalone-setup.md](./standalone-setup.md).
-
 ### I'm using GCR/GKE and I keep seeing "Quota exceeded" in logs
 
 GCP (in general) has quite conservative API rate limiting, and Flux's
@@ -86,9 +73,8 @@ problem.
 ### Why are my images not showing up in the list of images?
 
 Sometimes, instead of seeing the various images and their tags, the
-output of `fluxctl list-images` (or the UI in Weave Cloud, if you're
-using that) shows nothing. There's a number of reasons this can
-happen:
+output of `fluxctl list-images` shows nothing. There's a number of
+reasons this can happen:
 
  - Flux just hasn't fetched the image metadata yet. This may be the case
    if you've only just started using a particular image in a workload.

--- a/site/upgrading-to-1.0.md
+++ b/site/upgrading-to-1.0.md
@@ -10,10 +10,8 @@ different enough that you need to do a bit of work to upgrade it.
 
 In previous releases of Flux, much of the work was done by the
 service. This meant that to get a useful system, you had to run both
-the daemon and the service in your cluster, or connect the daemon to
-Weave Cloud. In version 1, the daemon does all of the mechanical
-work by itself, and Weave Cloud “merely” adds a web user interface and
-integrations, e.g., with Slack.
+the daemon and the service in your cluster. In version 1, the daemon
+does all of the mechanical work by itself.
 
 ## Differences between Old Flux and Flux v1
 
@@ -93,78 +91,6 @@ curl -o fluxctl_030 https://github.com/weaveworks/flux/releases/download/0.3.0/f
 # curl -o fluxctl_030 https://github.com/weaveworks/flux/releases/download/0.3.0/fluxctl_darwin_amd64
 chmod a+x ./fluxctl_030
 ```
-
-The next steps depend on whether you
-
- * [Connect Flux to Weave Cloud](#if-you-are-connecting-to-weave-cloud); or,
- * [You are running Flux standalone](#if-you-are-running-flux-in-standalone-mode) (i.e., you run both
-   the Flux daemon and the Flux service, rather than going through
-   Weave Cloud).
-
-## <a name="weavecloud">If you are connecting to Weave Cloud</a>
-
-Set the environment variable `FLUX_SERVICE_TOKEN` to be your service
-token (found in the Weave Cloud UI for the instance you are
-upgrading).
-
-Before making changes, get the config so that it can be consulted
-later:
-
-```sh
-./fluxctl_030 get-config --fingerprint=md5 | tee old-config.yaml
-```
-
-### Remove old Flux resources
-
-> *Important! If you have Flux resources committed to git* The first
-> thing to do is remove any manifests for running Flux that you have
-> stored in git, before deleting them in the cluster
-> (below). Otherwise, when the new Flux daemon runs it will restore
-> the old configuration.
-
-Run Weave Cloud’s launch generator to delete the resources in the
-cluster:
-
-```sh
-kubectl delete -n kube-system -f \
-  https://cloud.weave.works/k8s/flux.yaml?flux-version=0.3.0”
-```
-
-### Delete deployment keys
-
-It’s good practice to remove any unused deployment keys. If you’re
-using GitHub, look at the settings for the repository you were
-pointing Flux at, and delete the key Flux was using.
-
-To check you are removing the correct key, get the fingerprint of the
-key used by Flux with
-
-```sh
-./fluxctl_030 get-config --fingerprint=md5
-```
-
-### Configure and run the new Flux resources
-
-> First, it is important to understand that Flux manages more of your
-> cluster resources now. It will automatically apply manifests that
-> appear in your config repo, either by creating or by updating them. In
-> other words, it tries to keep the cluster running whatever is
-> represented in the repo. (Though it doesn’t delete things, yet.)
-
-To run the new Flux with Weave Cloud:
-
- * Go to your instance settings (the cog icon) and click the “Config”
-   then “Deploy” menu items
- * Enter the git URL, path and branch values from the saved config
-   (in `old-config.yaml`)
- * Run the `kubectl` command shown below the form.
- * Following the instructions underneath the command, to install the
-   deploy key (this is also a good opportunity to delete any old keys,
-   if you didn’t do that above).
- * Wait for the big red "Agent not configured" message to clear.
-
-You should now be able to click the “Deploy” tab at the top and see
-your running system (again), with the updated Flux daemon.
 
 ## If you are running Flux in "standalone" mode
 
@@ -249,8 +175,8 @@ the setup instructions linked above.
 
 It’s possible that the Flux resources are in an unusual namespace or
 given a different name. As a last resort, you can hunt down the
-resources by name and delete them. Weave Cloud’s “Explore” tab may
-help; or use kubectl to look for likely suspects.
+resources by name and delete them. Use kubectl to look for likely
+suspects.
 
 ```sh
 kubectl get serviceaccount,service,deployment --all-namespaces
@@ -266,8 +192,7 @@ and if there are manifests for the old Flux still in git, it will
 create those as resources.
 
 If that’s the case, you will need to remove the manifests from git
-before running Flux v1. You can download manifests from Weave Cloud,
-or adapt those given in the repo, if you want to check them back in.
+before running Flux v1.
 
 ### Something else went wrong
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,9 +9,9 @@ version-script: |
     echo "$FLUX_TAG+$GIT_REV"
   fi
 version: git
-summary: fluxctl talks to Weave Flux and helps you deploy your code
+summary: fluxctl talks to Flux and helps you deploy your code
 description: |
-  fluxctl talks to your Weave Flux instance and exposes all its
+  fluxctl talks to your Flux instance and exposes all its
   functionality to an easy to use command line interface.
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict


### PR DESCRIPTION
In order to fix #2180 I'm removing a bunch of WC related things - let me know what you think.

I'll move whatever's still relevant up to https://www.weave.works/docs/cloud/latest/tasks/deploy/ somewhere.