### PR TITLE
Flux Adapter preparation

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -8,10 +8,3 @@ import "github.com/weaveworks/flux/api/v11"
 type Server interface {
 	v11.Server
 }
-
-// UpstreamServer is the interface a Flux must satisfy in order to communicate with
-// Weave Cloud.
-type UpstreamServer interface {
-	v11.Server
-	v11.Upstream
-}

--- a/api/v11/api.go
+++ b/api/v11/api.go
@@ -18,8 +18,8 @@ type Server interface {
 	v10.Server
 
 	ListServicesWithOptions(ctx context.Context, opts ListServicesOptions) ([]v6.ControllerStatus, error)
-}
 
-type Upstream interface {
+	// NB Upstream methods move into the public API, since
+	// weaveworks/flux-adapter now relies on the public API
 	v10.Upstream
 }

--- a/cmd/fluxd/main.go
+++ b/cmd/fluxd/main.go
@@ -609,7 +609,7 @@ func main() {
 				client.Token(*token),
 				transport.NewUpstreamRouter(),
 				*upstreamURL,
-				remote.NewErrorLoggingUpstreamServer(daemon, upstreamLogger),
+				remote.NewErrorLoggingServer(daemon, upstreamLogger),
 				*rpcTimeout,
 				upstreamLogger,
 			)

--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -1,5 +1,8 @@
 package daemon
 
+// This file can be removed from the package once `--connect` is
+// removed from fluxd. Until then, it will be imported from here.
+
 import (
 	"context"
 	"net/http"

--- a/http/daemon/upstream.go
+++ b/http/daemon/upstream.go
@@ -32,7 +32,7 @@ type Upstream struct {
 	url       *url.URL
 	endpoint  string
 	apiClient *fluxclient.Client
-	server    api.UpstreamServer
+	server    api.Server
 	timeout   time.Duration
 	logger    log.Logger
 	quit      chan struct{}
@@ -50,13 +50,13 @@ var (
 	}, []string{"target"})
 )
 
