### PR TITLE
Helm chart: allow namespace scoping for Flux and helm-op

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -204,6 +204,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
 | `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
 | `serviceAccount.name`                             | `flux`                                               | Service account to be used
+| `clusterRole.create`                              | `true`                                               | If `false`, Flux and the Helm Operator will be restricted to the namespace where they are deployed
 | `service.type`                                    | `ClusterIP`                                          | Service type to be used (exposing the Flux API outside of the cluster is not advised)
 | `service.port`                                    | `3030`                                               | Service port to be used
 | `git.url`                                         | `None`                                               | URL of git repo with Kubernetes manifests

--- a/chart/flux/templates/deployment.yaml
+++ b/chart/flux/templates/deployment.yaml
@@ -148,6 +148,9 @@ spec:
 {{ toYaml .Values.extraEnvs | indent 10 }}
           {{- end }}
           args:
+          {{- if not .Values.clusterRole }}
+          - --k8s-allow-namespace={{ .Release.Namespace }}
+          {{end}}
           {{- if .Values.logFormat }}
           - --log-format={{ .Values.logFormat }}
           {{end}}

--- a/chart/flux/templates/helm-operator-crd.yaml
+++ b/chart/flux/templates/helm-operator-crd.yaml
@@ -1,5 +1,4 @@
-{{- if .Values.helmOperator.create -}}
-{{- if .Values.helmOperator.createCRD -}}
+{{- if and .Values.helmOperator.create .Values.helmOperator.createCRD -}}
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -176,4 +175,4 @@ spec:
                   name:
                     type: string
 {{- end -}}
-{{- end -}}
+

--- a/chart/flux/templates/helm-operator-deployment.yaml
+++ b/chart/flux/templates/helm-operator-deployment.yaml
@@ -126,7 +126,9 @@ spec:
         - --charts-sync-interval={{ .Values.helmOperator.chartsSyncInterval }}
         - --update-chart-deps={{ .Values.helmOperator.updateChartDeps }}
         - --log-release-diffs={{ .Values.helmOperator.logReleaseDiffs }}
-        {{- if .Values.helmOperator.allowNamespace }}
+        {{- if not .Values.clusterRole.create }}
+        - --allow-namespace={{ .Release.Namespace }}
+        {{- else if .Values.helmOperator.allowNamespace }}
         - --allow-namespace={{ .Values.helmOperator.allowNamespace }}
         {{- end }}
         - --tiller-namespace={{ .Values.helmOperator.tillerNamespace }}

--- a/chart/flux/templates/kube.yaml
+++ b/chart/flux/templates/kube.yaml
@@ -4,7 +4,20 @@ metadata:
   name: {{ template "flux.fullname" . }}-kube-config
 data:
   config: |
-    {{- if .Values.kube.config }}
+    {{- if not .Values.clusterRole.create }}
+    apiVersion: v1
+    clusters: []
+    contexts:
+    - context:
+        cluster: ""
+        namespace: {{ .Release.Name }}
+        user: ""
+      name: default
+    current-context: default
+    kind: Config
+    preferences: {}
+    users: []
+    {{- else if .Values.kube.config }}
       {{- if contains "\n" .Values.kube.config }}
         {{- range $value := .Values.kube.config | splitList "\n" }}
     {{ print $value }}

--- a/chart/flux/templates/rbac-role.yaml
+++ b/chart/flux/templates/rbac-role.yaml
@@ -1,0 +1,78 @@
+{{- if and .Values.rbac.create (eq .Values.clusterRole.create false) -}}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - '*'
+    resources:
+      - '*'
+    verbs:
+      - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "flux.fullname" . }}
+subjects:
+  - name: {{ template "flux.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "flux.fullname" . }}-crd
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "flux.fullname" . }}
+  labels:
+    app: {{ template "flux.name" . }}
+    chart: {{ template "flux.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "flux.fullname" . }}-crd
+subjects:
+  - name: {{ template "flux.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
+{{- end -}}

--- a/chart/flux/templates/rbac.yaml
+++ b/chart/flux/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create .Values.clusterRole.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:

--- a/chart/flux/values.yaml
+++ b/chart/flux/values.yaml
@@ -89,6 +89,11 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name:
 
+# If `false`, Flux and the Helm Operator will be restricted to the namespace where they are deployed
+# and the kubeconfig default context will be set to that namespace
+clusterRole:
+  create: true
+
 resources:
   requests:
     cpu: 50m


### PR DESCRIPTION
- add `clusterRole.create` field to chart values
- if `clusterRole.create` is false, Flux and the Helm Operator will be restricted to the namespace where they are deployed and the kubeconfig default context will be set to that namespace
- enforce the namespace restriction with RBAC and role bindings

Ref: #850 #1085 #1886

