### PR TITLE
 Helm chart: Restrict Flux's PSP

### DIFF
--- a/chart/flux/README.md
+++ b/chart/flux/README.md
@@ -202,6 +202,7 @@ The following tables lists the configurable parameters of the Flux chart and the
 | `token`                                           | `None`                                               | Weave Cloud service token
 | `extraEnvs`                                       | `[]`                                                 | Extra environment variables for the Flux pod(s)
 | `rbac.create`                                     | `true`                                               | If `true`, create and use RBAC resources
+| `rbac.pspEnabled`                                 | `false`                                              | If `true`, create and use a restricted pod security policy for Flux pod(s)
 | `serviceAccount.create`                           | `true`                                               | If `true`, create a new service account
 | `serviceAccount.name`                             | `flux`                                               | Service account to be used
 | `clusterRole.create`                              | `true`                                               | If `false`, Flux and the Helm Operator will be restricted to the namespace where they are deployed

--- a/chart/flux/templates/psp.yaml
+++ b/chart/flux/templates/psp.yaml
@@ -8,12 +8,19 @@ metadata:
     chart: {{ include "flux.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
 spec:
+  privileged: false
+  hostIPC: false
+  hostNetwork: false
+  hostPID: false
+  readOnlyRootFilesystem: false
+  allowPrivilegeEscalation: true
   allowedCapabilities:
-  - '*'
+    - '*'
   fsGroup:
     rule: RunAsAny
-  privileged: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -21,11 +28,5 @@ spec:
   supplementalGroups:
     rule: RunAsAny
   volumes:
-  - '*'
-  hostPID: true
-  hostIPC: true
-  hostNetwork: true
-  hostPorts:
-  - min: 1
-    max: 65536
+    - '*'
 {{- end }}

--- a/chart/flux/templates/psp.yaml
+++ b/chart/flux/templates/psp.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.pspEnabled }}
-apiVersion: extensions/v1beta1
+apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
   name: {{ template "flux.fullname" . }}


### PR DESCRIPTION
* disable privileged, hostIPC, hostNetwork and hostPID
* add psp flag to chart readme