-func NewUpstream(client *http.Client, ua string, t fluxclient.Token, router *mux.Router, endpoint string, s api.UpstreamServer, timeout time.Duration, logger log.Logger) (*Upstream, error) {
+func NewUpstream(client *http.Client, ua string, t fluxclient.Token, router *mux.Router, endpoint string, s api.Server, timeout time.Duration, logger log.Logger) (*Upstream, error) {
 	httpEndpoint, wsEndpoint, err := inferEndpoints(endpoint)
 	if err != nil {
 		return nil, errors.Wrap(err, "inferring WS/HTTP endpoints")
 	}
 
-	u, err := transport.MakeURL(wsEndpoint, router, transport.RegisterDaemonV10)
+	u, err := transport.MakeURL(wsEndpoint, router, transport.RegisterDaemonV11)
 	if err != nil {
 		return nil, errors.Wrap(err, "constructing URL")
 	}

--- a/http/routes.go
+++ b/http/routes.go
@@ -17,12 +17,20 @@ const (
 	RegeneratePublicSSHKey = "RegeneratePublicSSHKey"
 )
 
-var (
+// This is part of the API -- but it's the outward-facing (or service
+// provider) API, rather than the flux API.
+const (
+	LogEvent = "LogEvent"
+)
+
+// The RegisterDaemonX routes should move to weaveworks/flux-adapter
+// once we remove `--connect`, since they are pertinent only to making
+// an RPC relay connection.
+const (
 	RegisterDaemonV6  = "RegisterDaemonV6"
 	RegisterDaemonV7  = "RegisterDaemonV7"
 	RegisterDaemonV8  = "RegisterDaemonV8"
 	RegisterDaemonV9  = "RegisterDaemonV9"
 	RegisterDaemonV10 = "RegisterDaemonV10"
 	RegisterDaemonV11 = "RegisterDaemonV11"
-	LogEvent          = "LogEvent"
 )

--- a/http/routes.go
+++ b/http/routes.go
@@ -1,6 +1,11 @@
 package http
 
 const (
+	// Formerly Upstream methods, now (in v11) included in server API
+	Ping    = "Ping"
+	Version = "Version"
+	Notify  = "Notify"
+
 	ListServices            = "ListServices"
 	ListServicesWithOptions = "ListServicesWithOptions"
 	ListImages              = "ListImages"

--- a/http/transport.go
+++ b/http/transport.go
@@ -29,6 +29,10 @@ func DeprecateVersions(r *mux.Router, versions ...string) {
 func NewAPIRouter() *mux.Router {
 	r := mux.NewRouter()
 
+	r.NewRoute().Name(Ping).Methods("GET").Path("/v11/ping")
+	r.NewRoute().Name(Version).Methods("GET").Path("/v11/version")
+	r.NewRoute().Name(Notify).Methods("POST").Path("/v11/notify")
+
 	r.NewRoute().Name(ListServices).Methods("GET").Path("/v6/services")
 	r.NewRoute().Name(ListServicesWithOptions).Methods("GET").Path("/v11/services")
 	r.NewRoute().Name(ListImages).Methods("GET").Path("/v6/images")

--- a/http/transport.go
+++ b/http/transport.go
@@ -50,6 +50,8 @@ func NewAPIRouter() *mux.Router {
 	return r // TODO 404 though?
 }
 
+// These (routes, and constructor following) should move to
+// weaveworks/flux-adapter when `--connect` is removed from fluxd.
 func UpstreamRoutes(r *mux.Router) {
 	r.NewRoute().Name(RegisterDaemonV6).Methods("GET").Path("/v6/daemon")
 	r.NewRoute().Name(RegisterDaemonV7).Methods("GET").Path("/v7/daemon")

--- a/http/websocket/websocket.go
+++ b/http/websocket/websocket.go
@@ -1,5 +1,10 @@
 package websocket
 
+// This package can be moved to weaveworks/flux-adapter once
+// `--connect` is removed, since it is particular to making an RPC
+// relay connection, and that function will be supplied by
+// flux-adapter.
+
 import (
 	"io"
 

--- a/remote/doc.go
+++ b/remote/doc.go
@@ -2,3 +2,7 @@
 // an upstream service.
 
 package remote
+
+// This whole package can be moved to weaveworks/flux-adapter, once we
+// no longer `--connect` from fluxd. (Or before that, if we import it
+// from there.)

--- a/remote/logging.go
+++ b/remote/logging.go
@@ -15,7 +15,6 @@ import (
 )
 
 var _ api.Server = &ErrorLoggingServer{}
-var _ api.UpstreamServer = &ErrorLoggingUpstreamServer{}
 
 type ErrorLoggingServer struct {
 	server api.Server
@@ -108,19 +107,7 @@ func (p *ErrorLoggingServer) GitRepoConfig(ctx context.Context, regenerate bool)
 	return p.server.GitRepoConfig(ctx, regenerate)
 }
 
-type ErrorLoggingUpstreamServer struct {
-	*ErrorLoggingServer
-	server api.UpstreamServer
-}
-
-func NewErrorLoggingUpstreamServer(s api.UpstreamServer, l log.Logger) *ErrorLoggingUpstreamServer {
-	return &ErrorLoggingUpstreamServer{
-		NewErrorLoggingServer(s, l),
-		s,
-	}
-}
-
-func (p *ErrorLoggingUpstreamServer) Ping(ctx context.Context) (err error) {
+func (p *ErrorLoggingServer) Ping(ctx context.Context) (err error) {
 	defer func() {
 		if err != nil {
 			p.logger.Log("method", "Ping", "error", err)
@@ -129,7 +116,7 @@ func (p *ErrorLoggingUpstreamServer) Ping(ctx context.Context) (err error) {
 	return p.server.Ping(ctx)
 }
 
-func (p *ErrorLoggingUpstreamServer) Version(ctx context.Context) (v string, err error) {
+func (p *ErrorLoggingServer) Version(ctx context.Context) (v string, err error) {
 	defer func() {
 		if err != nil {
 			p.logger.Log("method", "Version", "error", err, "version", v)
@@ -138,7 +125,7 @@ func (p *ErrorLoggingUpstreamServer) Version(ctx context.Context) (v string, err
 	return p.server.Version(ctx)
 }
 
-func (p *ErrorLoggingUpstreamServer) NotifyChange(ctx context.Context, change v9.Change) (err error) {
+func (p *ErrorLoggingServer) NotifyChange(ctx context.Context, change v9.Change) (err error) {
 	defer func() {
 		if err != nil {
 			p.logger.Log("method", "NotifyChange", "error", err)

--- a/remote/metrics.go
+++ b/remote/metrics.go
@@ -128,21 +128,7 @@ func (i *instrumentedServer) GitRepoConfig(ctx context.Context, regenerate bool)
 	return i.s.GitRepoConfig(ctx, regenerate)
 }
 
-var _ api.UpstreamServer = &instrumentedUpstreamServer{}
-
-type instrumentedUpstreamServer struct {
-	*instrumentedServer
-	s api.UpstreamServer
-}
-
-func InstrumentUpstream(s api.UpstreamServer) *instrumentedUpstreamServer {
-	return &instrumentedUpstreamServer{
-		Instrument(s),
-		s,
-	}
-}
-
-func (i *instrumentedUpstreamServer) Ping(ctx context.Context) (err error) {
+func (i *instrumentedServer) Ping(ctx context.Context) (err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "Ping",
@@ -152,7 +138,7 @@ func (i *instrumentedUpstreamServer) Ping(ctx context.Context) (err error) {
 	return i.s.Ping(ctx)
 }
 
-func (i *instrumentedUpstreamServer) Version(ctx context.Context) (v string, err error) {
+func (i *instrumentedServer) Version(ctx context.Context) (v string, err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "Version",
@@ -162,7 +148,7 @@ func (i *instrumentedUpstreamServer) Version(ctx context.Context) (v string, err
 	return i.s.Version(ctx)
 }
 
-func (i *instrumentedUpstreamServer) NotifyChange(ctx context.Context, change v9.Change) (err error) {
+func (i *instrumentedServer) NotifyChange(ctx context.Context, change v9.Change) (err error) {
 	defer func(begin time.Time) {
 		requestDuration.With(
 			fluxmetrics.LabelMethod, "NotifyChange",

--- a/remote/mock.go
+++ b/remote/mock.go
@@ -104,13 +104,13 @@ func (p *MockServer) GitRepoConfig(ctx context.Context, regenerate bool) (v6.Git
 	return p.GitRepoConfigAnswer, p.GitRepoConfigError
 }
 
-var _ api.UpstreamServer = &MockServer{}
+var _ api.Server = &MockServer{}
 
 // -- Battery of tests for an api.Server implementation. Since these
 // essentially wrap the server in various transports, we expect
 // arguments and answers to be preserved.
 
-func ServerTestBattery(t *testing.T, wrap func(mock api.UpstreamServer) api.UpstreamServer) {
+func ServerTestBattery(t *testing.T, wrap func(mock api.Server) api.Server) {
 	// set up
 	namespace := "the-space-of-names"
 	serviceID := resource.MustParseID(namespace + "/service")

--- a/remote/mock_test.go
+++ b/remote/mock_test.go
@@ -8,5 +8,5 @@ import (
 
 // Just test that the mock does its job.
 func TestMock(t *testing.T) {
-	ServerTestBattery(t, func(mock api.UpstreamServer) api.UpstreamServer { return mock })
+	ServerTestBattery(t, func(mock api.Server) api.Server { return mock })
 }

--- a/remote/rpc/baseclient.go
+++ b/remote/rpc/baseclient.go
@@ -17,7 +17,7 @@ import (
 
 type baseClient struct{}
 
-var _ api.UpstreamServer = baseClient{}
+var _ api.Server = baseClient{}
 
 func (bc baseClient) Version(context.Context) (string, error) {
 	return "", remote.UpgradeNeededError(errors.New("Version method not implemented"))

--- a/remote/rpc/clientV11.go
+++ b/remote/rpc/clientV11.go
@@ -19,7 +19,6 @@ type RPCClientV11 struct {
 
 type clientV11 interface {
 	v11.Server
-	v11.Upstream
 }
 
 var _ clientV11 = &RPCClientV11{}

--- a/remote/rpc/rpc_test.go
+++ b/remote/rpc/rpc_test.go
@@ -24,7 +24,7 @@ func pipes() (io.ReadWriteCloser, io.ReadWriteCloser) {
 }
 
 func TestRPC(t *testing.T) {
-	wrap := func(mock api.UpstreamServer) api.UpstreamServer {
+	wrap := func(mock api.Server) api.Server {
 		clientConn, serverConn := pipes()
 
 		server, err := NewServer(mock, 10*time.Second)

--- a/remote/rpc/server.go
+++ b/remote/rpc/server.go
@@ -26,7 +26,7 @@ type Server struct {
 
 // NewServer instantiates a new RPC server, handling requests on the
 // conn by invoking methods on the underlying (assumed local) server.
-func NewServer(s api.UpstreamServer, t time.Duration) (*Server, error) {
+func NewServer(s api.Server, t time.Duration) (*Server, error) {
 	server := rpc.NewServer()
 	if err := server.Register(&RPCServer{s, t}); err != nil {
 		return nil, err
@@ -39,7 +39,7 @@ func (c *Server) ServeConn(conn io.ReadWriteCloser) {
 }
 
 type RPCServer struct {
-	s       api.UpstreamServer
+	s       api.Server
 	timeout time.Duration
 }
 


### PR DESCRIPTION
 - makes API changes so that all methods are available over HTTP, including NotifyChange (used for relaying webhooks, for example) /cc @alanjcastonguay 
 - adds some notes about what can be moved out of this repo and into `weaveworks/flux-adapter`

This (modulo passing tests and review) can be merged now, in principle, because it doesn't alter what is served over the Upstream connection -- it just adds to the HTTP API. But I am going to make it a draft until I've Actually Tried that.

Fixes #2210. 