### PR TITLE
Push images to DockerHub fluxcd org

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,13 +60,22 @@ jobs:
           name: Maybe push prerelease images
           command: |
             if [ -z "${CIRCLE_TAG}" -a "${CIRCLE_BRANCH}" == "master" ]; then
+              # Push to weaveworks org
               echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
 
-              docker tag "docker.io/weaveworks/flux:$(docker/image-tag)" "docker.io/weaveworks/flux-prerelease:$(docker/image-tag)"
+              docker tag "docker.io/fluxcd/flux:$(docker/image-tag)" "docker.io/weaveworks/flux-prerelease:$(docker/image-tag)"
               docker push "docker.io/weaveworks/flux-prerelease:$(docker/image-tag)"
 
-              docker tag "docker.io/weaveworks/helm-operator:$(docker/image-tag)" "docker.io/weaveworks/helm-operator-prerelease:$(docker/image-tag)"
+              docker tag "docker.io/fluxcd/helm-operator:$(docker/image-tag)" "docker.io/weaveworks/helm-operator-prerelease:$(docker/image-tag)"
               docker push "docker.io/weaveworks/helm-operator-prerelease:$(docker/image-tag)"
+
+              # Push to fluxcd org
+              echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
+              docker tag "docker.io/fluxcd/flux:$(docker/image-tag)" "docker.io/fluxcd/flux-prerelease:$(docker/image-tag)"
+              docker push "docker.io/fluxcd/flux-prerelease:$(docker/image-tag)"
+
+              docker tag "docker.io/fluxcd/helm-operator:$(docker/image-tag)" "docker.io/fluxcd/helm-operator-prerelease:$(docker/image-tag)"
+              docker push "docker.io/fluxcd/helm-operator-prerelease:$(docker/image-tag)"
             fi
       - deploy:
           name: Maybe push release image and upload binaries
@@ -75,13 +84,26 @@ jobs:
               go get github.com/weaveworks/github-release
               make release-bins
               bin/upload-binaries
+              # Push to weaveworks org
               echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
+              docker tag "docker.io/fluxcd/flux:${CIRCLE_TAG}" "docker.io/weaveworks/flux:${CIRCLE_TAG}"
               docker push "docker.io/weaveworks/flux:${CIRCLE_TAG}"
+
+              # Push to fluxcd org
+              echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
+              docker push "docker.io/fluxcd/flux:${CIRCLE_TAG}"
             fi
             if echo "${CIRCLE_TAG}" | grep -Eq "helm-[0-9]+(\.[0-9]+)*(-[a-z]+)?$"; then
-              echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
               RELEASE_TAG=$(echo "$CIRCLE_TAG" | cut -c 6-)
+
+              # Push to weaveworks org
+              echo "$DOCKER_REGISTRY_PASSWORD" | docker login --username "$DOCKER_REGISTRY_USER" --password-stdin
+              docker tag "docker.io/fluxcd/helm-operator:${RELEASE_TAG}" "docker.io/weaveworks/helm-operator:${RELEASE_TAG}"
               docker push "docker.io/weaveworks/helm-operator:${RELEASE_TAG}"
+
+              # Push to fluxcd org
+              echo "$DOCKER_FLUXCD_PASSWORD" | docker login --username "$DOCKER_FLUXCD_USER" --password-stdin
+              docker push "docker.io/fluxcd/helm-operator:${RELEASE_TAG}"
             fi
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ e2e: test/bin/helm test/bin/kubectl build/.flux.done build/.helm-operator.done
 build/.%.done: docker/Dockerfile.%
 	mkdir -p ./build/docker/$*
 	cp $^ ./build/docker/$*/
-	$(SUDO) docker build -t docker.io/weaveworks/$* -t docker.io/weaveworks/$*:$(IMAGE_TAG) \
+	$(SUDO) docker build -t docker.io/fluxcd/$* -t docker.io/fluxcd/$*:$(IMAGE_TAG) \
 		--build-arg VCS_REF="$(VCS_REF)" \
 		--build-arg BUILD_DATE="$(BUILD_DATE)" \
 		-f build/docker/$*/Dockerfile.$* ./build/docker/$*

--- a/test/bin/test-flux
+++ b/test/bin/test-flux
@@ -22,7 +22,7 @@ minikube start --profile "$PROFILE" --keep-context
 MINIKUBE_IP=$(minikube --profile "$PROFILE" ip)
 
 # Copy the latest Flux image into the minikube VM
-docker save "docker.io/weaveworks/flux:latest" | (eval $(minikube --profile "$PROFILE" docker-env) && docker load)
+docker save "docker.io/fluxcd/flux:latest" | (eval $(minikube --profile "$PROFILE" docker-env) && docker load)
 
 # Create a central git repo inside the minikube VM and get the host key for ssh access
 minikube --profile "$PROFILE" ssh -- git init --bare /home/docker/flux.git

--- a/test/e2e/run.sh
+++ b/test/e2e/run.sh
@@ -76,8 +76,8 @@ kubectl -n "${FLUX_NAMESPACE}" rollout status deployment/gitsrv
 
 if [ "${USING_KIND}" = 'true' ]; then
     echo '>>> Loading images into the Kind cluster'
-    kind --name "${KIND_CLUSTER}" load docker-image 'docker.io/weaveworks/flux:latest'
-    kind --name "${KIND_CLUSTER}" load docker-image 'docker.io/weaveworks/helm-operator:latest'
+    kind --name "${KIND_CLUSTER}" load docker-image 'docker.io/fluxcd/flux:latest'
+    kind --name "${KIND_CLUSTER}" load docker-image 'docker.io/fluxcd/helm-operator:latest'
 fi
 
 echo '>>> Installing Flux with Helm'
@@ -100,6 +100,7 @@ defer helm delete --purge flux > /dev/null 2>&1
 
 helm install --name flux --wait \
 --namespace "${FLUX_NAMESPACE}" \
+--set image.repository=docker.io/fluxcd/flux \
 --set image.tag=latest \
 --set git.url=ssh://git@gitsrv/git-server/repos/cluster.git \
 --set git.secretName=ssh-git \
@@ -107,6 +108,7 @@ helm install --name flux --wait \
 --set git.config.secretName=gitconfig \
 --set git.config.enabled=true \
 --set-string git.config.data="${GITCONFIG}" \
+--set helmOperator.repository=docker.io/fluxcd/helm-operator \
 --set helmOperator.tag=latest \
 --set helmOperator.create=true \
 --set helmOperator.createCRD=true \

--- a/test/flux-deploy-all.yaml
+++ b/test/flux-deploy-all.yaml
@@ -76,7 +76,7 @@ spec:
       containers:
       - name: flux
         # Require locally built image
-        image: docker.io/weaveworks/flux:latest
+        image: docker.io/fluxcd/flux:latest
         imagePullPolicy: Never
         ports:
         - containerPort: 3030 # informational


### PR DESCRIPTION
This includes the change of the default image name from `weaveworks/*` to `fluxcd/*`.

- [x] Needs a new bot account, with access to the organization, the credentials are expected to be environment variables in CircleCI (`DOCKER_FLUXCD_USER`, `DOCKER_FLUXCD_PASSWORD`).